### PR TITLE
Check existence of `kdialog` before using it

### DIFF
--- a/virtaal/support/native_widgets.py
+++ b/virtaal/support/native_widgets.py
@@ -22,7 +22,6 @@
 """This provides access to the native file dialogs for certain platforms, and
 some related helper code."""
 
-import distutils.spawn
 import os
 import sys
 import gettext
@@ -46,12 +45,13 @@ def _dialog_to_use():
         if win32_lang == ui_language or ui_language == 'en' and win32_lang == 'C':
             return 'win32'
 
-    elif os.environ.get('KDE_FULL_SESSION') == 'true' and \
-            distutils.spawn.find_executable("kdialog") is not None and ( \
+    elif os.environ.get('KDE_FULL_SESSION') == 'true' and ( \
                 pan_app.ui_language == 'en' or \
                 gettext.dgettext('kdelibs4', '') or \
                 not gettext.dgettext('gtk20', '')):
-            return 'kdialog'
+            import distutils.spawn
+            if distutils.spawn.find_executable("kdialog") is not None:
+                return 'kdialog'
 
     if sys.platform == 'darwin':
         return 'darwin'

--- a/virtaal/support/native_widgets.py
+++ b/virtaal/support/native_widgets.py
@@ -22,6 +22,7 @@
 """This provides access to the native file dialogs for certain platforms, and
 some related helper code."""
 
+import distutils.spawn
 import os
 import sys
 import gettext
@@ -45,7 +46,8 @@ def _dialog_to_use():
         if win32_lang == ui_language or ui_language == 'en' and win32_lang == 'C':
             return 'win32'
 
-    elif os.environ.get('KDE_FULL_SESSION') == 'true' and ( \
+    elif os.environ.get('KDE_FULL_SESSION') == 'true' and \
+            distutils.spawn.find_executable("kdialog") is not None and ( \
                 pan_app.ui_language == 'en' or \
                 gettext.dgettext('kdelibs4', '') or \
                 not gettext.dgettext('gtk20', '')):


### PR DESCRIPTION
Instead of doing some guesses, this commit adds a direct check for the existence of `kdialog` using `distutils.spawn.find_executable`. This allows a more accurate decision of the dialog to use.

Closes #3266