### PR TITLE
Fix unappropriate Update Menu string

### DIFF
--- a/share/virtaal/virtaal.glade
+++ b/share/virtaal/virtaal.glade
@@ -61,7 +61,7 @@
                     </child>
                     <child>
                       <widget class="GtkImageMenuItem" id="mnu_update">
-                        <property name="label" translatable="yes">_Update to Template</property>
+                        <property name="label" translatable="yes">_Update from Template</property>
                         <property name="visible">True</property>
                         <property name="sensitive">False</property>
                         <property name="use_underline">True</property>

--- a/share/virtaal/virtaal.ui
+++ b/share/virtaal/virtaal.ui
@@ -593,7 +593,7 @@ If you are translating from English to French then French would be your translat
                     </child>
                     <child>
                       <object class="GtkImageMenuItem" id="mnu_update">
-                        <property name="label" translatable="yes">_Update to Template</property>
+                        <property name="label" translatable="yes">_Update from Template</property>
                         <property name="visible">True</property>
                         <property name="sensitive">False</property>
                         <property name="can_focus">False</property>


### PR DESCRIPTION
Change update menu string from "_Update to Template" to "_Update from Template"
Regarding this issue #3237. Note that this change invalidates all previous translations.