### PR TITLE
Travis: drop Python 2.6, add libgnutls-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,15 @@
 sudo: required
 language: python
 python:
-  - 2.6
   - 2.7
 install:
+  - sudo apt-get install libgnutls-dev
+  - sudo apt-get install python-gtk2
   - pip install Sphinx
   - pip install translate-toolkit
   - pip install python-Levenshtein
   - pip install lxml
   - pip install pycurl
-  - sudo apt-get install python-gtk2
 script:
   - make docs
   - python setup.py install


### PR DESCRIPTION
Python 2.6 is not available anymore for installation,
so the job fails when trying to download it.
This version is unsupported for a long time now.

Adds libgnutls-dev to installation list as pycurl
installation fails without it.