### PR TITLE
Remove psyco support.

### DIFF
--- a/bin/virtaal
+++ b/bin/virtaal
@@ -185,12 +185,6 @@ def main(argv):
                 parser.error(_("Could not open profile file '%(filename)s'") % {"filename":options.profile})
 
         def default_runner(startup_file):
-            if not pan_app.DEBUG:
-                try:
-                    import psyco
-                    psyco.full()
-                except Exception:
-                    pass
             run_virtaal(startup_file)
 
         if options and getattr(options, "profile", None) != None:

--- a/docs/building.rst
+++ b/docs/building.rst
@@ -38,7 +38,6 @@ Optional Packages
 
 These are not build dependencies but usually improve the user experience.
 
-- psyco -- provides a nice speedup
 - Enchant, pyenchant, gtkspell and pygtkspell (might be packaged as
   gnome-python-extras or something similar) -- provides all :doc:`spell
   checking <spell_checking>` functionality.  For Windows:

--- a/setup.py
+++ b/setup.py
@@ -482,7 +482,7 @@ def add_win32_options(options):
             "dist_dir":   "virtaal-win32",
             "includes":   [
                     # some of these are needed by plugins and are therefore not detected
-                    "lxml", "lxml._elementpath", "psyco", "cairo", "pango",
+                    "lxml", "lxml._elementpath", "cairo", "pango",
                     "pangocairo", "atk", "gobject", "gtk.keysyms",
                     "gtkspell",
                     "gio", # needed for gtk.Builder
@@ -533,7 +533,7 @@ def add_mac_options(options):
         "options": {
             "py2app": {
             "packages": ["CoreFoundation", "objc"],
-            "includes":   ["lxml", "lxml._elementpath", "lxml.etree", "glib", "gio", "psyco", "cairo", "pango", "pangocairo", "atk", "gobject", "gtk.keysyms", "pycurl", "translate.services", "translate.services.tmclient", "translate.services.opentranclient", "CoreFoundation"],
+            "includes":   ["lxml", "lxml._elementpath", "lxml.etree", "glib", "gio", "cairo", "pango", "pangocairo", "atk", "gobject", "gtk.keysyms", "pycurl", "translate.services", "translate.services.tmclient", "translate.services.opentranclient", "CoreFoundation"],
                 #"semi_standalone": True,
                 "compressed": True,
                 "argv_emulation": True,

--- a/virtaal/plugins/spellchecker.py
+++ b/virtaal/plugins/spellchecker.py
@@ -29,14 +29,6 @@ import gobject
 from virtaal.common import pan_app
 from virtaal.controllers.baseplugin import PluginUnsupported, BasePlugin
 
-if not pan_app.DEBUG:
-    try:
-        import psyco
-    except:
-        psyco = None
-else:
-    psyco = None
-
 _dict_add_re = re.compile('Add "(.*)" to Dictionary')
 
 
@@ -243,8 +235,6 @@ class Plugin(BasePlugin):
         if not spell is None:
             spell.detach()
         text_view.spell_lang = None
-    if psyco:
-        psyco.cannotcompile(_disable_checking)
 
 
     # SIGNAL HANDLERS #
@@ -298,8 +288,7 @@ class Plugin(BasePlugin):
         gobject.idle_add(self._activate_checker, text_view, language, priority=gobject.PRIORITY_LOW)
 
     def _activate_checker(self, text_view, language):
-        # All the expensive stuff in here called on idle. We mush also isolate
-        # this away from psyco
+        # All the expensive stuff in here called on idle
         try:
             spell = None
             try:
@@ -319,10 +308,6 @@ class Plugin(BasePlugin):
             logging.exception("Could not initialize spell checking: %s", e)
             self.gtkspell = None
             #TODO: unload plugin
-    if psyco:
-        # Some of the gtkspell stuff can't work with psyco and will dump core
-        # if we don't avoid psyco compilation
-        psyco.cannotcompile(_activate_checker)
 
     def _on_populate_popup(self, textbox, menu):
         # We can't work with the menu immediately, since gtkspell only adds its


### PR DESCRIPTION
Psyco is unmaintained and unusable with Python 2.7. This removes Virtaal's dependency on it.
