### PR TITLE
Travis: Remove python 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@
 sudo: required
 language: python
 python:
-  - 2.6
   - 2.7
 install:
   - pip install Sphinx


### PR DESCRIPTION
Keeping Python 2.6 results in fail as Sphinx requires Python >=2.7
The 2.6 release is no longer supported by the Python core team anyway.