### PR TITLE
Remove invalid `caption` option for `kdialog`

### DIFF
--- a/virtaal/support/native_widgets.py
+++ b/virtaal/support/native_widgets.py
@@ -101,7 +101,6 @@ def _show_kdialog(window, title, args):
             'kdialog',
 #            '--name', _('Virtaal'),
 #            '--title', 'Virtaal',
-            '--caption', _('Virtaal'),
             '--icon', 'virtaal',
             '--title', title,
             '--attach', str(xid),


### PR DESCRIPTION
The `native_widget` module was using `kdialog` with the `caption` option. According to [the source code of `kdialog`][kdialog-source], this option is invalid (it is not supported). Using it causes errors: the file selection dialog does not open.

Reported in #3266

[kdialog-source]: https://cgit.kde.org/kdialog.git/tree/src/kdialog.cpp?h=fd50a04df49bac3ce3e95f3eef5e5aa38b4021e0#n286