### PR TITLE
README: Update URLs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ several purposes.
 
 References
 ----------
-* Website: <http://translate.sourceforge.net/wiki/virtaal/index>
+* Website: <https://virtaal.translatehouse.org>
 * Bug tracker: <https://github.com/translate/virtaal/issues>
 
 Installation
@@ -18,7 +18,7 @@ Virtaal website there should be packages for Windows and several other systems.
 If you want to install from source code, you will need to ensure you have all
 the dependencies. For more information on building Virtaal to install it
 yourself, please consult the website here:
-http://translate.sourceforge.net/wiki/virtaal/building
+https://virtaal.readthedocs.io/en/latest/building.html
 
 Note that you will probably already want the Translate Toolkit installed and
 working before you attempt to install Virtaal.


### PR DESCRIPTION
Update URLs that were pointing to the old sourceforge website.
For the "Building" documentation, the old wiki page (currently down)
has almost the same content of the current Building documentation,
except the latter is more up-to-date and is available.