### PR TITLE
Python 3 + GTK3 port, part 1: the raw pioneer-era port

### DIFF
--- a/bin/virtaal
+++ b/bin/virtaal
@@ -21,8 +21,8 @@
 
 import sys
 from os import path
-from virtaal.common import pan_app
 
+from virtaal.common import pan_app
 
 # Some behaviour should vary, depending on whether Virtaal is packaged or not
 packaged = getattr(sys, 'frozen', False)
@@ -57,15 +57,15 @@ if not packaged:
         warnings = '\n'.join([error_messages[name] for name in failed if name in optional_modules])
 
         if warnings:
-            print 'DEPENDENCY WARNINGS:'
-            print warnings
+            print('DEPENDENCY WARNINGS:')
+            print(warnings)
         if errors:
-            print 'DEPENDENCY ERRORS:'
-            print errors
-        print
-        print "You can disable dependency checking to speed up startup by setting"
-        print "  packaged = True"
-        print "in the file '%s'" % __file__
+            print('DEPENDENCY ERRORS:')
+            print(errors)
+        print()
+        print("You can disable dependency checking to speed up startup by setting")
+        print("  packaged = True")
+        print("in the file '%s'" % __file__)
         if errors:
             sys.exit(1)
 # OK, dependencies seem to be acceptable

--- a/devsupport/debugging.py
+++ b/devsupport/debugging.py
@@ -46,7 +46,7 @@ def log_args(fn, classname=None):
         else:
             all_args = ', '.join([args_s, kwargs_s])
         retval = fn(*args, **kwargs)
-        print '%s%s(%s) => %s' % (classname, fn.__name__, all_args, retval)
+        print('%s%s(%s) => %s' % (classname, fn.__name__, all_args, retval))
         return retval
 
     return logger_fn

--- a/devsupport/update_autocorr.py
+++ b/devsupport/update_autocorr.py
@@ -15,7 +15,7 @@ SKIP_LANGS = ("eu",) # garbage == en-US
 
 langs = []
 
-print "Getting language list..."
+print("Getting language list...")
 
 for line in urllib.urlopen('%s/?style=raw' % HG_AUTOCORR_DIR).readlines():
     if line.startswith("drwx"): # readable, executable directory
@@ -23,21 +23,21 @@ for line in urllib.urlopen('%s/?style=raw' % HG_AUTOCORR_DIR).readlines():
         if lang not in SKIP_LANGS:
             langs.append(lang)
         else:
-            print "Skipping %s" % lang
+            print("Skipping %s" % lang)
 
-print "done"
-print "Available languages: %s" % " ".join(langs)
+print("done")
+print("Available languages: %s" % " ".join(langs))
 
 for lang in langs:
     for line in urllib.urlopen('%s/%s/?style=raw' % (HG_AUTOCORR_DIR, lang)).readlines():
         try:
             chmod, size, fname = line.split()
             if FILE_PATTERN.match(fname):
-                print "Downloading %s (%s bytes)..." % (fname, size)
+                print("Downloading %s (%s bytes)..." % (fname, size))
                 file_contents = urllib.urlopen('%s/%s/%s?style=raw' %
                                                (HG_AUTOCORR_DIR, lang, fname)).read()
                 file(fname, "wb").write(file_contents)
-                print "done"
+                print("done")
         except ValueError:
             # don't process empty lines
             pass

--- a/setup.py
+++ b/setup.py
@@ -541,7 +541,7 @@ def add_mac_options(options):
         "options": {
             "py2app": {
             "packages": ["CoreFoundation", "objc"],
-                "includes": ["lxml", "lxml._elementpath", "lxml.etree", "glib", "gio", "psyco", "cairo", "pango",
+                "includes": ["lxml", "lxml._elementpath", "lxml.etree", "glib", "gio", "cairo", "pango",
                              "pangocairo", "atk", "gobject", "Gtk.keysyms", "pycurl", "translate.services",
                              "translate.services.tmclient", "translate.services.opentranclient", "CoreFoundation"],
                 #"semi_standalone": True,

--- a/setup.py
+++ b/setup.py
@@ -375,7 +375,7 @@ def find_gtk_files():
             'iso_3166_2.mo',
             'iso_4217.mo',
             'iso_639_3.mo',
-            'gtk20-properties.mo',
+            'gtk30-properties.mo',
             'gtkspell.mo', # This isn't picked up, so our code does the i18n
             'gettext-tools.mo',
             'gettext-runtime.mo',

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,13 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import print_function
+from __future__ import print_function
+from __future__ import print_function
+from __future__ import print_function
+from __future__ import print_function
+from __future__ import print_function
+
 import os
 import os.path as path
 import sys
@@ -303,8 +310,8 @@ def compile_inno_script(script_path):
     compile_command = shell_compile_command.replace('"%1"', script_path)
     result = os.system(compile_command)
     if result:
-        print "Error compiling iss file"
-        print "Opening iss file, use InnoSetup GUI to compile manually"
+        print("Error compiling iss file")
+        print("Opening iss file, use InnoSetup GUI to compile manually")
         os.startfile(script_path)
 
 class BuildWin32Installer(build_exe):
@@ -322,10 +329,10 @@ class BuildWin32Installer(build_exe):
         build_exe.run(self)
         # create the Installer, using the files py2exe has created.
         exe_files = self.windows_exe_files + self.console_exe_files
-        print "*** creating the inno setup script***"
+        print("*** creating the inno setup script***")
         script_path = create_inno_script(PRETTY_NAME, self.lib_dir, self.dist_dir, exe_files, self.lib_files,
                                          version=self.distribution.metadata.version)
-        print "*** compiling the inno setup script***"
+        print("*** compiling the inno setup script***")
         compile_inno_script(script_path)
         # Note: By default the final setup.exe will be in an Output subdirectory.
 
@@ -610,8 +617,8 @@ class DepCheckInstall(distutils.command.install.install):
             from virtaal.support import depcheck
             failed = depcheck.check_dependencies()
             if failed:
-                print 'Failed dependencies: %s' % (', '.join(failed))
-                print 'Use the --nodepcheck option to ignore dependencies.'
+                print('Failed dependencies: %s' % (', '.join(failed)))
+                print('Use the --nodepcheck option to ignore dependencies.')
                 exit(0)
         distutils.command.install.install.run(self, *args, **kwargs)
 

--- a/setup.py
+++ b/setup.py
@@ -619,7 +619,7 @@ class DepCheckInstall(distutils.command.install.install):
             if failed:
                 print('Failed dependencies: %s' % (', '.join(failed)))
                 print('Use the --nodepcheck option to ignore dependencies.')
-                exit(0)
+                exit(1)
         distutils.command.install.install.run(self, *args, **kwargs)
 
 def main(options):

--- a/setup.py
+++ b/setup.py
@@ -19,12 +19,26 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-from distutils.core import setup
-from virtaal.__version__ import ver as virtaal_version
-from glob import glob
 import os
 import os.path as path
 import sys
+from distutils.core import setup, Command
+from glob import glob
+
+from virtaal.__version__ import ver as virtaal_version
+
+try:
+    import py2exe
+    build_exe = py2exe.build_exe.py2exe
+    Distribution = py2exe.Distribution
+except ImportError:
+    py2exe = None
+    build_exe = Command
+
+try:
+    import py2app
+except ImportError:
+    py2app = None
 
 PRETTY_NAME = "Virtaal"
 SOURCE_DATA_DIR = 'share'
@@ -38,9 +52,10 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: End Users/Desktop",
     "Intended Audience :: Information Technology",
+    "License :: OSI Approved :: GNU General Public License (GPL)",
     "Programming Language :: Python",
     "Topic :: Software Development :: Localization",
-    "Topic :: Text Processing :: Linguistic",
+    "Topic :: Text Processing :: Linguistic"
     "Operating System :: OS Independent",
     "Operating System :: Microsoft :: Windows",
     "Operating System :: Unix"
@@ -114,11 +129,435 @@ options = {
     ],
 }
 
+# For innosetup and py2app, we need to treat the plug-ins as data files.
+if os.name == 'nt' or sys.platform == 'darwin':
+    noplugins = []
+    for pkg in options['packages']:
+        if 'plugins' not in pkg:
+            noplugins.append(pkg)
+    options['packages'] = noplugins
+
+    plugin_src = path.join('virtaal', 'plugins')
+    plugin_dest = 'virtaal_plugins'
+    options['data_files'] += [
+        (plugin_dest, glob(path.join(plugin_src, '*.py'))),
+        (path.join(plugin_dest, 'lookup'), glob(path.join(plugin_src, 'lookup', '*.py'))),
+        (path.join(plugin_dest, 'lookup', 'models'), glob(path.join(plugin_src, 'lookup', 'models', '*.py'))),
+        (path.join(plugin_dest, 'terminology'), glob(path.join(plugin_src, 'terminology', '*.py'))),
+        (path.join(plugin_dest, 'terminology', 'models'), glob(path.join(plugin_src, 'terminology', 'models', '*.py'))),
+        (path.join(plugin_dest, 'terminology', 'models', 'localfile'), glob(path.join(plugin_src, 'terminology', 'models', 'localfile', '*.py'))),
+        (path.join(plugin_dest, 'tm'), glob(path.join(plugin_src, 'tm', '*.py'))),
+        (path.join(plugin_dest, 'tm', 'models'), glob(path.join(plugin_src, 'tm', 'models', '*.py'))),
+    ]
+
 no_install_files = [
-    ['LICENSE', 'maketranslations']
+    ['LICENSE', 'maketranslations', path.join('devsupport', 'virtaal_innosetup.bmp')]
 ]
 
 no_install_dirs = ['po']
+
+#############################
+# WIN 32 specifics
+
+def get_compile_command():
+    try:
+        import _winreg
+        compile_key = _winreg.OpenKey(_winreg.HKEY_CLASSES_ROOT, "innosetupscriptfile\\shell\\compile\\command")
+        compilecommand = _winreg.QueryValue(compile_key, "")
+        compile_key.Close()
+
+    except:
+        compilecommand = "compil32.exe"
+    return compilecommand
+
+def chop(dist_dir, pathname):
+    """returns the path relative to dist_dir"""
+    assert pathname.startswith(dist_dir)
+    return pathname[len(dist_dir):]
+
+def create_inno_script(name, _lib_dir, dist_dir, exe_files, other_files, version = "1.0"):
+    if not dist_dir.endswith(os.sep):
+        dist_dir += os.sep
+    exe_files = [chop(dist_dir, p) for p in exe_files]
+    other_files = [chop(dist_dir, p) for p in other_files]
+    pathname = path.join(dist_dir, name + os.extsep + "iss")
+
+# See http://www.jrsoftware.org/isfaq.php for more InnoSetup config options.
+    ofi = open(pathname, "w")
+    print >> ofi, r'''; WARNING: This script has been created by py2exe. Changes to this script
+; will be overwritten the next time py2exe is run!
+
+[Languages]
+Name: "en"; MessagesFile: "compiler:Default.isl"
+Name: "eu"; MessagesFile: "compiler:Languages\Basque.isl"
+Name: "ca"; MessagesFile: "compiler:Languages\Catalan.isl"
+Name: "cz"; MessagesFile: "compiler:Languages\Czech.isl"
+Name: "da"; MessagesFile: "compiler:Languages\Danish.isl"
+Name: "nl"; MessagesFile: "compiler:Languages\Dutch.isl"
+Name: "fi"; MessagesFile: "compiler:Languages\Finnish.isl"
+Name: "fr"; MessagesFile: "compiler:Languages\French.isl"
+Name: "de"; MessagesFile: "compiler:Languages\German.isl"
+Name: "he"; MessagesFile: "compiler:Languages\Hebrew.isl"
+Name: "hu"; MessagesFile: "compiler:Languages\Hungarian.isl"
+Name: "it"; MessagesFile: "compiler:Languages\Italian.isl"
+Name: "nb"; MessagesFile: "compiler:Languages\Norwegian.isl"
+Name: "pl"; MessagesFile: "compiler:Languages\Polish.isl"
+Name: "pt_BR"; MessagesFile: "compiler:Languages\BrazilianPortuguese.isl"
+Name: "pt"; MessagesFile: "compiler:Languages\Portuguese.isl"
+Name: "ru"; MessagesFile: "compiler:Languages\Russian.isl"
+Name: "sk"; MessagesFile: "compiler:Languages\Slovak.isl"
+Name: "sl"; MessagesFile: "compiler:Languages\Slovenian.isl"
+Name: "es"; MessagesFile: "compiler:Languages\Spanish.isl"
+
+[Setup]
+AppName=%(name)s
+AppVerName=%(name)s %(version)s
+AppPublisher=Zuza Software Foundation
+AppPublisherURL=http://www.translate.org.za/
+AppVersion=%(version)s
+AppSupportURL=http://translate.sourceforge.net/
+;AppComments=
+;AppCopyright=Copyright (C) 2007-2009 Zuza Software Foundation
+DefaultDirName={pf}\%(name)s
+DefaultGroupName=%(name)s
+LanguageDetectionMethod=locale
+OutputBaseFilename=%(name)s-%(version)s-setup
+ChangesAssociations=yes
+SetupIconFile=%(icon_path)s
+;WizardSmallImageFile=compiler:images\WizModernSmallImage13.bmp
+WizardImageFile=%(wizard_image)s
+
+[Files]''' % {
+    'name': name,
+    'version': version,
+    'icon_path': path.join(TARGET_DATA_DIR, "icons", "virtaal.ico"),
+    'wizard_image': path.join(os.pardir, "devsupport", "virtaal_innosetup.bmp")
+}
+    for fpath in exe_files + other_files:
+        print >> ofi, r'Source: "%s"; DestDir: "{app}\%s"; Flags: ignoreversion' % (fpath, os.path.dirname(fpath))
+    print >> ofi, r'''
+[Icons]
+Name: "{group}\%(name)s Translation Editor"; Filename: "{app}\virtaal.exe";
+Name: "{group}\%(name)s (uninstall)"; Filename: "{uninstallexe}"''' % {'name': name}
+
+#    For now we don't worry about install scripts
+#    if install_scripts:
+#        print >> ofi, r"[Run]"
+#
+#        for fpath in install_scripts:
+#            print >> ofi, r'Filename: "{app}\%s"; WorkingDir: "{app}"; Parameters: "-install"' % fpath
+#
+#        print >> ofi
+#        print >> ofi, r"[UninstallRun]"
+#
+#        for fpath in install_scripts:
+#            print >> ofi, r'Filename: "{app}\%s"; WorkingDir: "{app}"; Parameters: "-remove"' % fpath
+
+    # File associations. Note the directive "ChangesAssociations=yes" above
+    # that causes the installer to tell Explorer to refresh associations.
+    # This part might cause the created installer to need administrative
+    # privileges. An alternative might be to rather write to
+    # HKCU\Software\Classes, but this won't be system usable then. Didn't
+    # see a way to test and alter the behaviour.
+
+    # For each file type we should have something like this:
+    #
+    #;File extension:
+    #Root: HKCR; Subkey: ".po"; ValueType: string; ValueName: ""; ValueData: "virtaal_po"; Flags: uninsdeletevalue
+    #;Description of the file type
+    #Root: HKCR; Subkey: "virtaal_po"; ValueType: string; ValueName: ""; ValueData: "Gettext PO"; Flags: uninsdeletekey
+    #;Icon to use in Explorer
+    #Root: HKCR; Subkey: "virtaal_po\DefaultIcon"; ValueType: string; ValueName: ""; ValueData: "{app}\share\icons\virtaal.ico"
+    #;The command to open the file
+    #Root: HKCR; Subkey: "virtaal_po\shell\open\command"; ValueType: string; ValueName: ""; ValueData: """{app}\virtaal.exe"" ""%1"""
+
+    print >> ofi, "[Registry]"
+    from translate.storage import factory
+    for description, extentions, _mimetypes in factory.supported_files():
+        # We skip those types where we depend on mime types, not extentions
+        if not extentions:
+            continue
+        # Form a key from the first extention for internal only
+        key = extentions[0]
+        # Associate each extention with the file type
+        for extention in extentions:
+            # We don't want to associate with all .txt or .pot (PowerPoint template) files, so let's skip it
+            if extention in ["txt", "pot", "csv"]:
+                continue
+            print >> ofi, r'Root: HKCR; Subkey: ".%(extention)s"; ValueType: string; ValueName: ""; ValueData: "virtaal_%(key)s"; Flags: uninsdeletevalue' % {'extention': extention, 'key': key}
+        print >> ofi, r'''Root: HKCR; Subkey: "virtaal_%(key)s"; ValueType: string; ValueName: ""; ValueData: "%(description)s"; Flags: uninsdeletekey
+Root: HKCR; Subkey: "virtaal_%(key)s\DefaultIcon"; ValueType: string; ValueName: ""; ValueData: "{app}\share\icons\x-translation.ico"
+Root: HKCR; Subkey: "virtaal_%(key)s\shell\open\command"; ValueType: string; ValueName: ""; ValueData: """{app}\virtaal.exe"" ""%%1"""''' % {'key': key, 'description': description}
+
+    # Show a "Launch Virtaal" checkbox on the last installer screen
+    print >> ofi, r'''
+[Run]
+Filename: "{app}\virtaal.exe"; Description: "{cm:LaunchProgram,%(name)s}"; Flags: nowait postinstall skipifsilent''' % {'name': name}
+    print >> ofi
+    ofi.close()
+    return pathname
+
+def compile_inno_script(script_path):
+    """compiles the script using InnoSetup"""
+    shell_compile_command = get_compile_command()
+    compile_command = shell_compile_command.replace('"%1"', script_path)
+    result = os.system(compile_command)
+    if result:
+        print "Error compiling iss file"
+        print "Opening iss file, use InnoSetup GUI to compile manually"
+        os.startfile(script_path)
+
+class BuildWin32Installer(build_exe):
+    """distutils class that first builds the exe file(s), then creates a Windows installer using InnoSetup"""
+    description = "create an executable installer for MS Windows using InnoSetup and py2exe"
+    user_options = getattr(build_exe, 'user_options', []) + \
+        [('install-script=', None,
+          "basename of installation script to be run after installation or before deinstallation")]
+
+    def initialize_options(self):
+        build_exe.initialize_options(self)
+
+    def run(self):
+        # First, let py2exe do it's work.
+        build_exe.run(self)
+        # create the Installer, using the files py2exe has created.
+        exe_files = self.windows_exe_files + self.console_exe_files
+        print "*** creating the inno setup script***"
+        script_path = create_inno_script(PRETTY_NAME, self.lib_dir, self.dist_dir, exe_files, self.lib_files,
+                                         version=self.distribution.metadata.version)
+        print "*** compiling the inno setup script***"
+        compile_inno_script(script_path)
+        # Note: By default the final setup.exe will be in an Output subdirectory.
+
+def find_gtk_bin_directory():
+    GTK_NAME = "libgtk"
+    # Look for GTK in the user's Path as well as in some familiar locations
+    paths = os.environ['Path'].split(';') + [r'C:\GTK\bin', r'C:\Program Files\GTK\bin' r'C:\Program Files\GTK2-Runtime']
+    for p in paths:
+        if not os.path.exists(p):
+            continue
+        files = [path.join(p, f) for f in os.listdir(p) if path.isfile(path.join(p, f)) and f.startswith(GTK_NAME)]
+        if len(files) > 0:
+            return p
+    raise Exception("""Could not find the GTK runtime.
+Please place bin directory of your GTK installation in the program path.""")
+
+def find_gtk_files():
+    def parent(dir_path):
+        return path.abspath(path.join(path.abspath(dir_path), '..'))
+
+    def strip_leading_path(leadingPath, p):
+        return p[len(leadingPath) + 1:]
+
+    def wanted(data_file):
+        """We don't want all the GTK files for the installer. Let's strip out a
+        few ones that are taking too much space."""
+        name = os.path.basename(data_file)
+        if name in no_package_names:
+            return False
+        _base, ext = os.path.splitext(name)
+        if ext in no_package_extensions:
+            return False
+        return True
+
+    #file names that we don't want
+    no_package_names = set([
+            #We want some .mo files, but we won't use these ones
+            'libiconv.mo',
+            'iso_15924.mo',
+            'iso_3166_2.mo',
+            'iso_4217.mo',
+            'iso_639_3.mo',
+            'gtk20-properties.mo',
+            'gtkspell.mo', # This isn't picked up, so our code does the i18n
+            'gettext-tools.mo',
+            'gettext-runtime.mo',
+            'gtkspell.mo',
+    ])
+    #extensions of files we don't want
+    no_package_extensions = set([
+            '.log',
+            '.m4',
+            #package config
+            '.pc',
+            #man pages
+            '.1',
+            '.3',
+            '.5',
+            #source code
+            '.h',
+            '.c',
+            '.tcl',
+            #library files
+            '.a',
+            '.def',
+            '.lib',
+            #emacs files
+            '.el',
+            '.elc',
+    ])
+
+    # We don't want anything from these directories from the full GTK install.
+    no_dirnames = [
+        r'share\doc',
+        r'share\dtds',
+        r'share\glib-2.0',
+        r'share\gtk-2.0',
+        r'share\gtk-doc',
+        r'share\icon-naming-utils',
+        r'share\icons\Tango',
+        r'share\xml',
+        r'etc\bash_completion.d',
+        r'etc\fonts',
+    ]
+
+    data_files = []
+    gtk_path = parent(find_gtk_bin_directory())
+    for dir_path in [path.join(gtk_path, p) for p in ('etc', 'share', 'lib')]:
+        for dir_name, dirs, files in os.walk(dir_path):
+            skip = False
+            for dname in no_dirnames:
+                for d in dirs:
+                    if d.find(dname) >= 0:
+                        dirs.remove(d)
+                if dir_name.find(dname) >= 0:
+                    skip = True
+            if skip == True:
+                continue
+            files = [path.abspath(path.join(dir_name, f)) for f in files if wanted(f)]
+            if len(files) > 0:
+                data_files.append((strip_leading_path(gtk_path, dir_name), files))
+    return data_files
+
+def find_enchant_files():
+    data_files = []
+    import enchant
+    en = enchant.Dict('en')
+    # This should give us something like
+    # C:\Python25\Lib\site-packages\enchant\lib\enchant\libenchant_myspell.dll
+    data_files.append(('lib/enchant', [en.provider.file]))
+    # Our version of gtkspell expects libenchant.dll, but enchant itselfs needs
+    # libenchant-1.dll
+    libenchant = enchant.utils.get_resource_filename("libenchant.dll")
+    libenchant1 = enchant.utils.get_resource_filename("libenchant-1.dll")
+    data_files.append(('',[libenchant, libenchant1]))
+    return data_files
+
+def find_langmodel_files():
+    from translate.misc.file_discovery import get_abs_data_filename
+    lmdir = path.abspath(get_abs_data_filename('langmodels'))
+    if not path.isdir(lmdir):
+        return []
+
+    return [(path.join(TARGET_DATA_DIR, 'langmodels'), glob(path.join(lmdir, '*.*')))]
+
+def add_win32_options(options):
+    """This function is responsible for finding data files and setting options necessary
+    to build executables and installers under Windows.
+
+    @return: A 2-tuple (data_files, options), where data_files is a list of Windows
+             specific data files (this would include the GTK binaries) and where
+             options are the options required by py2exe."""
+    if py2exe != None and ('py2exe' in sys.argv or 'innosetup' in sys.argv):
+        options['data_files'].extend(find_gtk_files())
+        options['data_files'].extend(find_enchant_files())
+        options['data_files'].extend(find_langmodel_files())
+        options['data_files'].extend([(
+            path.join(TARGET_DATA_DIR, "icons", "hicolor", "24x24", "mimetypes"),
+            [path.join(SOURCE_DATA_DIR, "icons", "hicolor", "24x24", "mimetypes", "x-translation.png")]
+        )])
+        #This depends on setup.py being run from a checkout with the translate
+        #toolkit in place. Also mentioned below.
+        options['scripts'].append("../translate/translate/services/tmserver")
+
+        py2exe_options = {
+            # translate.lang and translate.storage contain classes that are
+            # imported dynamically, therefore we need to add them here,
+            # otherwise py2exe doesn't find them.
+            "packages":   ["encodings", "translate.lang", "translate.storage._factory_classes", "virtaal"],
+            "compressed": True,
+            "excludes":   ["PyLucene", "Tkconstants", "Tkinter", "tcl",
+                # strange things unnecessarily included with some versions of pyenchant:
+                "win32ui", "_win32sysloader", "win32pipe", "py2exe", "pywin", "isapi", "_tkinter", "win32api",
+            ],
+            "dist_dir":   "virtaal-win32",
+            "includes":   [
+                    # some of these are needed by plugins and are therefore not detected
+                    "lxml", "lxml._elementpath", "cairo", "pango",
+                "pangocairo", "atk", "gobject", "Gtk.keysyms",
+                    "gtkspell",
+                "gio",  # needed for Gtk.Builder
+                    "tarfile",
+                    "translate.storage.placeables.terminology", # terminology
+                    "xmlrpclib", # Moses
+                    "bsddb", #migration
+                    "zipfile", #autocorrect
+                ],
+            "optimize":   2,
+        }
+        innosetup_options = py2exe_options.copy()
+        options.update({
+            "windows": [
+                {
+                    'script': 'bin/virtaal',
+                    'icon_resources': [(1, path.join(SOURCE_DATA_DIR, "icons", "virtaal.ico"))],
+                },
+                { 'script': "../translate/translate/services/tmserver"}
+            ],
+            'zipfile':  "virtaal.zip",
+            "options": {
+                "py2exe":    py2exe_options,
+                "innosetup": innosetup_options
+            },
+            'cmdclass':  {
+                "py2exe":    build_exe,
+                "innosetup": BuildWin32Installer
+            }
+        })
+    return options
+
+def add_mac_options(options):
+    # http://svn.pythonmac.org/py2app/py2app/trunk/doc/index.html#tweaking-your-info-plist
+    # http://developer.apple.com/documentation/MacOSX/Conceptual/BPRuntimeConfig/Articles/PListKeys.html
+    if py2app is None:
+        return options
+    options['data_files'].extend([('share/OSX_Leopard_theme', glob(path.join('devsupport', 'OSX_Leopard_theme', '*')))])
+    options['data_files'].extend([('', ['devsupport/virtaal.icns'])])
+
+    # For some reason py2app can't handle bin/virtaal since it doesn't end in .py
+    import shutil
+    shutil.copy2('bin/virtaal', 'bin/run_virtaal.py')
+
+    from translate.storage import factory
+    options.update({
+        "app": ["bin/run_virtaal.py"],
+        "options": {
+            "py2app": {
+            "packages": ["CoreFoundation", "objc"],
+                "includes": ["lxml", "lxml._elementpath", "lxml.etree", "glib", "gio", "psyco", "cairo", "pango",
+                             "pangocairo", "atk", "gobject", "Gtk.keysyms", "pycurl", "translate.services",
+                             "translate.services.tmclient", "translate.services.opentranclient", "CoreFoundation"],
+                #"semi_standalone": True,
+                "compressed": True,
+                "argv_emulation": True,
+                "plist":  {
+                    "CFBundleGetInfoString": virtaal_description,
+                    "CFBundleName": PRETTY_NAME,
+                    "CFBundleIconFile": "virtaal.icns",
+                    "CFBundleShortVersionString": virtaal_version,
+                    #"LSHasLocalizedDisplayName": "1",
+                    #"LSMinimumSystemVersion": ???,
+                    "NSHumanReadableCopyright": "Copyright (C) 2007-2009 Zuza Software Foundation",
+                    "CFBundleDocumentTypes": [{
+                        "CFBundleTypeExtensions": [extention.lstrip("*.") for extention in extentions],
+                        "CFBundleTypeIconFile": "virtaal.icns",
+                        "CFBundleTypeMIMETypes": mimetypes,
+                        "CFBundleTypeName": description, #????
+                        } for description, extentions, mimetypes in factory.supported_files()]
+                    }
+                }
+            }})
+    return options
 
 def add_freedesktop_options(options):
     options['data_files'].extend([
@@ -137,6 +576,10 @@ def add_freedesktop_options(options):
 # General functions
 
 def add_platform_specific_options(options):
+    if sys.platform == 'win32':
+        return add_win32_options(options)
+    if sys.platform == 'darwin':
+        return add_mac_options(options)
     return add_freedesktop_options(options)
 
 def create_manifest(data_files, extra_files, extra_dirs):
@@ -180,7 +623,7 @@ def main(options):
     create_manifest(options['data_files'], no_install_files, no_install_dirs)
     setup(name="virtaal",
           version=virtaal_version,
-          license="GPL-2.0-or-later",
+          license="GNU General Public License (GPL)",
           description=virtaal_description,
           long_description="""Virtaal is used to create program translations.
 
@@ -196,3 +639,19 @@ can edit a variety of files (including PO and XLIFF files).""",
 
 if __name__ == '__main__':
     main(options)
+    # For some reason, Resources/lib/python2.5/lib-dynload is not in the Python
+    # path. We need to get it in, therefore this hack.
+    if sys.platform == 'darwin':
+        f = open('dist/virtaal.app/Contents/Resources/__boot__.py', "r+")
+        s = f.read()
+        f.truncate(0)
+        s = s.replace("base = os.environ['RESOURCEPATH']", r"""
+    base = os.environ['RESOURCEPATH']
+    sys.path = [os.path.join(base, "lib", "python2.5", "lib-dynload")] + sys.path
+    sys.path = [os.path.join(base, "lib", "python2.5")] + sys.path
+""")
+        f.seek(0)
+        f.write(s)
+        f.close()
+        # hdiutil create -imagekey zlib-level=9 -srcfolder dist/virtaal.app dist/virtaal.dmg
+        # hdiutil create -fs HFS+ -volname "RUR-PLE" -srcfolder dist dist_mac/RUR-PLE.dmg

--- a/share/virtaal/virtaal.ui
+++ b/share/virtaal/virtaal.ui
@@ -2125,7 +2125,7 @@ If you are translating from English to French then French would be your translat
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkComboBox" id="cmb_termfile">
+                    <object class="GtkComboBoxText" id="cmb_termfile">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                   </object>

--- a/share/virtaal/virtaal.ui
+++ b/share/virtaal/virtaal.ui
@@ -2740,13 +2740,21 @@ If you are translating from English to French then French would be your translat
       <object class="GtkVBox" id="vbox8">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
+        <property name="valign">start</property>
         <property name="spacing">15</property>
         <child>
-          <object class="GtkImage" id="img_banner">
+          <object class="GtkLayout">
+            <property name="height_request">80</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="xalign">0</property>
-            <property name="yalign">0</property>
+            <property name="width">400</property>
+            <property name="height">160</property>
+            <child>
+              <object class="GtkImage" id="img_banner">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+              </object>
+            </child>
           </object>
           <packing>
             <property name="expand">False</property>

--- a/share/virtaal/virtaal.ui
+++ b/share/virtaal/virtaal.ui
@@ -111,8 +111,6 @@
                             <property name="can_focus">True</property>
                             <property name="primary_icon_activatable">False</property>
                             <property name="secondary_icon_activatable">False</property>
-                            <property name="primary_icon_sensitive">True</property>
-                            <property name="secondary_icon_sensitive">True</property>
                           </object>
                           <packing>
                             <property name="left_attach">1</property>
@@ -127,8 +125,6 @@
                             <property name="max_length">100</property>
                             <property name="primary_icon_activatable">False</property>
                             <property name="secondary_icon_activatable">False</property>
-                            <property name="primary_icon_sensitive">True</property>
-                            <property name="secondary_icon_sensitive">True</property>
                           </object>
                           <packing>
                             <property name="left_attach">1</property>
@@ -170,8 +166,6 @@
                             <property name="can_focus">True</property>
                             <property name="primary_icon_activatable">False</property>
                             <property name="secondary_icon_activatable">False</property>
-                            <property name="primary_icon_sensitive">True</property>
-                            <property name="secondary_icon_sensitive">True</property>
                           </object>
                           <packing>
                             <property name="left_attach">1</property>
@@ -202,8 +196,6 @@
                             <property name="can_focus">True</property>
                             <property name="primary_icon_activatable">False</property>
                             <property name="secondary_icon_activatable">False</property>
-                            <property name="primary_icon_sensitive">True</property>
-                            <property name="secondary_icon_sensitive">True</property>
                             <property name="numeric">True</property>
                           </object>
                           <packing>
@@ -222,7 +214,6 @@
                             <property name="yalign">0.10000000149011612</property>
                             <property name="label" translatable="yes">Depending on the translation task, the plural information might be optional.</property>
                             <property name="wrap">True</property>
-                            <property name="wrap_mode">word-char</property>
                           </object>
                           <packing>
                             <property name="right_attach">2</property>

--- a/share/virtaal/virtaal.ui
+++ b/share/virtaal/virtaal.ui
@@ -2309,6 +2309,9 @@ If you are translating from English to French then French would be your translat
   <object class="GtkWindow" id="UnitEditor">
     <property name="can_focus">False</property>
     <child>
+      <placeholder/>
+    </child>
+    <child>
       <object class="GtkVBox" id="vbox_editor">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
@@ -2324,10 +2327,10 @@ If you are translating from English to French then French would be your translat
           </packing>
         </child>
         <child>
-            <object class="GtkGrid" id="tbl_editor">
+          <object class="GtkGrid" id="tbl_editor">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-                <property name="column-homogeneous">True</property>
+            <property name="column_homogeneous">True</property>
             <child>
               <object class="GtkVBox" id="vbox_right">
                 <property name="visible">True</property>
@@ -2337,12 +2340,13 @@ If you are translating from English to French then French would be your translat
                 </child>
               </object>
               <packing>
-                  <property name="left_attach">4</property>
-                  <!--                <property name="x_padding">5</property>-->
+                <property name="left_attach">3</property>
+                <property name="top_attach">0</property>
               </packing>
             </child>
             <child>
               <object class="GtkVBox" id="vbox_middle">
+                <property name="name">vbox_middle</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <child>
@@ -2399,11 +2403,20 @@ If you are translating from English to French then French would be your translat
               </object>
               <packing>
                 <property name="left_attach">1</property>
-                  <property name="width">3</property>
+                <property name="top_attach">0</property>
+                <property name="width">2</property>
               </packing>
             </child>
             <child>
-              <placeholder/>
+              <object class="GtkBox">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="orientation">vertical</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">0</property>
+              </packing>
             </child>
           </object>
           <packing>

--- a/share/virtaal/virtaal.ui
+++ b/share/virtaal/virtaal.ui
@@ -2333,11 +2333,10 @@ If you are translating from English to French then French would be your translat
           </packing>
         </child>
         <child>
-          <object class="GtkTable" id="tbl_editor">
+            <object class="GtkGrid" id="tbl_editor">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="n_columns">4</property>
-            <property name="homogeneous">True</property>
+                <property name="column-homogeneous">True</property>
             <child>
               <object class="GtkVBox" id="vbox_right">
                 <property name="visible">True</property>
@@ -2347,9 +2346,8 @@ If you are translating from English to French then French would be your translat
                 </child>
               </object>
               <packing>
-                <property name="left_attach">3</property>
-                <property name="right_attach">4</property>
-                <property name="x_padding">5</property>
+                  <property name="left_attach">4</property>
+                  <!--                <property name="x_padding">5</property>-->
               </packing>
             </child>
             <child>
@@ -2410,7 +2408,7 @@ If you are translating from English to French then French would be your translat
               </object>
               <packing>
                 <property name="left_attach">1</property>
-                <property name="right_attach">3</property>
+                  <property name="width">3</property>
               </packing>
             </child>
             <child>

--- a/virtaal/common/__init__.py
+++ b/virtaal/common/__init__.py
@@ -17,8 +17,9 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import
 
-import pan_app
-from gobjectwrapper import GObjectWrapper
+from . import pan_app
+from .gobjectwrapper import GObjectWrapper
 
 __all__ = ['pan_app', 'GObjectWrapper']

--- a/virtaal/common/gobjectwrapper.py
+++ b/virtaal/common/gobjectwrapper.py
@@ -32,27 +32,25 @@ class GObjectWrapper(GObject.GObject):
     def __init__(self):
         super(GObjectWrapper, self).__init__()
         self._all_signals = GObject.signal_list_names(self)
-        self._enabled_signals = list(self._all_signals)
+        self._enabled_signals = set(self._all_signals)
 
 
     # METHODS #
-    def disable_signals(self, signals=[]):
+    def disable_signals(self, signals=None):
         """Disable all or specified signals."""
         if signals:
             for sig in signals:
-                if sig in self._enabled_signals:
-                    self._enabled_signals.remove(sig)
+                self._enabled_signals.discard(sig)
         else:
-            self._enabled_signals = []
+            self._enabled_signals.clear()
 
-    def enable_signals(self, signals=[]):
+    def enable_signals(self, signals=None):
         """Enable all or specified signals."""
         if signals:
             for sig in signals:
-                if sig not in self._enabled_signals:
-                    self._enabled_signals.append(sig)
+                self._enabled_signals.add(sig)
         else:
-            self._enabled_signals = list(self._all_signals) # Enable all signals
+            self._enabled_signals = set(self._all_signals)  # Enable all signals
 
     def emit(self, signame, *args):
         if signame in self._enabled_signals:

--- a/virtaal/common/gobjectwrapper.py
+++ b/virtaal/common/gobjectwrapper.py
@@ -18,11 +18,11 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-from gobject import GObject, signal_list_names
+from gi.repository import GObject
 #import logging
 
 
-class GObjectWrapper(GObject):
+class GObjectWrapper(GObject.GObject):
     """
     A wrapper for GObject sub-classes that provides some more powerful signal-
     handling.
@@ -30,8 +30,8 @@ class GObjectWrapper(GObject):
 
     # INITIALIZERS #
     def __init__(self):
-        GObject.__init__(self)
-        self._all_signals = signal_list_names(self.__gtype_name__)
+        GObject.GObject.__init__(self)
+        self._all_signals = GObject.signal_list_names(self)
         self._enabled_signals = list(self._all_signals)
 
 
@@ -57,4 +57,4 @@ class GObjectWrapper(GObject):
     def emit(self, signame, *args):
         if signame in self._enabled_signals:
             #logging.debug('emit("%s", %s)' % (signame, ','.join([repr(arg) for arg in args])))
-            GObject.emit(self, signame, *args)
+            super(GObjectWrapper, self).emit(signame, *args)

--- a/virtaal/common/gobjectwrapper.py
+++ b/virtaal/common/gobjectwrapper.py
@@ -30,7 +30,7 @@ class GObjectWrapper(GObject.GObject):
 
     # INITIALIZERS #
     def __init__(self):
-        GObject.GObject.__init__(self)
+        super(GObjectWrapper, self).__init__()
         self._all_signals = GObject.signal_list_names(self)
         self._enabled_signals = list(self._all_signals)
 

--- a/virtaal/common/gobjectwrapper.py
+++ b/virtaal/common/gobjectwrapper.py
@@ -31,7 +31,10 @@ class GObjectWrapper(GObject.GObject):
     # INITIALIZERS #
     def __init__(self):
         super(GObjectWrapper, self).__init__()
-        self._all_signals = GObject.signal_list_names(self)
+        self._all_signals = []
+        for type_ in self.__class__.mro():
+            if issubclass(type_, GObject.GObject):
+                self._all_signals.extend(GObject.signal_list_names(type_))
         self._enabled_signals = set(self._all_signals)
 
 

--- a/virtaal/common/pan_app.py
+++ b/virtaal/common/pan_app.py
@@ -114,6 +114,7 @@ def get_default_font():
 
     # First try and get the default font size from GConf
     try:
+        gi.require_version('GConf', '2.0')
         from gi.repository import GConf
         client = GConf.Client.get_default()
         client.add_dir('/desktop/gnome/interface', GConf.ClientPreloadType.PRELOAD_NONE)

--- a/virtaal/common/pan_app.py
+++ b/virtaal/common/pan_app.py
@@ -109,9 +109,9 @@ def get_default_font():
 
     # First try and get the default font size from GConf
     try:
-        import gconf
-        client = gconf.client_get_default()
-        client.add_dir('/desktop/gnome/interface', gconf.CLIENT_PRELOAD_NONE)
+        from gi.repository import GConf
+        client = GConf.Client.get_default()
+        client.add_dir('/desktop/gnome/interface', GConf.ClientPreloadType.PRELOAD_NONE)
         font_name = client.get_string('/desktop/gnome/interface/monospace_font_name')
         font_size = font_name.split(' ')[-1]
     except ImportError, ie:
@@ -123,8 +123,10 @@ def get_default_font():
 
     # Get the default font size from Gtk
     if not font_size:
-        import gtk
-        font_name = str(gtk.Label().rc_get_style().font_desc)
+        import gi
+        gi.require_version('Gtk', '3.0')
+        from gi.repository import Gtk
+        font_name = str(Gtk.rc_get_style().font_desc)
         font_size = font_name.split(' ')[-1]
 
     if font_size:

--- a/virtaal/common/pan_app.py
+++ b/virtaal/common/pan_app.py
@@ -120,6 +120,12 @@ def get_default_font():
         font_name = client.get_string('/desktop/gnome/interface/monospace_font_name')
         font_size = font_name.split(' ')[-1]
     except ImportError as ie:
+        from gi.repository import Gio
+        settings = Gio.Settings.new('org.gnome.desktop.interface')
+        font_name = settings.get_string('monospace-font-name')
+        if font_name:
+            return font_name
+    except ImportError as ie:
         import logging
         logging.debug('Unable to import gconf module: %s', ie)
     except Exception:

--- a/virtaal/common/pan_app.py
+++ b/virtaal/common/pan_app.py
@@ -126,7 +126,8 @@ def get_default_font():
         import gi
         gi.require_version('Gtk', '3.0')
         from gi.repository import Gtk
-        font_name = str(Gtk.rc_get_style().font_desc)
+        style_context = Gtk.Label().get_style_context()
+        font_name = str(style_context.get_property('font', style_context.get_state()))
         font_size = font_name.split(' ')[-1]
 
     if font_size:

--- a/virtaal/common/pan_app.py
+++ b/virtaal/common/pan_app.py
@@ -132,7 +132,7 @@ def get_default_font():
         gi.require_version('Gtk', '3.0')
         from gi.repository import Gtk
         style_context = Gtk.Label().get_style_context()
-        font_name = str(style_context.get_property('font', style_context.get_state()))
+        font_name = style_context.get_font(style_context.get_state()).to_string()
         font_size = font_name.split(' ')[-1]
 
     if font_size:

--- a/virtaal/common/utils.py
+++ b/virtaal/common/utils.py
@@ -1,0 +1,15 @@
+import sys
+
+from six import text_type
+
+
+def get_unicode(string, encoding=None):
+    if isinstance(string, text_type):
+        return string
+    return string.decode(encoding or sys.getfilesystemencoding())
+
+
+def get_bytes(string):
+    if isinstance(string, text_type):
+        return string.encode()
+    return string

--- a/virtaal/controllers/baseplugin.py
+++ b/virtaal/controllers/baseplugin.py
@@ -22,6 +22,7 @@ import os
 
 from virtaal.common import pan_app
 
+
 class PluginUnsupported(Exception):
     pass
 
@@ -34,7 +35,7 @@ class BasePlugin(object):
     """A description about the plug-in's purpose."""
     display_name = ''
     """The plug-in's name, suitable for display."""
-    version = 0
+    version = '0'
     """The plug-in's version number."""
     default_config = {}
 
@@ -43,7 +44,7 @@ class BasePlugin(object):
         """Create a new plug-in instance and check that it is valid."""
         if not cls.display_name:
             raise Exception('No name specified')
-        if cls.version <= 0:
+        if str(cls.version) <= '0':
             raise Exception('Invalid version number specified')
         return super(BasePlugin, cls).__new__(cls)
 

--- a/virtaal/controllers/checkscontroller.py
+++ b/virtaal/controllers/checkscontroller.py
@@ -17,13 +17,14 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import, print_function, unicode_literals
 
 import logging
 
 from gi.repository.GObject import SIGNAL_RUN_FIRST, timeout_add, PRIORITY_LOW
 
-from basecontroller import BaseController
 from virtaal.common import GObjectWrapper
+from .basecontroller import BaseController
 
 check_names = {
     'fuzzy': _(u"Fuzzy"),

--- a/virtaal/controllers/checkscontroller.py
+++ b/virtaal/controllers/checkscontroller.py
@@ -19,11 +19,11 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 import logging
-from gobject import SIGNAL_RUN_FIRST, timeout_add, PRIORITY_LOW
 
-from virtaal.common import GObjectWrapper
+from gi.repository.GObject import SIGNAL_RUN_FIRST, timeout_add, PRIORITY_LOW
 
 from basecontroller import BaseController
+from virtaal.common import GObjectWrapper
 
 check_names = {
     'fuzzy': _(u"Fuzzy"),

--- a/virtaal/controllers/cursor.py
+++ b/virtaal/controllers/cursor.py
@@ -19,8 +19,9 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 import logging
-from gobject import SIGNAL_RUN_FIRST
 from bisect import bisect_left
+
+from gi.repository.GObject import SIGNAL_RUN_FIRST
 
 from virtaal.common import GObjectWrapper
 

--- a/virtaal/controllers/cursor.py
+++ b/virtaal/controllers/cursor.py
@@ -110,7 +110,7 @@ class Cursor(GObjectWrapper):
             @returns: C{self.model[self.index]}, or C{None} if any error occurred."""
         try:
             return self.model[self.index]
-        except Exception, exc:
+        except Exception as exc:
             logging.debug('Unable to dereference cursor:\n%s' % (exc))
             return None
 

--- a/virtaal/controllers/langcontroller.py
+++ b/virtaal/controllers/langcontroller.py
@@ -17,14 +17,16 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import, print_function, unicode_literals
 
 import os
 
 from gi.repository.GObject import SIGNAL_RUN_FIRST
+from six import string_types as basestring
 
-from basecontroller import BaseController
 from virtaal.common import GObjectWrapper, pan_app
 from virtaal.models.langmodel import LanguageModel
+from .basecontroller import BaseController
 
 
 class LanguageController(BaseController):

--- a/virtaal/controllers/langcontroller.py
+++ b/virtaal/controllers/langcontroller.py
@@ -19,12 +19,12 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 import os
-from gobject import SIGNAL_RUN_FIRST
 
-from virtaal.common import GObjectWrapper, pan_app
-from virtaal.models.langmodel import LanguageModel
+from gi.repository.GObject import SIGNAL_RUN_FIRST
 
 from basecontroller import BaseController
+from virtaal.common import GObjectWrapper, pan_app
+from virtaal.models.langmodel import LanguageModel
 
 
 class LanguageController(BaseController):

--- a/virtaal/controllers/maincontroller.py
+++ b/virtaal/controllers/maincontroller.py
@@ -19,14 +19,14 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-import gtk
-from gobject import SIGNAL_RUN_FIRST
 import os
 
-from virtaal.common import GObjectWrapper, pan_app
-from virtaal.views.mainview import MainView
+from gi.repository import Gtk
+from gobject import SIGNAL_RUN_FIRST
 
 from basecontroller import BaseController
+from virtaal.common import GObjectWrapper, pan_app
+from virtaal.views.mainview import MainView
 
 
 class MainController(BaseController):
@@ -181,7 +181,7 @@ class MainController(BaseController):
         # make it our problem and ensure the last ones are in the main
         # controller.
         while not self.placeables_controller:
-            gtk.main_iteration(False)
+            Gtk.main_iteration(False)
         if filename is None:
             return self.view.open_file()
         if self.store_controller.is_modified():

--- a/virtaal/controllers/maincontroller.py
+++ b/virtaal/controllers/maincontroller.py
@@ -21,6 +21,9 @@
 
 import os
 
+import gi
+
+gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk, GObject
 
 from basecontroller import BaseController

--- a/virtaal/controllers/maincontroller.py
+++ b/virtaal/controllers/maincontroller.py
@@ -21,8 +21,7 @@
 
 import os
 
-from gi.repository import Gtk
-from gobject import SIGNAL_RUN_FIRST
+from gi.repository import Gtk, GObject
 
 from basecontroller import BaseController
 from virtaal.common import GObjectWrapper, pan_app
@@ -35,8 +34,8 @@ class MainController(BaseController):
 
     __gtype_name__ = 'MainController'
     __gsignals__ = {
-        'controller-registered': (SIGNAL_RUN_FIRST, None, (object,)),
-        'quit':                  (SIGNAL_RUN_FIRST, None, tuple()),
+        'controller-registered': (GObject.SignalFlags.RUN_FIRST, None, (object,)),
+        'quit': (GObject.SignalFlags.RUN_FIRST, None, ()),
     }
 
     # INITIALIZERS #
@@ -181,7 +180,7 @@ class MainController(BaseController):
         # make it our problem and ensure the last ones are in the main
         # controller.
         while not self.placeables_controller:
-            Gtk.main_iteration(False)
+            Gtk.main_iteration()
         if filename is None:
             return self.view.open_file()
         if self.store_controller.is_modified():

--- a/virtaal/controllers/maincontroller.py
+++ b/virtaal/controllers/maincontroller.py
@@ -26,7 +26,7 @@ import gi
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk, GObject
 
-from basecontroller import BaseController
+from .basecontroller import BaseController
 from virtaal.common import GObjectWrapper, pan_app
 from virtaal.views.mainview import MainView
 
@@ -210,7 +210,7 @@ class MainController(BaseController):
             self.store_controller.open_file(filename, uri, forget_dir=forget_dir)
             self.mode_controller.refresh_mode()
             return True
-        except Exception, exc:
+        except Exception as exc:
             import logging
             logging.exception('MainController.open_file(filename="%s", uri="%s")' % (filename, uri))
             self.show_error(
@@ -255,11 +255,11 @@ class MainController(BaseController):
         try:
             self.store_controller.save_file(filename)
             return True
-        except IOError, exc:
+        except IOError as exc:
             self.show_error(
                 _("Could not save file.\n\n%(error_message)s\n\nTry saving to a different location.") % {'error_message': str(exc)}
             )
-        except Exception, exc:
+        except Exception as exc:
             import logging
             logging.exception('MainController.save_file(filename="%s")' % (filename))
             self.show_error(
@@ -289,11 +289,11 @@ class MainController(BaseController):
         try:
             self.store_controller.binary_export(filename)
             return True
-        except IOError, exc:
+        except IOError as exc:
             self.show_error(
                 _("Could not export file.\n\n%(error_message)s\n\nTry saving to a different location.") % {'error_message': str(exc)}
             )
-        except Exception, exc:
+        except Exception as exc:
             import logging
             logging.exception('MainController.binary_export(filename="%s")' % (filename))
             self.show_error(
@@ -320,7 +320,7 @@ class MainController(BaseController):
         try:
             self.store_controller.revert_file()
             self.mode_controller.refresh_mode()
-        except Exception, exc:
+        except Exception as exc:
             import logging
             logging.exception('MainController.revert_file(filename="%s")' % (filename))
             self.show_error(
@@ -348,7 +348,7 @@ class MainController(BaseController):
             self.store_controller.update_file(filename, uri)
             self.mode_controller.refresh_mode()
             return True
-        except Exception, exc:
+        except Exception as exc:
             import logging
             logging.exception('MainController.update_file(filename="%s", uri="%s")' % (filename, uri))
             self.show_error(

--- a/virtaal/controllers/modecontroller.py
+++ b/virtaal/controllers/modecontroller.py
@@ -18,11 +18,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-import gobject
-
-from virtaal.common import GObjectWrapper
+from gi.repository import GObject
 
 from basecontroller import BaseController
+from virtaal.common import GObjectWrapper
 
 
 class ModeController(BaseController):
@@ -37,7 +36,7 @@ class ModeController(BaseController):
 
     __gtype_name__ = 'ModeController'
     __gsignals__ = {
-        'mode-selected': (gobject.SIGNAL_RUN_FIRST, gobject.TYPE_NONE, (gobject.TYPE_PYOBJECT,)),
+        'mode-selected': (GObject.SignalFlags.RUN_FIRST, None, (GObject.TYPE_PYOBJECT,)),
     }
     default_mode_name = 'Default'
 

--- a/virtaal/controllers/modecontroller.py
+++ b/virtaal/controllers/modecontroller.py
@@ -17,11 +17,12 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import, print_function, unicode_literals
 
 from gi.repository import GObject
 
-from basecontroller import BaseController
 from virtaal.common import GObjectWrapper
+from .basecontroller import BaseController
 
 
 class ModeController(BaseController):

--- a/virtaal/controllers/placeablescontroller.py
+++ b/virtaal/controllers/placeablescontroller.py
@@ -236,13 +236,16 @@ class PlaceablesController(BaseController):
 
     # EVENT HANDLERS #
     def _on_style_set(self, widget, prev_style=None):
-        placeablesguiinfo.update_style(widget)
+        textbox = None
 
         # Refresh text boxes' colours
         unitview = self.main_controller.unit_controller.view
         for textbox in unitview.sources + unitview.targets:
             if textbox.props.visible:
                 textbox.refresh()
+
+        if textbox:
+            placeablesguiinfo.update_style(textbox)
 
     def _on_quit(self, main_ctrlr):
         for parser in general.parsers:

--- a/virtaal/controllers/placeablescontroller.py
+++ b/virtaal/controllers/placeablescontroller.py
@@ -19,13 +19,12 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-import gobject
+from gi.repository import GObject
 from translate.storage.placeables import general, StringElem, parse as parse_placeables
 
+from basecontroller import BaseController
 from virtaal.common import pan_app, GObjectWrapper
 from virtaal.views import placeablesguiinfo
-
-from basecontroller import BaseController
 
 
 class PlaceablesController(BaseController):
@@ -33,7 +32,7 @@ class PlaceablesController(BaseController):
 
     __gtype_name__ = 'PlaceablesController'
     __gsignals__ = {
-        'parsers-changed': (gobject.SIGNAL_RUN_FIRST, gobject.TYPE_NONE, tuple()),
+        'parsers-changed': (GObject.SignalFlags.RUN_FIRST, None, tuple()),
     }
 
     parsers = []

--- a/virtaal/controllers/placeablescontroller.py
+++ b/virtaal/controllers/placeablescontroller.py
@@ -53,6 +53,7 @@ class PlaceablesController(BaseController):
         self._init_notarget_list()
 
         self.main_controller.view.main_window.connect('style-set', self._on_style_set)
+        self.main_controller.view.main_window.connect('style-updated', self._on_style_set)
         self._on_style_set(self.main_controller.view.main_window, None)
         self.main_controller.connect('quit', self._on_quit)
 
@@ -234,7 +235,7 @@ class PlaceablesController(BaseController):
 
 
     # EVENT HANDLERS #
-    def _on_style_set(self, widget, prev_style):
+    def _on_style_set(self, widget, prev_style=None):
         placeablesguiinfo.update_style(widget)
 
         # Refresh text boxes' colours

--- a/virtaal/controllers/placeablescontroller.py
+++ b/virtaal/controllers/placeablescontroller.py
@@ -18,13 +18,15 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import, print_function, unicode_literals
 
 from gi.repository import GObject
+from six import text_type as unicode
 from translate.storage.placeables import general, StringElem, parse as parse_placeables
 
-from basecontroller import BaseController
 from virtaal.common import pan_app, GObjectWrapper
 from virtaal.views import placeablesguiinfo
+from .basecontroller import BaseController
 
 
 class PlaceablesController(BaseController):
@@ -70,7 +72,7 @@ class PlaceablesController(BaseController):
 
         self.parsers = []
         for parser in general.parsers:
-            classname = parser.im_self.__name__.lower()
+            classname = parser.__self__.__name__.lower()
             if classname in disabled:
                 continue
             self.add_parsers(parser)
@@ -206,7 +208,7 @@ class PlaceablesController(BaseController):
             text."""
         if textbox in self.main_controller.unit_controller.view.targets:
             tgt_parsers = []
-            return [p for p in self.parsers if p.im_self not in self.non_target_placeables]
+            return [p for p in self.parsers if p.__self__ not in self.non_target_placeables]
         return self.parsers
 
     def get_gui_info(self, placeable):
@@ -243,7 +245,7 @@ class PlaceablesController(BaseController):
 
     def _on_quit(self, main_ctrlr):
         for parser in general.parsers:
-            classname = parser.im_self.__name__
+            classname = parser.__self__.__name__
             enabled = parser in self.parsers
             if classname in pan_app.settings.placeable_state or not enabled:
                 pan_app.settings.placeable_state[classname.lower()] = enabled and 'enabled' or 'disabled'

--- a/virtaal/controllers/plugincontroller.py
+++ b/virtaal/controllers/plugincontroller.py
@@ -212,7 +212,7 @@ class PluginController(BaseController):
             if not os.path.isdir(dir):
                 continue
             for name in os.listdir(dir):
-                if name.startswith(u'.') or name.startswith(u'test_'):
+                if self._is_wrong_plugin_name(name):
                     continue
                 fullpath = os.path.join(dir, name)
                 if os.path.isdir(fullpath):
@@ -229,3 +229,7 @@ class PluginController(BaseController):
         plugin_names = list(set(plugin_names))
         #logging.debug('Found plugins: %s' % (', '.join(plugin_names)))
         return plugin_names
+
+    @staticmethod
+    def _is_wrong_plugin_name(name):
+        return name.startswith(u'.') or name.startswith(u'test_') or name == '__pycache__'

--- a/virtaal/controllers/plugincontroller.py
+++ b/virtaal/controllers/plugincontroller.py
@@ -21,13 +21,12 @@
 import logging
 import os
 import sys
-from gobject import SIGNAL_RUN_FIRST, TYPE_PYOBJECT, idle_add
 
-from virtaal.common import pan_app, GObjectWrapper
+from gi.repository.GObject import SIGNAL_RUN_FIRST, TYPE_PYOBJECT, idle_add
 
 from basecontroller import BaseController
 from baseplugin import PluginUnsupported, BasePlugin
-
+from virtaal.common import pan_app, GObjectWrapper
 
 if os.name == 'nt':
     sys.path.insert(0, pan_app.main_dir.encode(sys.getfilesystemencoding()))

--- a/virtaal/controllers/prefscontroller.py
+++ b/virtaal/controllers/prefscontroller.py
@@ -17,10 +17,10 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import, print_function, unicode_literals
 
 from virtaal.common import GObjectWrapper, pan_app
-
-from basecontroller import BaseController
+from .basecontroller import BaseController
 
 
 class PreferencesController(BaseController):
@@ -60,7 +60,7 @@ class PreferencesController(BaseController):
     def update_config_placeables_state(self, parser, disabled):
         """Make sure that the placeable with the given name is enabled/disabled
             in the main configuration file."""
-        classname = parser.im_self.__name__
+        classname = parser.__self__.__name__
         pan_app.settings.placeable_state[classname.lower()] = disabled and 'disabled' or 'enabled'
 
     def update_config_plugin_state(self, plugin_name, disabled):
@@ -90,7 +90,7 @@ class PreferencesController(BaseController):
 
     def _update_placeables_gui_data(self):
         items = []
-        allparsers = self.placeables_controller.parser_info.items()
+        allparsers = list(self.placeables_controller.parser_info.items())
         allparsers.sort(key=lambda x: x[1][0])
         for parser, (name, desc) in allparsers:
             items.append({
@@ -116,7 +116,7 @@ class PreferencesController(BaseController):
             else:
                 try:
                     info = self.plugin_controller.get_plugin_info(found_plugin)
-                except Exception, e:
+                except Exception as e:
                     import logging
                     logging.debug('Problem getting information for plugin %s' % found_plugin)
                     continue

--- a/virtaal/controllers/propertiescontroller.py
+++ b/virtaal/controllers/propertiescontroller.py
@@ -17,11 +17,10 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
-
+from __future__ import absolute_import, print_function, unicode_literals
 
 from virtaal.common import GObjectWrapper
-
-from basecontroller import BaseController
+from .basecontroller import BaseController
 
 
 class PropertiesController(BaseController):

--- a/virtaal/controllers/storecontroller.py
+++ b/virtaal/controllers/storecontroller.py
@@ -18,13 +18,14 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import, print_function, unicode_literals
 
 import os
 
 from gi.repository import GObject
 
-from basecontroller import BaseController
 from virtaal.common import GObjectWrapper
+from .basecontroller import BaseController
 
 
 # TODO: Create an event that is emitted when a cursor is created
@@ -170,7 +171,7 @@ class StoreController(BaseController):
             # calls unit.__eq__ which does a *lot* of things.
             i = self.store.get_units().index(unit)
             #TODO: consider replacing with API that uses index instead of unit
-        except Exception, exc:
+        except Exception as exc:
             import logging
             logging.debug('Unit not found:\n%s' % (exc))
 
@@ -190,7 +191,7 @@ class StoreController(BaseController):
             try:
                 from translate.storage.project import Project
                 self.project = Project(bundleprojstore.BundleProjectStore(filename))
-            except bundleprojstore.InvalidBundleError, err:
+            except bundleprojstore.InvalidBundleError as err:
                 logging.exception('Unable to load project bundle')
 
             if not len(self.project.store.transfiles):
@@ -248,7 +249,7 @@ class StoreController(BaseController):
         self.main_controller.set_force_saveas(force_saveas)
         self.main_controller.set_saveable(self._modified)
 
-        from cursor import Cursor
+        from .cursor import Cursor
         self.cursor = Cursor(self.store, self.store.stats['total'])
 
         self.view.load_store(self.store)

--- a/virtaal/controllers/storecontroller.py
+++ b/virtaal/controllers/storecontroller.py
@@ -19,11 +19,12 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-import gobject
 import os
 
-from virtaal.common import GObjectWrapper
+from gi.repository import GObject
+
 from basecontroller import BaseController
+from virtaal.common import GObjectWrapper
 
 
 # TODO: Create an event that is emitted when a cursor is created
@@ -32,9 +33,9 @@ class StoreController(BaseController):
 
     __gtype_name__ = 'StoreController'
     __gsignals__ = {
-        'store-loaded': (gobject.SIGNAL_RUN_FIRST, gobject.TYPE_NONE, ()),
-        'store-saved':  (gobject.SIGNAL_RUN_FIRST, gobject.TYPE_NONE, ()),
-        'store-closed': (gobject.SIGNAL_RUN_FIRST, gobject.TYPE_NONE, ()),
+        'store-loaded': (GObject.SignalFlags.RUN_FIRST, None, ()),
+        'store-saved': (GObject.SignalFlags.RUN_FIRST, None, ()),
+        'store-closed': (GObject.SignalFlags.RUN_FIRST, None, ()),
     }
 
     # INITIALIZERS #
@@ -135,7 +136,7 @@ class StoreController(BaseController):
 
     def get_unit_celleditor(self, unit):
         """Load the given unit in via the C{UnitController} and return
-            the C{gtk.CellEditable} it creates."""
+            the C{Gtk.CellEditable} it creates."""
         return self.unit_controller.load_unit(unit)
 
     def is_modified(self):

--- a/virtaal/controllers/undocontroller.py
+++ b/virtaal/controllers/undocontroller.py
@@ -17,14 +17,15 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import, print_function, unicode_literals
 
 from gi.repository import GObject
 from gi.repository import Gdk
 from gi.repository import Gtk
 from translate.storage.placeables import StringElem
 
-from basecontroller import BaseController
 from virtaal.common import GObjectWrapper, pan_app
+from .basecontroller import BaseController
 
 
 class UndoController(BaseController):

--- a/virtaal/controllers/undocontroller.py
+++ b/virtaal/controllers/undocontroller.py
@@ -18,14 +18,13 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-import gobject
-import gtk
-from gtk import gdk
+from gi.repository import GObject
+from gi.repository import Gdk
+from gi.repository import Gtk
 from translate.storage.placeables import StringElem
 
-from virtaal.common import GObjectWrapper, pan_app
-
 from basecontroller import BaseController
+from virtaal.common import GObjectWrapper, pan_app
 
 
 class UndoController(BaseController):
@@ -69,9 +68,9 @@ class UndoController(BaseController):
             This method *may* need to be moved into a view object, but if it is,
             it will be the only functionality in such a class. Therefore, it
             is done here. At least for now."""
-        gtk.accel_map_add_entry("<Virtaal>/Edit/Undo", gtk.keysyms.z, gdk.CONTROL_MASK)
+        Gtk.AccelMap.add_entry("<Virtaal>/Edit/Undo", Gdk.KEY_z, Gdk.ModifierType.CONTROL_MASK)
 
-        self.accel_group = gtk.AccelGroup()
+        self.accel_group = Gtk.AccelGroup()
         # The following line was commented out, because it caused a double undo when pressing
         # Ctrl+Z, but only one if done through the menu item. This way it all works as expected.
         #self.accel_group.connect_by_path("<Virtaal>/Edit/Undo", self._on_undo_activated)
@@ -148,7 +147,8 @@ class UndoController(BaseController):
             textbox.refresh_cursor_pos = undo_info['cursorpos']
             # TODO: try to avoid full refresh
             textbox.refresh(update=True)
-        gobject.idle_add(refresh)
+
+        GObject.idle_add(refresh)
 
     def _select_unit(self, unit):
         """Select the given unit in the store view.

--- a/virtaal/controllers/unitcontroller.py
+++ b/virtaal/controllers/unitcontroller.py
@@ -239,6 +239,9 @@ class UnitController(BaseController):
 
 
 def create_unit_workflow(unit, state_names):
+    """Copied from the toolkit for Py3 compatibility
+
+    See translate.storage.workflow::create_unit_workflow()."""
     wf = Workflow(unit)
 
     state_info = list(unit.STATE.items())

--- a/virtaal/controllers/unitcontroller.py
+++ b/virtaal/controllers/unitcontroller.py
@@ -18,12 +18,12 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-from gobject import SIGNAL_RUN_FIRST, timeout_add
+from gi.repository.GLib import timeout_add
+from gi.repository.GObject import SignalFlags
 from translate.storage import workflow
 
-from virtaal.common import GObjectWrapper
-
 from basecontroller import BaseController
+from virtaal.common import GObjectWrapper
 
 
 class UnitController(BaseController):
@@ -31,11 +31,11 @@ class UnitController(BaseController):
 
     __gtype_name__ = "UnitController"
     __gsignals__ = {
-        'unit-done':           (SIGNAL_RUN_FIRST, None, (object, int)),
-        'unit-modified':       (SIGNAL_RUN_FIRST, None, (object,)),
-        'unit-delete-text':    (SIGNAL_RUN_FIRST, None, (object, object, object, int, int, object, int)),
-        'unit-insert-text':    (SIGNAL_RUN_FIRST, None, (object, object, int, object, int)),
-        'unit-paste-start':    (SIGNAL_RUN_FIRST, None, (object, object, object, int)),
+        'unit-done': (SignalFlags.RUN_FIRST, None, (object, int)),
+        'unit-modified': (SignalFlags.RUN_FIRST, None, (object,)),
+        'unit-delete-text': (SignalFlags.RUN_FIRST, None, (object, object, object, int, int, object, int)),
+        'unit-insert-text': (SignalFlags.RUN_FIRST, None, (object, object, int, object, int)),
+        'unit-paste-start': (SignalFlags.RUN_FIRST, None, (object, object, object, int)),
     }
 
     STATE_TIMEOUT = 200

--- a/virtaal/controllers/welcomescreencontroller.py
+++ b/virtaal/controllers/welcomescreencontroller.py
@@ -56,8 +56,8 @@ class WelcomeScreenController(BaseController):
     def activate(self):
         """Show the welcome screen and trigger activation logic (ie. find
             recent files)."""
-        import gobject
-        gobject.idle_add(self.update_recent, priority=gobject.PRIORITY_LOW)
+        from gi.repository import GObject
+        GObject.idle_add(self.update_recent, priority=GObject.PRIORITY_LOW)
         self.view.show()
 
     def open_cheatsheat(self):

--- a/virtaal/controllers/welcomescreencontroller.py
+++ b/virtaal/controllers/welcomescreencontroller.py
@@ -18,9 +18,10 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import, print_function, unicode_literals
 
-
-from basecontroller import BaseController
+from virtaal.common.utils import get_unicode
+from .basecontroller import BaseController
 
 
 class WelcomeScreenController(BaseController):
@@ -71,7 +72,7 @@ class WelcomeScreenController(BaseController):
     def open_recent(self, n):
         n -= 1 # Shift from nominal value [1; 5] to index value [0; 4]
         if 0 <= n <= len(self._recent_files)-1:
-            self.open_file(self._recent_files[n]['uri'].decode('utf-8'))
+            self.open_file(get_unicode(self._recent_files[n]['uri'], 'utf-8'))
         else:
             import logging
             logging.debug('Invalid recent file index (%d) given. Recent files: %s)' % (n, self._recent_files))

--- a/virtaal/main.py
+++ b/virtaal/main.py
@@ -97,8 +97,8 @@ class Virtaal(object):
         main_controller = self.main_controller
 
         if isinstance(startupfile, str):
-            import sys
-            startupfile = unicode(startupfile, sys.getfilesystemencoding())
+            from virtaal.common.utils import get_unicode
+            startupfile = get_unicode(startupfile)
 
         UnitController(main_controller.store_controller)
         ModeController(main_controller)

--- a/virtaal/main.py
+++ b/virtaal/main.py
@@ -96,7 +96,7 @@ class Virtaal(object):
 
         main_controller = self.main_controller
 
-        if isinstance(startupfile, str):
+        if isinstance(startupfile, bytes):
             from virtaal.common.utils import get_unicode
             startupfile = get_unicode(startupfile)
 

--- a/virtaal/main.py
+++ b/virtaal/main.py
@@ -26,7 +26,7 @@
 # after the GUI is already showing.
 
 
-import gobject
+from gi.repository import GObject
 
 
 class _Deferer:
@@ -49,7 +49,7 @@ class _Deferer:
 
         if not self._todo:
             # No existing jobs, so start one
-            gobject.idle_add(next_job, priority=gobject.PRIORITY_LOW)
+            GObject.idle_add(next_job, priority=GObject.PRIORITY_LOW)
         self._todo.append((func, args))
 
 

--- a/virtaal/models/basemodel.py
+++ b/virtaal/models/basemodel.py
@@ -18,22 +18,22 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-import gobject
+from gi.repository import GObject
 
 
-class BaseModel(gobject.GObject):
+class BaseModel(GObject.GObject):
     """Base class for all models."""
 
     __gtype_name__ = "BaseModel"
 
     __gsignals__ = {
-        "loaded": (gobject.SIGNAL_RUN_FIRST, gobject.TYPE_NONE, ()),
-        "saved":  (gobject.SIGNAL_RUN_FIRST, gobject.TYPE_NONE, ()),
+        "loaded": (GObject.SignalFlags.RUN_FIRST, None, ()),
+        "saved": (GObject.SignalFlags.RUN_FIRST, None, ()),
     }
 
     # INITIALIZERS #
     def __init__(self):
-        gobject.GObject.__init__(self)
+        GObject.GObject.__init__(self)
 
 
     # ACCESSORS #

--- a/virtaal/models/basemodel.py
+++ b/virtaal/models/basemodel.py
@@ -33,7 +33,7 @@ class BaseModel(GObject.GObject):
 
     # INITIALIZERS #
     def __init__(self):
-        GObject.GObject.__init__(self)
+        super(BaseModel, self).__init__()
 
 
     # ACCESSORS #

--- a/virtaal/models/langmodel.py
+++ b/virtaal/models/langmodel.py
@@ -17,15 +17,15 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import, print_function, unicode_literals
 
 import logging
 
-from translate.lang.data import languages as toolkit_langs, tr_lang
 from translate.lang import data
+from translate.lang.data import languages as toolkit_langs, tr_lang
 
 from virtaal.common.pan_app import ui_language
-
-from basemodel import BaseModel
+from .basemodel import BaseModel
 
 gettext_lang = tr_lang(ui_language)
 

--- a/virtaal/models/storemodel.py
+++ b/virtaal/models/storemodel.py
@@ -17,12 +17,14 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import, print_function, unicode_literals
 
 import os
 
-from virtaal.common import pan_app
+from six import string_types
 
-from basemodel import BaseModel
+from virtaal.common import pan_app
+from .basemodel import BaseModel
 
 
 def fix_indexes(stats, valid_units=None):
@@ -127,7 +129,7 @@ class StoreModel(BaseModel):
     def load_file(self, fileobj):
         # Adapted from Document.__init__()
         filename = fileobj
-        if isinstance(filename, basestring):
+        if isinstance(filename, string_types):
             if not os.path.exists(filename):
                 raise IOError(_('The file does not exist.'))
             if not os.path.isfile(filename):

--- a/virtaal/models/undomodel.py
+++ b/virtaal/models/undomodel.py
@@ -18,8 +18,9 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import, print_function, unicode_literals
 
-from basemodel import BaseModel
+from .basemodel import BaseModel
 
 
 class UndoModel(BaseModel):

--- a/virtaal/modes/__init__.py
+++ b/virtaal/modes/__init__.py
@@ -17,13 +17,13 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import
 
-from defaultmode      import DefaultMode
-from quicktransmode   import QuickTranslateMode
-from searchmode       import SearchMode
-from qualitycheckmode import QualityCheckMode
-from workflowmode     import WorkflowMode
-
+from .defaultmode import DefaultMode
+from .qualitycheckmode import QualityCheckMode
+from .quicktransmode import QuickTranslateMode
+from .searchmode import SearchMode
+from .workflowmode import WorkflowMode
 
 modeclasses = [DefaultMode, QuickTranslateMode, SearchMode, QualityCheckMode, WorkflowMode]
 

--- a/virtaal/modes/defaultmode.py
+++ b/virtaal/modes/defaultmode.py
@@ -17,8 +17,9 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import, print_function, unicode_literals
 
-from basemode import BaseMode
+from .basemode import BaseMode
 
 
 class DefaultMode(BaseMode):

--- a/virtaal/modes/qualitycheckmode.py
+++ b/virtaal/modes/qualitycheckmode.py
@@ -57,7 +57,7 @@ class QualityCheckMode(BaseMode):
         self.filter_checks = [check for check in self.filter_checks if check in self.stats]
         self.storecursor = self.store_controller.cursor
         self.checks_names = {}
-        for check, indices in self.stats.iteritems():
+        for check, indices in self.stats.items():
             if indices and check not in ('total', 'translated', 'untranslated', 'extended'):
                 self.checks_names[check] = self.main_controller.checks_controller.get_check_name(check)
 
@@ -111,7 +111,7 @@ class QualityCheckMode(BaseMode):
         return menu
 
     def _create_menu_entries(self, menu):
-        for mi, (name, signal_id) in self._menuitem_checks.iteritems():
+        for mi, (name, signal_id) in self._menuitem_checks.items():
             mi.disconnect(signal_id)
             menu.remove(mi)
         assert not menu.get_children()

--- a/virtaal/modes/qualitycheckmode.py
+++ b/virtaal/modes/qualitycheckmode.py
@@ -116,7 +116,7 @@ class QualityCheckMode(BaseMode):
             menu.remove(mi)
         assert not menu.get_children()
         self._menuitem_checks = {}
-        for check_name, display_name in sorted(self.checks_names.iteritems(), key=lambda x: x[1], cmp=locale.strcoll):
+        for check_name, display_name in sorted(self.checks_names.items(), key=lambda x: locale.strxfrm(x[1])):
             #l10n: %s is the name of the check and must be first. %d is the number of failures
             menuitem = Gtk.CheckMenuItem(label="%s (%d)" % (display_name, len(self.stats[check_name])))
             menuitem.set_active(check_name in self.filter_checks)

--- a/virtaal/modes/qualitycheckmode.py
+++ b/virtaal/modes/qualitycheckmode.py
@@ -17,13 +17,14 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import, print_function, unicode_literals
 
 import locale
 
 from gi.repository import Gtk
 
-from basemode import BaseMode
 from virtaal.views.widgets.popupmenubutton import PopupMenuButton, POS_NW_SW
+from .basemode import BaseMode
 
 
 class QualityCheckMode(BaseMode):

--- a/virtaal/modes/qualitycheckmode.py
+++ b/virtaal/modes/qualitycheckmode.py
@@ -19,11 +19,11 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 import locale
-import gtk
 
-from virtaal.views.widgets.popupmenubutton import PopupMenuButton, POS_NW_SW
+from gi.repository import Gtk
 
 from basemode import BaseMode
+from virtaal.views.widgets.popupmenubutton import PopupMenuButton, POS_NW_SW
 
 
 class QualityCheckMode(BaseMode):
@@ -94,18 +94,18 @@ class QualityCheckMode(BaseMode):
     def _add_widgets(self):
         table = self.controller.view.mode_box
         self.btn_popup = PopupMenuButton(menu_pos=POS_NW_SW)
-        self.btn_popup.set_relief(gtk.RELIEF_NORMAL)
+        self.btn_popup.set_relief(Gtk.ReliefStyle.NORMAL)
         self.btn_popup.set_menu(self._create_checks_menu())
 
         self.widgets = [self.btn_popup]
 
-        xoptions = gtk.FILL
+        xoptions = Gtk.AttachOptions.FILL
         table.attach(self.btn_popup, 2, 3, 0, 1, xoptions=xoptions)
 
         table.show_all()
 
     def _create_checks_menu(self):
-        menu = gtk.Menu()
+        menu = Gtk.Menu()
         self._create_menu_entries(menu)
         return menu
 
@@ -117,14 +117,14 @@ class QualityCheckMode(BaseMode):
         self._menuitem_checks = {}
         for check_name, display_name in sorted(self.checks_names.iteritems(), key=lambda x: x[1], cmp=locale.strcoll):
             #l10n: %s is the name of the check and must be first. %d is the number of failures
-            menuitem = gtk.CheckMenuItem(label="%s (%d)" % (display_name, len(self.stats[check_name])))
+            menuitem = Gtk.CheckMenuItem(label="%s (%d)" % (display_name, len(self.stats[check_name])))
             menuitem.set_active(check_name in self.filter_checks)
             menuitem.show()
             self._menuitem_checks[menuitem] = (check_name, menuitem.connect('toggled', self._on_check_menuitem_toggled))
             menu.append(menuitem)
 
     def _update_button_label(self):
-        check_labels = [mi.child.get_label() for mi in self.btn_popup.menu if mi.get_active()]
+        check_labels = [mi.get_child().get_label() for mi in self.btn_popup.menu if mi.get_active()]
         btn_label = u''
         if not check_labels:
             #l10n: This is the button where the user can select units by failing quality checks
@@ -149,7 +149,7 @@ class QualityCheckMode(BaseMode):
     def _on_check_menuitem_toggled(self, checkmenuitem):
         self.filter_checks = []
         for menuitem in self.btn_popup.menu:
-            if not isinstance(menuitem, gtk.CheckMenuItem) or not menuitem.get_active():
+            if not isinstance(menuitem, Gtk.CheckMenuItem) or not menuitem.get_active():
                 continue
             if menuitem in self._menuitem_checks:
                 self.filter_checks.append(self._menuitem_checks[menuitem][0])

--- a/virtaal/modes/qualitycheckmode.py
+++ b/virtaal/modes/qualitycheckmode.py
@@ -85,10 +85,10 @@ class QualityCheckMode(BaseMode):
         indices = []
         for check in self.filter_checks:
             indices.extend(self.stats[check])
+            indices.sort()
 
         if not indices:
-            indices = range(len(self.storecursor.model))
-        indices.sort()
+            indices = list(range(len(self.storecursor.model)))
 
         self.storecursor.indices = indices
 

--- a/virtaal/modes/quicktransmode.py
+++ b/virtaal/modes/quicktransmode.py
@@ -17,11 +17,11 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import, print_function, unicode_literals
 
 from virtaal.support.set_enumerator import UnionSetEnumerator
 from virtaal.support.sorted_set import SortedSet
-
-from basemode import BaseMode
+from .basemode import BaseMode
 
 
 class QuickTranslateMode(BaseMode):

--- a/virtaal/modes/searchmode.py
+++ b/virtaal/modes/searchmode.py
@@ -474,7 +474,7 @@ class SearchMode(BaseMode):
 
     def _on_textbox_refreshed(self, textbox, elem):
         """Redoes highlighting after a C{StringElem} render destoyed it."""
-        if not textbox.props.visible or not unicode(elem):
+        if not textbox.props.visible or not bool(elem):
             return
 
         self._highlight_textbox_matches(textbox, select_match=False)

--- a/virtaal/modes/searchmode.py
+++ b/virtaal/modes/searchmode.py
@@ -211,8 +211,7 @@ class SearchMode(BaseMode):
         logging.debug('Search text: %s (%d matches)' % (self.ent_search.get_text(), len(indexes)))
 
         if indexes:
-            self.ent_search.modify_base(Gtk.StateType.NORMAL, self.default_base)
-            self.ent_search.modify_text(Gtk.StateType.NORMAL, self.default_text)
+            self.ent_search.override_background_color(Gtk.StateType.NORMAL, self.default_base)
 
             self.storecursor.indices = indexes
             # Select initial match for in the current unit.
@@ -225,11 +224,11 @@ class SearchMode(BaseMode):
             self.matchcursor.index = match_index
         else:
             if self.ent_search.get_text():
-                self.ent_search.modify_base(Gtk.StateType.NORMAL, Gdk.color_parse(current_theme['warning_bg']))
-                self.ent_search.modify_text(Gtk.StateType.NORMAL, Gdk.color_parse('#fff'))
+                rgba = Gdk.RGBA()
+                rgba.parse(current_theme['warning_bg'])
+                self.ent_search.override_background_color(Gtk.StateType.NORMAL, rgba)
             else:
-                self.ent_search.modify_base(Gtk.StateType.NORMAL, self.default_base)
-                self.ent_search.modify_text(Gtk.StateType.NORMAL, self.default_text)
+                self.ent_search.override_background_color(Gtk.StateType.NORMAL, self.default_base)
 
             self.filter.re_search = None
             # Act like the "Default" mode...
@@ -469,9 +468,7 @@ class SearchMode(BaseMode):
 
     def _on_style_set(self, widget, prev_style=None):
         self.default_base = widget.get_style_context().get_background_color(Gtk.StateType.NORMAL)
-        self.default_text = widget.get_style_context().get_color(Gtk.StateType.NORMAL)
         self.ent_search.override_background_color(Gtk.StateType.NORMAL, self.default_base)
-        self.ent_search.override_color(Gtk.StateType.NORMAL, self.default_text)
 
     def _on_textbox_refreshed(self, textbox, elem):
         """Redoes highlighting after a C{StringElem} render destoyed it."""

--- a/virtaal/modes/searchmode.py
+++ b/virtaal/modes/searchmode.py
@@ -24,6 +24,7 @@ import logging
 
 from gi.repository import GObject, Gtk, Gdk
 
+from virtaal.common.utils import get_unicode
 from virtaal.controllers.cursor import Cursor
 from virtaal.views.theme import current_theme
 from .basemode import BaseMode
@@ -196,7 +197,7 @@ class SearchMode(BaseMode):
         self._search_timeout = 0
         from translate.tools.pogrep import GrepFilter
         self.filter = GrepFilter(
-            searchstring=unicode(self.ent_search.get_text()),
+            searchstring=get_unicode(self.ent_search.get_text(), 'utf-8'),
             searchparts=('source', 'target'),
             ignorecase=not self.chk_casesensitive.get_active(),
             useregexp=self.chk_regex.get_active(),

--- a/virtaal/modes/searchmode.py
+++ b/virtaal/modes/searchmode.py
@@ -53,6 +53,7 @@ class SearchMode(BaseMode):
         # We alter the colours of ent_search, so let's listen for changes on
         # ent_replace to ensure we are always compliant to the style.
         self.ent_replace.connect('style-set', self._on_style_set)
+        self.ent_replace.connect('style-updated', self._on_style_set)
 
         self.filter = None
         self.matches = []
@@ -466,7 +467,7 @@ class SearchMode(BaseMode):
             return
         self.controller.select_mode(self)
 
-    def _on_style_set(self, widget, prev_style):
+    def _on_style_set(self, widget, prev_style=None):
         self.default_base = widget.get_style_context().get_background_color(Gtk.StateType.NORMAL)
         self.default_text = widget.get_style_context().get_color(Gtk.StateType.NORMAL)
         self.ent_search.override_background_color(Gtk.StateType.NORMAL, self.default_base)

--- a/virtaal/modes/searchmode.py
+++ b/virtaal/modes/searchmode.py
@@ -465,10 +465,10 @@ class SearchMode(BaseMode):
         self.controller.select_mode(self)
 
     def _on_style_set(self, widget, prev_style):
-        self.default_base = widget.style.base[Gtk.StateType.NORMAL]
-        self.default_text = widget.style.text[Gtk.StateType.NORMAL]
-        self.ent_search.modify_base(Gtk.StateType.NORMAL, self.default_base)
-        self.ent_search.modify_text(Gtk.StateType.NORMAL, self.default_text)
+        self.default_base = widget.get_style_context().get_background_color(Gtk.StateType.NORMAL)
+        self.default_text = widget.get_style_context().get_color(Gtk.StateType.NORMAL)
+        self.ent_search.override_background_color(Gtk.StateType.NORMAL, self.default_base)
+        self.ent_search.override_color(Gtk.StateType.NORMAL, self.default_text)
 
     def _on_textbox_refreshed(self, textbox, elem):
         """Redoes highlighting after a C{StringElem} render destoyed it."""

--- a/virtaal/modes/searchmode.py
+++ b/virtaal/modes/searchmode.py
@@ -18,14 +18,15 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import, print_function, unicode_literals
 
 import logging
 
 from gi.repository import GObject, Gtk, Gdk
 
-from basemode import BaseMode
 from virtaal.controllers.cursor import Cursor
 from virtaal.views.theme import current_theme
+from .basemode import BaseMode
 
 
 class SearchMode(BaseMode):
@@ -330,7 +331,7 @@ class SearchMode(BaseMode):
             if tag:
                 tagtable.remove(tag)
             tagtable.add(self._make_highlight_tag())
-        except ValueError, ve:
+        except ValueError as ve:
             logging.exception("(Re-)adding search highlighting tag exception:")
 
         select_iters = []

--- a/virtaal/modes/searchmode.py
+++ b/virtaal/modes/searchmode.py
@@ -19,14 +19,14 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-import gobject
-import gtk
-import gtk.gdk
 import logging
 
-from virtaal.controllers.cursor import Cursor
+import Gtk.gdk
+from gi.repository import GObject
+from gi.repository import Gtk
 
 from basemode import BaseMode
+from virtaal.controllers.cursor import Cursor
 from virtaal.views.theme import current_theme
 
 
@@ -62,16 +62,16 @@ class SearchMode(BaseMode):
 
     def _create_widgets(self):
         # Widgets for search functionality (in first row)
-        self.ent_search = gtk.Entry()
+        self.ent_search = Gtk.Entry()
         self.ent_search.connect('changed', self._on_search_text_changed)
         self.ent_search.connect('activate', self._on_entry_activate)
-        self.btn_search = gtk.Button(_('Search'))
+        self.btn_search = Gtk.Button(_('Search'))
         self.btn_search.connect('clicked', self._on_search_clicked)
-        self.chk_casesensitive = gtk.CheckButton(_('_Case sensitive'))
+        self.chk_casesensitive = Gtk.CheckButton(_('_Case sensitive'))
         self.chk_casesensitive.connect('toggled', self._refresh_proxy)
         # l10n: To read about what regular expressions are, see
         # http://en.wikipedia.org/wiki/Regular_expression
-        self.chk_regex = gtk.CheckButton(_("_Regular expression"))
+        self.chk_regex = Gtk.CheckButton(_("_Regular expression"))
         self.chk_regex.connect('toggled', self._refresh_proxy)
 
         # Widgets for replace (second row)
@@ -79,13 +79,13 @@ class SearchMode(BaseMode):
         # text is typed. Keep in mind that the text box will appear after this text.
         # If this sentence construction is hard to use, consdider translating this as
         # "Replacement"
-        self.lbl_replace = gtk.Label(_('Replace with'))
-        self.ent_replace = gtk.Entry()
+        self.lbl_replace = Gtk.Label(label=_('Replace with'))
+        self.ent_replace = Gtk.Entry()
         # l10n: Button text
-        self.btn_replace = gtk.Button(_('Replace'))
+        self.btn_replace = Gtk.Button(_('Replace'))
         self.btn_replace.connect('clicked', self._on_replace_clicked)
         # l10n: Check box
-        self.chk_replace_all = gtk.CheckButton(_('Replace _All'))
+        self.chk_replace_all = Gtk.CheckButton(_('Replace _All'))
 
         self.widgets = [
             self.ent_search, self.btn_search, self.chk_casesensitive, self.chk_regex,
@@ -93,12 +93,13 @@ class SearchMode(BaseMode):
         ]
 
     def _setup_key_bindings(self):
-        gtk.accel_map_add_entry("<Virtaal>/Edit/Search", gtk.keysyms.F3, 0)
-        gtk.accel_map_add_entry("<Virtaal>/Edit/Search Ctrl+F", gtk.keysyms.F, gtk.gdk.CONTROL_MASK)
-        gtk.accel_map_add_entry("<Virtaal>/Edit/Search: Next", gtk.keysyms.G, gtk.gdk.CONTROL_MASK)
-        gtk.accel_map_add_entry("<Virtaal>/Edit/Search: Previous", gtk.keysyms.G, gtk.gdk.CONTROL_MASK | gtk.gdk.SHIFT_MASK)
+        Gtk.AccelMap.add_entry("<Virtaal>/Edit/Search", Gdk.KEY_F3, 0)
+        Gtk.AccelMap.add_entry("<Virtaal>/Edit/Search Ctrl+F", Gdk.KEY_F, Gdk.ModifierType.CONTROL_MASK)
+        Gtk.AccelMap.add_entry("<Virtaal>/Edit/Search: Next", Gdk.KEY_G, Gdk.ModifierType.CONTROL_MASK)
+        Gtk.AccelMap.add_entry("<Virtaal>/Edit/Search: Previous", Gdk.KEY_G,
+                               Gdk.ModifierType.CONTROL_MASK | Gdk.ModifierType.SHIFT_MASK)
 
-        self.accel_group = gtk.AccelGroup()
+        self.accel_group = Gtk.AccelGroup()
         self.accel_group.connect_by_path("<Virtaal>/Edit/Search", self._on_start_search)
         self.accel_group.connect_by_path("<Virtaal>/Edit/Search Ctrl+F", self._on_start_search)
         self.accel_group.connect_by_path("<Virtaal>/Edit/Search: Next", self._on_search_next)
@@ -135,7 +136,7 @@ class SearchMode(BaseMode):
             return False
 
         # FIXME: The following line is a VERY UGLY HACK, but at least it works.
-        gobject.timeout_add(100, grab_focus)
+        GObject.timeout_add(100, grab_focus)
 
     def select_match(self, match):
         """Select the specified match in the GUI."""
@@ -169,7 +170,7 @@ class SearchMode(BaseMode):
             return False
 
         # TODO: Implement for 'notes' and 'locations' parts
-        gobject.idle_add(select_match_text)
+        GObject.idle_add(select_match_text)
 
     def replace_match(self, match, replace_str):
         main_controller = self.controller.main_controller
@@ -209,8 +210,8 @@ class SearchMode(BaseMode):
         logging.debug('Search text: %s (%d matches)' % (self.ent_search.get_text(), len(indexes)))
 
         if indexes:
-            self.ent_search.modify_base(gtk.STATE_NORMAL, self.default_base)
-            self.ent_search.modify_text(gtk.STATE_NORMAL, self.default_text)
+            self.ent_search.modify_base(Gtk.StateType.NORMAL, self.default_base)
+            self.ent_search.modify_text(Gtk.StateType.NORMAL, self.default_text)
 
             self.storecursor.indices = indexes
             # Select initial match for in the current unit.
@@ -223,11 +224,11 @@ class SearchMode(BaseMode):
             self.matchcursor.index = match_index
         else:
             if self.ent_search.get_text():
-                self.ent_search.modify_base(gtk.STATE_NORMAL, gtk.gdk.color_parse(current_theme['warning_bg']))
-                self.ent_search.modify_text(gtk.STATE_NORMAL, gtk.gdk.color_parse('#fff'))
+                self.ent_search.modify_base(Gtk.StateType.NORMAL, Gdk.color_parse(current_theme['warning_bg']))
+                self.ent_search.modify_text(Gtk.StateType.NORMAL, Gdk.color_parse('#fff'))
             else:
-                self.ent_search.modify_base(gtk.STATE_NORMAL, self.default_base)
-                self.ent_search.modify_text(gtk.STATE_NORMAL, self.default_text)
+                self.ent_search.modify_base(Gtk.StateType.NORMAL, self.default_base)
+                self.ent_search.modify_text(Gtk.StateType.NORMAL, self.default_text)
 
             self.filter.re_search = None
             # Act like the "Default" mode...
@@ -240,7 +241,8 @@ class SearchMode(BaseMode):
             # that will select all text, so reset the cursor position
             self.ent_search.set_position(curpos)
             return False
-        gobject.idle_add(grabfocus)
+
+        GObject.idle_add(grabfocus)
 
     def unselected(self):
         # TODO: Unhightlight the previously selected unit
@@ -260,7 +262,7 @@ class SearchMode(BaseMode):
     def _add_widgets(self):
         table = self.controller.view.mode_box
 
-        xoptions = gtk.FILL
+        xoptions = Gtk.AttachOptions.FILL
         table.attach(self.ent_search, 2, 3, 0, 1, xoptions=xoptions)
         table.attach(self.btn_search, 3, 4, 0, 1, xoptions=xoptions)
         table.attach(self.chk_casesensitive, 4, 5, 0, 1, xoptions=xoptions)
@@ -361,7 +363,7 @@ class SearchMode(BaseMode):
             buff.select_range(select_iters[1], select_iters[0])
 
     def _make_highlight_tag(self):
-        tag = gtk.TextTag(name='search_highlight')
+        tag = Gtk.TextTag(name='search_highlight')
         tag.set_property('background', 'yellow')
         tag.set_property('foreground', 'black')
         return tag
@@ -453,9 +455,9 @@ class SearchMode(BaseMode):
 
     def _on_search_text_changed(self, entry):
         if self._search_timeout:
-            gobject.source_remove(self._search_timeout)
+            GObject.source_remove(self._search_timeout)
 
-        self._search_timeout = gobject.timeout_add(self.SEARCH_DELAY, self.update_search)
+        self._search_timeout = GObject.timeout_add(self.SEARCH_DELAY, self.update_search)
 
     def _on_start_search(self, _accel_group, _acceleratable, _keyval, _modifier):
         """This is called via the accelerator."""
@@ -465,10 +467,10 @@ class SearchMode(BaseMode):
         self.controller.select_mode(self)
 
     def _on_style_set(self, widget, prev_style):
-        self.default_base = widget.style.base[gtk.STATE_NORMAL]
-        self.default_text = widget.style.text[gtk.STATE_NORMAL]
-        self.ent_search.modify_base(gtk.STATE_NORMAL, self.default_base)
-        self.ent_search.modify_text(gtk.STATE_NORMAL, self.default_text)
+        self.default_base = widget.style.base[Gtk.StateType.NORMAL]
+        self.default_text = widget.style.text[Gtk.StateType.NORMAL]
+        self.ent_search.modify_base(Gtk.StateType.NORMAL, self.default_base)
+        self.ent_search.modify_text(Gtk.StateType.NORMAL, self.default_text)
 
     def _on_textbox_refreshed(self, textbox, elem):
         """Redoes highlighting after a C{StringElem} render destoyed it."""

--- a/virtaal/modes/searchmode.py
+++ b/virtaal/modes/searchmode.py
@@ -66,11 +66,11 @@ class SearchMode(BaseMode):
         self.ent_search.connect('activate', self._on_entry_activate)
         self.btn_search = Gtk.Button(_('Search'))
         self.btn_search.connect('clicked', self._on_search_clicked)
-        self.chk_casesensitive = Gtk.CheckButton(_('_Case sensitive'))
+        self.chk_casesensitive = Gtk.CheckButton.new_with_mnemonic(_('_Case sensitive'))
         self.chk_casesensitive.connect('toggled', self._refresh_proxy)
         # l10n: To read about what regular expressions are, see
         # http://en.wikipedia.org/wiki/Regular_expression
-        self.chk_regex = Gtk.CheckButton(_("_Regular expression"))
+        self.chk_regex = Gtk.CheckButton.new_with_mnemonic(_("_Regular expression"))
         self.chk_regex.connect('toggled', self._refresh_proxy)
 
         # Widgets for replace (second row)
@@ -84,7 +84,7 @@ class SearchMode(BaseMode):
         self.btn_replace = Gtk.Button(_('Replace'))
         self.btn_replace.connect('clicked', self._on_replace_clicked)
         # l10n: Check box
-        self.chk_replace_all = Gtk.CheckButton(_('Replace _All'))
+        self.chk_replace_all = Gtk.CheckButton.new_with_mnemonic(_('Replace _All'))
 
         self.widgets = [
             self.ent_search, self.btn_search, self.chk_casesensitive, self.chk_regex,

--- a/virtaal/modes/searchmode.py
+++ b/virtaal/modes/searchmode.py
@@ -21,9 +21,7 @@
 
 import logging
 
-import Gtk.gdk
-from gi.repository import GObject
-from gi.repository import Gtk
+from gi.repository import GObject, Gtk, Gdk
 
 from basemode import BaseMode
 from virtaal.controllers.cursor import Cursor

--- a/virtaal/modes/workflowmode.py
+++ b/virtaal/modes/workflowmode.py
@@ -18,12 +18,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-import logging
-import gtk
-
-from virtaal.views.widgets.popupmenubutton import PopupMenuButton, POS_NW_SW
+from gi.repository import Gtk
 
 from basemode import BaseMode
+from virtaal.views.widgets.popupmenubutton import PopupMenuButton, POS_NW_SW
 
 
 class WorkflowMode(BaseMode):
@@ -83,21 +81,21 @@ class WorkflowMode(BaseMode):
     def _add_widgets(self):
         table = self.controller.view.mode_box
         self.btn_popup = PopupMenuButton(menu_pos=POS_NW_SW)
-        self.btn_popup.set_relief(gtk.RELIEF_NORMAL)
+        self.btn_popup.set_relief(Gtk.ReliefStyle.NORMAL)
         self.btn_popup.set_menu(self._create_state_menu())
 
         self.widgets = [self.btn_popup]
 
-        xoptions = gtk.FILL
+        xoptions = Gtk.AttachOptions.FILL
         table.attach(self.btn_popup, 2, 3, 0, 1, xoptions=xoptions)
 
         table.show_all()
 
     def _create_state_menu(self):
-        menu = gtk.Menu()
+        menu = Gtk.Menu()
 
         for iid, name in self.state_names:
-            menuitem = gtk.CheckMenuItem(label=name)
+            menuitem = Gtk.CheckMenuItem(label=name)
             menuitem.show()
             self._menuitem_states[menuitem] = iid
             menuitem.connect('toggled', self._on_state_menuitem_toggled)
@@ -105,7 +103,7 @@ class WorkflowMode(BaseMode):
         return menu
 
     def _update_button_label(self):
-        state_labels = [mi.child.get_label() for mi in self.btn_popup.menu if mi.get_active()]
+        state_labels = [mi.get_child().get_label() for mi in self.btn_popup.menu if mi.get_active()]
         btn_label = u''
         if not state_labels:
             #l10n: This is the button where the user can select units by workflow state
@@ -127,7 +125,7 @@ class WorkflowMode(BaseMode):
     def _on_state_menuitem_toggled(self, checkmenuitem):
         self.filter_states = []
         for menuitem in self.btn_popup.menu:
-            if not isinstance(menuitem, gtk.CheckMenuItem) or not menuitem.get_active():
+            if not isinstance(menuitem, Gtk.CheckMenuItem) or not menuitem.get_active():
                 continue
             if menuitem in self._menuitem_states:
                 self.filter_states.append(self._menuitem_states[menuitem])

--- a/virtaal/modes/workflowmode.py
+++ b/virtaal/modes/workflowmode.py
@@ -17,11 +17,12 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import, print_function, unicode_literals
 
 from gi.repository import Gtk
 
-from basemode import BaseMode
 from virtaal.views.widgets.popupmenubutton import PopupMenuButton, POS_NW_SW
+from .basemode import BaseMode
 
 
 class WorkflowMode(BaseMode):

--- a/virtaal/plugins/_ipython_console/__init__.py
+++ b/virtaal/plugins/_ipython_console/__init__.py
@@ -1,15 +1,14 @@
 #!/usr/bin/env python
 
-import gtk
-import pango
-from gtk import gdk
-
-from virtaal.controllers.baseplugin import BasePlugin
+from gi.repository import Gdk
+from gi.repository import Gtk
+from gi.repository import Pango
 
 from ipython_view import *
+from virtaal.controllers.baseplugin import BasePlugin
 
 
-class IPythonWindow(gtk.Window):
+class IPythonWindow(Gtk.Window):
     """The window that will contain the console widget."""
 
     FONT = "Luxi Mono 10"
@@ -21,11 +20,11 @@ class IPythonWindow(gtk.Window):
         self.console.updateNamespace(namespace)
 
     def _setup_console(self):
-        self.scrolled_win = gtk.ScrolledWindow()
-        self.scrolled_win.set_policy(gtk.POLICY_AUTOMATIC,gtk.POLICY_AUTOMATIC)
+        self.scrolled_win = Gtk.ScrolledWindow()
+        self.scrolled_win.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
         self.console = IPythonView()
-        self.console.modify_font(pango.FontDescription(self.FONT))
-        self.console.set_wrap_mode(gtk.WRAP_CHAR)
+        self.console.modify_font(Pango.FontDescription(self.FONT))
+        self.console.set_wrap_mode(Gtk.WrapMode.CHAR)
 
         self.scrolled_win.add(self.console)
         self.add(self.scrolled_win)
@@ -52,16 +51,16 @@ class Plugin(BasePlugin):
     def _setup_key_bindings(self):
         """Setup Gtk+ key bindings (accelerators)."""
 
-        gtk.accel_map_add_entry("<Virtaal>/View/IPython Console", gtk.keysyms.y, gdk.CONTROL_MASK)
+        Gtk.AccelMap.add_entry("<Virtaal>/View/IPython Console", Gdk.KEY_y, Gdk.ModifierType.CONTROL_MASK)
 
-        self.accel_group = gtk.AccelGroup()
+        self.accel_group = Gtk.AccelGroup()
         self.accel_group.connect_by_path("<Virtaal>/View/IPython Console", self._on_menuitem_activated)
 
         self.main_controller.view.add_accel_group(self.accel_group)
 
     def _setup_menu_item(self):
         self.menu = self.main_controller.view.gui.get_object('menu_view')
-        self.menuitem = gtk.MenuItem(label=_('_IPython Console'))
+        self.menuitem = Gtk.MenuItem(label=_('_IPython Console'))
         self.menuitem.show()
         self.menu.append(self.menuitem)
 
@@ -93,7 +92,7 @@ class Plugin(BasePlugin):
             self.window = IPythonWindow(namespace=ns, destroy_cb=self._on_console_destroyed)
             self.window.set_size_request(600, 400)
             self.window.set_title('Virtaal IPython Console')
-            self.window.set_transient_for(self.main_controller.view.main_window)
+            self.set_transient_for(self.main_controller.view.main_window)
             self.window.connect('destroy', self._on_console_destroyed)
         self.window.show_all()
         self.window.grab_focus()

--- a/virtaal/plugins/_ipython_console/__init__.py
+++ b/virtaal/plugins/_ipython_console/__init__.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python
+from __future__ import absolute_import, unicode_literals, print_function
 
 from gi.repository import Gdk
 from gi.repository import Gtk
 from gi.repository import Pango
 
-from ipython_view import *
 from virtaal.controllers.baseplugin import BasePlugin
+from .ipython_view import *
 
 
 class IPythonWindow(Gtk.Window):

--- a/virtaal/plugins/_ipython_console/ipython_view.py
+++ b/virtaal/plugins/_ipython_console/ipython_view.py
@@ -15,10 +15,10 @@ is available at U{http://www.opensource.org/licenses/bsd-license.php}
 import os
 import re
 import sys
-from StringIO import StringIO
 
 import IPython
-from gi.repository import Pango
+from gi.repository import Pango, Gtk
+from six.moves import cStringIO as StringIO
 
 
 class IterableIPShell:
@@ -216,11 +216,11 @@ class IterableIPShell:
     @type header: string
     '''
     stat = 0
-    if verbose or debug: print header+cmd
+    if verbose or debug: print(header + cmd)
     # flush stdout so we don't mangle python's buffering
     if not debug:
       input, output = os.popen4(cmd)
-      print output.read()
+      print(output.read())
       output.close()
       input.close()
 
@@ -392,13 +392,13 @@ class ConsoleView(Gtk.TextView):
     start_iter = self.text_buffer.get_iter_at_mark(self.line_start)
     if event.keyval == Gdk.KEY_Home:
         if event.get_state() & Gdk.ModifierType.CONTROL_MASK or event.get_state() & Gdk.ModifierType.MOD1_MASK:
-        pass
+            pass
         elif event.get_state() & Gdk.ModifierType.SHIFT_MASK:
-        self.text_buffer.move_mark(insert_mark, start_iter)
-        return True
-      else:
-        self.text_buffer.place_cursor(start_iter)
-        return True
+            self.text_buffer.move_mark(insert_mark, start_iter)
+            return True
+        else:
+            self.text_buffer.place_cursor(start_iter)
+            return True
     elif event.keyval == Gdk.KEY_Left:
       insert_iter.backward_cursor_position()
       if not insert_iter.editable(True):

--- a/virtaal/plugins/_ipython_console/ipython_view.py
+++ b/virtaal/plugins/_ipython_console/ipython_view.py
@@ -12,13 +12,14 @@ available under the terms of the BSD which accompanies this distribution, and
 is available at U{http://www.opensource.org/licenses/bsd-license.php}
 '''
 
+import os
 import re
 import sys
-import os
-from gi.repository import Pango
 from StringIO import StringIO
 
 import IPython
+from gi.repository import Pango
+
 
 class IterableIPShell:
   '''
@@ -253,7 +254,7 @@ class ConsoleView(Gtk.TextView):
     '''
     Initialize console view.
     '''
-    GObject.GObject.__init__(self)
+    super(ConsoleView, self).__init__()
     self.modify_font(Pango.FontDescription('Mono'))
     self.set_cursor_visible(True)
     self.text_buffer = self.get_buffer()

--- a/virtaal/plugins/_ipython_console/ipython_view.py
+++ b/virtaal/plugins/_ipython_console/ipython_view.py
@@ -12,11 +12,10 @@ available under the terms of the BSD which accompanies this distribution, and
 is available at U{http://www.opensource.org/licenses/bsd-license.php}
 '''
 
-import gtk, gobject
 import re
 import sys
 import os
-import pango
+from gi.repository import Pango
 from StringIO import StringIO
 
 import IPython
@@ -224,7 +223,8 @@ class IterableIPShell:
       output.close()
       input.close()
 
-class ConsoleView(gtk.TextView):
+
+class ConsoleView(Gtk.TextView):
   '''
   Specialized text view for console-like workflow.
 
@@ -232,13 +232,13 @@ class ConsoleView(gtk.TextView):
   @type ANSI_COLORS: dictionary
 
   @ivar text_buffer: Widget's text buffer.
-  @type text_buffer: gtk.TextBuffer
+  @type text_buffer: Gtk.TextBuffer
   @ivar color_pat: Regex of terminal color pattern
   @type color_pat: _sre.SRE_Pattern
   @ivar mark: Scroll mark for automatic scrolling on input.
-  @type mark: gtk.TextMark
+  @type mark: Gtk.TextMark
   @ivar line_start: Start of command line mark.
-  @type line_start: gtk.TextMark
+  @type line_start: Gtk.TextMark
   '''
   ANSI_COLORS =  {'0;30': 'Black',     '0;31': 'Red',
                   '0;32': 'Green',     '0;33': 'Brown',
@@ -253,8 +253,8 @@ class ConsoleView(gtk.TextView):
     '''
     Initialize console view.
     '''
-    gtk.TextView.__init__(self)
-    self.modify_font(pango.FontDescription('Mono'))
+    GObject.GObject.__init__(self)
+    self.modify_font(Pango.FontDescription('Mono'))
     self.set_cursor_visible(True)
     self.text_buffer = self.get_buffer()
     self.mark = self.text_buffer.create_mark('scroll_mark', 
@@ -273,7 +273,7 @@ class ConsoleView(gtk.TextView):
     self.connect('key-press-event', self.onKeyPress)
     
   def write(self, text, editable=False):
-    gobject.idle_add(self._write, text, editable)
+      GObject.idle_add(self._write, text, editable)
 
   def _write(self, text, editable=False):
     '''
@@ -307,7 +307,7 @@ class ConsoleView(gtk.TextView):
 
 
   def showPrompt(self, prompt):
-    gobject.idle_add(self._showPrompt, prompt)
+      GObject.idle_add(self._showPrompt, prompt)
 
   def _showPrompt(self, prompt):
     '''
@@ -321,7 +321,7 @@ class ConsoleView(gtk.TextView):
                                self.text_buffer.get_end_iter())
 
   def changeLine(self, text):
-    gobject.idle_add(self._changeLine, text)
+      GObject.idle_add(self._changeLine, text)
 
   def _changeLine(self, text):
     '''
@@ -348,7 +348,7 @@ class ConsoleView(gtk.TextView):
     return rv
 
   def showReturned(self, text):
-    gobject.idle_add(self._showReturned, text)
+      GObject.idle_add(self._showReturned, text)
 
   def _showReturned(self, text):
     '''
@@ -377,9 +377,9 @@ class ConsoleView(gtk.TextView):
     line.
     
     @param widget: Widget that key press accored in.
-    @type widget: gtk.Widget
+    @type widget: Gtk.Widget
     @param event: Event object
-    @type event: gtk.gdk.Event
+    @type event: Gdk.Event
     
     @return: Return True if event should not trickle.
     @rtype: boolean
@@ -389,16 +389,16 @@ class ConsoleView(gtk.TextView):
     selection_mark = self.text_buffer.get_selection_bound()
     selection_iter = self.text_buffer.get_iter_at_mark(selection_mark)
     start_iter = self.text_buffer.get_iter_at_mark(self.line_start)
-    if event.keyval == gtk.keysyms.Home:
-      if event.state & gtk.gdk.CONTROL_MASK or event.state & gtk.gdk.MOD1_MASK:
+    if event.keyval == Gdk.KEY_Home:
+        if event.get_state() & Gdk.ModifierType.CONTROL_MASK or event.get_state() & Gdk.ModifierType.MOD1_MASK:
         pass
-      elif event.state & gtk.gdk.SHIFT_MASK:
+        elif event.get_state() & Gdk.ModifierType.SHIFT_MASK:
         self.text_buffer.move_mark(insert_mark, start_iter)
         return True
       else:
         self.text_buffer.place_cursor(start_iter)
         return True
-    elif event.keyval == gtk.keysyms.Left:
+    elif event.keyval == Gdk.KEY_Left:
       insert_iter.backward_cursor_position()
       if not insert_iter.editable(True):
         return True
@@ -463,27 +463,27 @@ class IPythonView(ConsoleView, IterableIPShell):
     autocompletions, etc.
     
     @param widget: Widget that key press occured in.
-    @type widget: gtk.Widget
+    @type widget: Gtk.Widget
     @param event: Event object.
-    @type event: gtk.gdk.Event
+    @type event: Gdk.Event
     
     @return: True if event should not trickle.
     @rtype: boolean
     '''
-    if event.state & gtk.gdk.CONTROL_MASK and event.keyval == 99:
+    if event.get_state() & Gdk.ModifierType.CONTROL_MASK and event.keyval == 99:
       self.interrupt = True
       self._processLine()
       return True
-    elif event.keyval == gtk.keysyms.Return:
+    elif event.keyval == Gdk.KEY_Return:
       self._processLine()
       return True
-    elif event.keyval == gtk.keysyms.Up:
+    elif event.keyval == Gdk.KEY_Up:
       self.changeLine(self.historyBack())
       return True
-    elif event.keyval == gtk.keysyms.Down:
+    elif event.keyval == Gdk.KEY_Down:
       self.changeLine(self.historyForward())
       return True
-    elif event.keyval == gtk.keysyms.Tab:
+    elif event.keyval == Gdk.KEY_Tab:
       if not self.getCurrentLine().strip():
         return False
       completed, possibilities = self.complete(self.getCurrentLine())

--- a/virtaal/plugins/_python_console.py
+++ b/virtaal/plugins/_python_console.py
@@ -288,9 +288,7 @@ class gtkoutfile:
     def readlines(self):     return []
     def write(self, s):      self.console.write(s, self.tag)
     def writelines(self, l): self.console.write(l, self.tag)
-
     def seek(self, a):       raise IOError(29, 'Illegal seek')
-
     def tell(self):          raise IOError(29, 'Illegal seek')
     truncate = tell
 
@@ -357,7 +355,7 @@ class Plugin(BasePlugin):
 
             self.window = Gtk.Window()
             self.window.set_title('Virtaal Python Console')
-            self.set_transient_for(self.main_controller.view.main_window)
+            self.window.set_transient_for(self.main_controller.view.main_window)
             self.window.add(console)
             self.window.connect('destroy', self._on_console_destroyed)
         self.window.show_all()

--- a/virtaal/plugins/_python_console.py
+++ b/virtaal/plugins/_python_console.py
@@ -255,7 +255,7 @@ class PythonConsole(Gtk.ScrolledWindow):
             try:
                 r = eval(command, self.namespace, self.namespace)
                 if r is not None:
-                    print(r)
+                    print(repr(r))
             except SyntaxError:
                 exec_(command, globals=self.namespace)
         except:

--- a/virtaal/plugins/_python_console.py
+++ b/virtaal/plugins/_python_console.py
@@ -8,6 +8,7 @@ from gi.repository import GObject
 from gi.repository import Gdk
 from gi.repository import Gtk
 from gi.repository import Pango
+from six import exec_
 
 from virtaal.controllers.baseplugin import BasePlugin
 
@@ -254,9 +255,9 @@ class PythonConsole(Gtk.ScrolledWindow):
             try:
                 r = eval(command, self.namespace, self.namespace)
                 if r is not None:
-                    print `r`
+                    print(r)
             except SyntaxError:
-                exec command in self.namespace
+                exec_(command, globals=self.namespace)
         except:
             if hasattr(sys, 'last_type') and sys.last_type == SystemExit:
                 self.destroy()
@@ -287,8 +288,10 @@ class gtkoutfile:
     def readlines(self):     return []
     def write(self, s):      self.console.write(s, self.tag)
     def writelines(self, l): self.console.write(l, self.tag)
-    def seek(self, a):       raise IOError, (29, 'Illegal seek')
-    def tell(self):          raise IOError, (29, 'Illegal seek')
+
+    def seek(self, a):       raise IOError(29, 'Illegal seek')
+
+    def tell(self):          raise IOError(29, 'Illegal seek')
     truncate = tell
 
 

--- a/virtaal/plugins/_python_console.py
+++ b/virtaal/plugins/_python_console.py
@@ -14,7 +14,7 @@ from virtaal.controllers.baseplugin import BasePlugin
 
 class PythonConsole(Gtk.ScrolledWindow):
     def __init__(self, namespace = {}, destroy_cb = None):
-        GObject.GObject.__init__(self)
+        super(PythonConsole, self).__init__()
 
         self.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC);
         self.set_shadow_type(Gtk.ShadowType.IN)

--- a/virtaal/plugins/_python_console.py
+++ b/virtaal/plugins/_python_console.py
@@ -1,26 +1,27 @@
 #!/usr/bin/env python
 
-import gobject
-import gtk
-import pango
 import re
 import sys
 import traceback
-from gtk import gdk
+
+from gi.repository import GObject
+from gi.repository import Gdk
+from gi.repository import Gtk
+from gi.repository import Pango
 
 from virtaal.controllers.baseplugin import BasePlugin
 
 
-class PythonConsole(gtk.ScrolledWindow):
+class PythonConsole(Gtk.ScrolledWindow):
     def __init__(self, namespace = {}, destroy_cb = None):
-        gtk.ScrolledWindow.__init__(self)
+        GObject.GObject.__init__(self)
 
-        self.set_policy(gtk.POLICY_NEVER, gtk.POLICY_AUTOMATIC);
-        self.set_shadow_type(gtk.SHADOW_IN)
-        self.view = gtk.TextView()
-        self.view.modify_font(pango.FontDescription('Monospace'))
+        self.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC);
+        self.set_shadow_type(Gtk.ShadowType.IN)
+        self.view = Gtk.TextView()
+        self.view.modify_font(Pango.FontDescription('Monospace'))
         self.view.set_editable(True)
-        self.view.set_wrap_mode(gtk.WRAP_WORD_CHAR)
+        self.view.set_wrap_mode(Gtk.WrapMode.WORD_CHAR)
         self.add(self.view)
         self.view.show()
 
@@ -59,12 +60,12 @@ class PythonConsole(gtk.ScrolledWindow):
 
 
     def __key_press_event_cb(self, view, event):
-        if event.keyval == gtk.keysyms.d and \
-           event.state == gtk.gdk.CONTROL_MASK:
+        if event.keyval == Gdk.KEY_d and \
+                event.get_state() == Gdk.ModifierType.CONTROL_MASK:
             self.destroy()
 
-        elif event.keyval == gtk.keysyms.Return and \
-             event.state == gtk.gdk.CONTROL_MASK:
+        elif event.keyval == Gdk.KEY_Return and \
+                event.get_state() == Gdk.ModifierType.CONTROL_MASK:
             # Get the command
             buffer = view.get_buffer()
             inp_mark = buffer.get_mark("input")
@@ -87,10 +88,10 @@ class PythonConsole(gtk.ScrolledWindow):
                 cur = buffer.get_end_iter()
 
             buffer.place_cursor(cur)
-            gobject.idle_add(self.scroll_to_end)
+            GObject.idle_add(self.scroll_to_end)
             return True
 
-        elif event.keyval == gtk.keysyms.Return:
+        elif event.keyval == Gdk.KEY_Return:
             # Get the marks
             buffer = view.get_buffer()
             lin_mark = buffer.get_mark("input-line")
@@ -131,39 +132,39 @@ class PythonConsole(gtk.ScrolledWindow):
             cur = buffer.get_end_iter()
             buffer.move_mark(inp_mark, cur)
             buffer.place_cursor(cur)
-            gobject.idle_add(self.scroll_to_end)
+            GObject.idle_add(self.scroll_to_end)
             return True
 
-        elif event.keyval == gtk.keysyms.KP_Down or \
-             event.keyval == gtk.keysyms.Down:
+        elif event.keyval == Gdk.KEY_KP_Down or \
+                event.keyval == Gdk.KEY_Down:
             # Next entry from history
             view.emit_stop_by_name("key_press_event")
             self.history_down()
-            gobject.idle_add(self.scroll_to_end)
+            GObject.idle_add(self.scroll_to_end)
             return True
 
-        elif event.keyval == gtk.keysyms.KP_Up or \
-             event.keyval == gtk.keysyms.Up:
+        elif event.keyval == Gdk.KEY_KP_Up or \
+                event.keyval == Gdk.KEY_Up:
             # Previous entry from history
             view.emit_stop_by_name("key_press_event")
             self.history_up()
-            gobject.idle_add(self.scroll_to_end)
+            GObject.idle_add(self.scroll_to_end)
             return True
 
-        elif event.keyval == gtk.keysyms.KP_Left or \
-             event.keyval == gtk.keysyms.Left or \
-             event.keyval == gtk.keysyms.BackSpace:
+        elif event.keyval == Gdk.KEY_KP_Left or \
+                event.keyval == Gdk.KEY_Left or \
+                event.keyval == Gdk.KEY_BackSpace:
             buffer = view.get_buffer()
             inp = buffer.get_iter_at_mark(buffer.get_mark("input"))
             cur = buffer.get_iter_at_mark(buffer.get_insert())
             return inp.compare(cur) == 0
 
-        elif event.keyval == gtk.keysyms.Home:
+        elif event.keyval == Gdk.KEY_Home:
             # Go to the begin of the command instead of the begin of
             # the line
             buffer = view.get_buffer()
             inp = buffer.get_iter_at_mark(buffer.get_mark("input"))
-            if event.state == gtk.gdk.SHIFT_MASK:
+            if event.get_state() == Gdk.ModifierType.SHIFT_MASK:
                 buffer.move_mark_by_name("insert", inp)
             else:
                 buffer.place_cursor(inp)
@@ -220,7 +221,7 @@ class PythonConsole(gtk.ScrolledWindow):
             buffer.insert(buffer.get_end_iter(), text)
         else:
             buffer.insert_with_tags(buffer.get_end_iter(), text, tag)
-        gobject.idle_add(self.scroll_to_end)
+        GObject.idle_add(self.scroll_to_end)
 
     def eval(self, command, display_command = False):
         buffer = self.view.get_buffer()
@@ -312,20 +313,20 @@ class Plugin(BasePlugin):
     def _setup_key_bindings(self):
         """Setup Gtk+ key bindings (accelerators)."""
 
-        gtk.accel_map_add_entry("<Virtaal>/View/Python Console", gtk.keysyms.y, gdk.CONTROL_MASK)
+        Gtk.AccelMap.add_entry("<Virtaal>/View/Python Console", Gdk.KEY_y, Gdk.ModifierType.CONTROL_MASK)
 
-        self.accel_group = gtk.AccelGroup()
+        self.accel_group = Gtk.AccelGroup()
         self.accel_group.connect_by_path("<Virtaal>/View/Python Console", self._on_menuitem_activated)
 
         self.main_controller.view.add_accel_group(self.accel_group)
 
     def _setup_menu_item(self):
         self.menu = self.main_controller.view.gui.get_object('menu_view')
-        self.menuitem = gtk.MenuItem(label=_('P_ython Console'))
+        self.menuitem = Gtk.MenuItem(label=_('P_ython Console'))
         self.menuitem.show()
         self.menu.append(self.menuitem)
 
-        gtk.accel_map_add_entry("<Virtaal>/View/Python Console", gtk.keysyms.F9, 0)
+        Gtk.AccelMap.add_entry("<Virtaal>/View/Python Console", Gdk.KEY_F9, 0)
         accel_group = self.menu.get_accel_group()
         if accel_group is None:
             accel_group = self.accel_group
@@ -351,9 +352,9 @@ class Plugin(BasePlugin):
             console = PythonConsole(namespace = ns, destroy_cb = self._on_console_destroyed)
             console.set_size_request(600, 400)
 
-            self.window = gtk.Window()
+            self.window = Gtk.Window()
             self.window.set_title('Virtaal Python Console')
-            self.window.set_transient_for(self.main_controller.view.main_window)
+            self.set_transient_for(self.main_controller.view.main_window)
             self.window.add(console)
             self.window.connect('destroy', self._on_console_destroyed)
         self.window.show_all()

--- a/virtaal/plugins/_python_console.py
+++ b/virtaal/plugins/_python_console.py
@@ -325,7 +325,7 @@ class Plugin(BasePlugin):
 
     def _setup_menu_item(self):
         self.menu = self.main_controller.view.gui.get_object('menu_view')
-        self.menuitem = Gtk.MenuItem(label=_('P_ython Console'))
+        self.menuitem = Gtk.MenuItem.new_with_mnemonic(label=_('P_ython Console'))
         self.menuitem.show()
         self.menu.append(self.menuitem)
 

--- a/virtaal/plugins/autocompletor.py
+++ b/virtaal/plugins/autocompletor.py
@@ -24,6 +24,7 @@
 import re
 
 from gi.repository import GObject
+from six import text_type as unicode, string_types as basestring
 
 try:
     from collections import defaultdict
@@ -207,7 +208,7 @@ class AutoCompletor(object):
 
     def _update_word_list(self):
         """Update and sort found words according to frequency."""
-        wordlist = self._word_freq.items()
+        wordlist = list(self._word_freq.items())
         wordlist.sort(key=lambda x:x[1], reverse=True)
         self._word_list = [items[0] for items in wordlist]
 

--- a/virtaal/plugins/autocompletor.py
+++ b/virtaal/plugins/autocompletor.py
@@ -21,8 +21,10 @@
 
 """Contains the AutoCompletor class."""
 
-import gobject
 import re
+
+from gi.repository import GObject
+
 try:
     from collections import defaultdict
 except ImportError:
@@ -176,7 +178,7 @@ class AutoCompletor(object):
             if completed_word:
                 # Updating of the buffer is deferred until after this signal
                 # and its side effects are taken care of. We abuse
-                # gobject.idle_add for that.
+                # GObject.idle_add for that.
                 insert_offset = offset + 1 # len(text) == 1
                 def suggest_completion():
                     textbox.handler_block(self._textbox_insert_ids[textbox])
@@ -190,7 +192,7 @@ class AutoCompletor(object):
 
                     return False
 
-                gobject.idle_add(suggest_completion, priority=gobject.PRIORITY_HIGH)
+                GObject.idle_add(suggest_completion, priority=GObject.PRIORITY_HIGH)
 
     def _remove_textbox(self, textbox):
         """Remove the given L{TextBox} from the list of widgets to do
@@ -223,7 +225,6 @@ class Plugin(BasePlugin):
         self._init_plugin()
 
     def _init_plugin(self):
-        from virtaal.common import pan_app
         self.autocomp = AutoCompletor(self.main_controller)
 
         self._store_loaded_id = self.main_controller.store_controller.connect('store-loaded', self._on_store_loaded)
@@ -269,7 +270,8 @@ class Plugin(BasePlugin):
                         #logging.debug('Adding words: %s' % (self.autocomp.wordsep_re.split(unicode(self.lastunit.target))))
                         self.autocomp.add_words(self.autocomp.wordsep_re.split(unicode(self.lastunit.target)))
             self.lastunit = cursor.deref()
-        gobject.idle_add(add_widgets)
+
+        GObject.idle_add(add_widgets)
 
     def _on_store_loaded(self, storecontroller):
         self.autocomp.add_words_from_units(storecontroller.get_store().get_units())

--- a/virtaal/plugins/autocorrector.py
+++ b/virtaal/plugins/autocorrector.py
@@ -30,7 +30,6 @@ from gi.repository import GObject
 from six import text_type as unicode, string_types as basestring
 
 from virtaal.common import pan_app
-from virtaal.common.utils import get_unicode
 from virtaal.controllers.baseplugin import BasePlugin
 from virtaal.views.widgets.textbox import TextBox
 
@@ -182,7 +181,8 @@ class AutoCorrector(object):
 
         # Add auto-correction regex for each loaded word.
         for key, value in self.correctiondict.items():
-            self.correctiondict[key] = (get_unicode(value), re.compile(r'\b%s$' % (re.escape(key)), re.UNICODE))
+            # lxml gives bytestrings for ASCII only values
+            self.correctiondict[key] = (unicode(value), re.compile(r'\b%s$' % (re.escape(key)), re.UNICODE))
 
         self.lang = lang
         return

--- a/virtaal/plugins/autocorrector.py
+++ b/virtaal/plugins/autocorrector.py
@@ -27,8 +27,10 @@ import re
 import zipfile
 
 from gi.repository import GObject
+from six import text_type as unicode, string_types as basestring
 
 from virtaal.common import pan_app
+from virtaal.common.utils import get_unicode
 from virtaal.controllers.baseplugin import BasePlugin
 from virtaal.views.widgets.textbox import TextBox
 
@@ -147,7 +149,7 @@ class AutoCorrector(object):
         lang = lang.replace('_', '-')
         try:
             acor = zipfile.ZipFile(os.path.join(self.acorpath, 'acor_%s.dat' % lang))
-        except IOError, _exc:
+        except IOError as _exc:
             # Try to find a file that starts with 'acor_%s' % (lang[0]) (where
             # lang[0] is the part of lang before the '-') and ends with '.dat'
             langparts = lang.split('-')
@@ -180,7 +182,7 @@ class AutoCorrector(object):
 
         # Add auto-correction regex for each loaded word.
         for key, value in self.correctiondict.items():
-            self.correctiondict[key] = (unicode(value), re.compile(r'\b%s$' % (re.escape(key)), re.UNICODE))
+            self.correctiondict[key] = (get_unicode(value), re.compile(r'\b%s$' % (re.escape(key)), re.UNICODE))
 
         self.lang = lang
         return

--- a/virtaal/plugins/autocorrector.py
+++ b/virtaal/plugins/autocorrector.py
@@ -21,11 +21,12 @@
 
 """Contains the AutoCorrector class."""
 
-import gobject
 import logging
 import os
 import re
 import zipfile
+
+from gi.repository import GObject
 
 from virtaal.common import pan_app
 from virtaal.controllers.baseplugin import BasePlugin
@@ -224,7 +225,7 @@ class AutoCorrector(object):
             if reprange is not None:
                 # Updating of the buffer is deferred until after this signal
                 # and its side effects are taken care of. We abuse
-                # gobject.idle_add for that.
+                # GObject.idle_add for that.
                 def correct_text():
                     buffer = textbox.buffer
                     start_iter = elem.gui_info.treeindex_to_iter(reprange[0])
@@ -239,10 +240,11 @@ class AutoCorrector(object):
                     def refresh():
                         textbox.refresh_cursor_pos = newcursorpos
                         textbox.refresh()
-                    gobject.idle_add(refresh)
+
+                    GObject.idle_add(refresh)
                     return False
 
-                gobject.idle_add(correct_text)
+                GObject.idle_add(correct_text)
 
     def _remove_textbox(self, textbox):
         """Remove the given C{TextBox} from the list of widgets to do
@@ -275,7 +277,8 @@ class Plugin(BasePlugin):
                 for target in self.main_controller.unit_controller.view.targets:
                     self.autocorr.add_widget(target)
                 return False
-            gobject.idle_add(add_widgets)
+
+            GObject.idle_add(add_widgets)
 
         def on_store_loaded(storecontroller):
             self.autocorr.load_dictionary(lang=self.main_controller.lang_controller.target_lang.code)

--- a/virtaal/plugins/lookup/__init__.py
+++ b/virtaal/plugins/lookup/__init__.py
@@ -19,10 +19,10 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 """Performs external look-ups on selected text."""
+from __future__ import absolute_import, print_function, unicode_literals
 
 from virtaal.controllers.baseplugin import BasePlugin
-
-from lookupcontroller import LookupController
+from .lookupcontroller import LookupController
 
 
 class Plugin(BasePlugin):

--- a/virtaal/plugins/lookup/lookupcontroller.py
+++ b/virtaal/plugins/lookup/lookupcontroller.py
@@ -18,15 +18,15 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-import gobject
 import os
 
-from virtaal.common import GObjectWrapper
-from virtaal.controllers.basecontroller import BaseController
-from virtaal.controllers.plugincontroller import PluginController
+from gi.repository import GObject
 
 from lookupview import LookupView
 from models.baselookupmodel import BaseLookupModel
+from virtaal.common import GObjectWrapper
+from virtaal.controllers.basecontroller import BaseController
+from virtaal.controllers.plugincontroller import PluginController
 
 
 class LookupController(BaseController):
@@ -34,7 +34,7 @@ class LookupController(BaseController):
 
     __gtype_name__ = 'LookupController'
     __gsignals__ = {
-        'lookup-query': (gobject.SIGNAL_RUN_FIRST, None, (object,))
+        'lookup-query': (GObject.SignalFlags.RUN_FIRST, None, (object,))
     }
 
     # INITIALIZERS #

--- a/virtaal/plugins/lookup/lookupcontroller.py
+++ b/virtaal/plugins/lookup/lookupcontroller.py
@@ -17,16 +17,17 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import, print_function, unicode_literals
 
 import os
 
 from gi.repository import GObject
 
-from lookupview import LookupView
-from models.baselookupmodel import BaseLookupModel
 from virtaal.common import GObjectWrapper
 from virtaal.controllers.basecontroller import BaseController
 from virtaal.controllers.plugincontroller import PluginController
+from .lookupview import LookupView
+from .models.baselookupmodel import BaseLookupModel
 
 
 class LookupController(BaseController):

--- a/virtaal/plugins/lookup/lookupview.py
+++ b/virtaal/plugins/lookup/lookupview.py
@@ -19,7 +19,8 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 import logging
-import gtk
+
+from gi.repository import Gtk
 
 from virtaal.views.baseview import BaseView
 from virtaal.views.widgets.selectdialog import SelectDialog
@@ -71,7 +72,7 @@ class LookupView(BaseView):
             message=_('Select the services that should be used to perform look-ups'),
             size=(self.controller.config['backends_dialog_width'], 200)
         )
-        if isinstance(parent, gtk.Window):
+        if isinstance(parent, Gtk.Window):
             selectdlg.set_transient_for(parent)
             selectdlg.set_icon(parent.get_icon())
 
@@ -127,13 +128,13 @@ class LookupView(BaseView):
         srclang   = self.lang_controller.source_lang.code
         tgtlang   = self.lang_controller.target_lang.code
 
-        lookup_menu = gtk.Menu()
+        lookup_menu = Gtk.Menu()
         if len(selection) > 40:
             #l10n: The menu entry when looking up a very long selection of text. Here start and end are snippets from the start and end of the long selection.
             selection_entry = _('Look-up "%(start)s … %(end)s"') % {'start': selection[:15], 'end': selection[-15:]}
         else:
             selection_entry = _('Look-up "%(selection)s"') % {'selection': selection}
-        menu_item = gtk.MenuItem(selection_entry)
+        menu_item = Gtk.MenuItem(selection_entry)
 
         plugins = self.controller.plugin_controller.plugins
         menu_items = []
@@ -149,7 +150,7 @@ class LookupView(BaseView):
         for i in menu_items:
             lookup_menu.append(i)
 
-        sep = gtk.SeparatorMenuItem()
+        sep = Gtk.SeparatorMenuItem()
         sep.show()
         menu.append(sep)
         menu_item.set_submenu(lookup_menu)

--- a/virtaal/plugins/lookup/lookupview.py
+++ b/virtaal/plugins/lookup/lookupview.py
@@ -139,7 +139,7 @@ class LookupView(BaseView):
 
         plugins = self.controller.plugin_controller.plugins
         menu_items = []
-        names = plugins.keys()
+        names = list(plugins.keys())
         names.sort()
         for name in names:
             menu_items.extend(

--- a/virtaal/plugins/lookup/lookupview.py
+++ b/virtaal/plugins/lookup/lookupview.py
@@ -116,8 +116,6 @@ class LookupView(BaseView):
 
 
     # SIGNAL HANDLERS #
-    def _on_lookup_selected(self, menuitem, plugin, query, query_is_source):
-        plugin.lookup(query, query_is_source, srclang, tgtlang)
 
     def _on_populate_popup(self, textbox, menu):
         buf = textbox.buffer

--- a/virtaal/plugins/lookup/lookupview.py
+++ b/virtaal/plugins/lookup/lookupview.py
@@ -83,7 +83,7 @@ class LookupView(BaseView):
                 continue
             try:
                 info = plugin_controller.get_plugin_info(plugin_name)
-            except Exception, e:
+            except Exception as e:
                 logging.debug('Problem getting information for plugin %s' % plugin_name)
                 continue
             enabled = plugin_name in plugin_controller.plugins

--- a/virtaal/plugins/lookup/lookupview.py
+++ b/virtaal/plugins/lookup/lookupview.py
@@ -124,7 +124,7 @@ class LookupView(BaseView):
         if not buf.get_has_selection():
             return
 
-        selection = get_unicode(buf.get_text(*buf.get_selection_bounds()), 'utf-8').strip()
+        selection = get_unicode(buf.get_text(*buf.get_selection_bounds(), include_hidden_chars=False)).strip()
         role      = textbox.role
         srclang   = self.lang_controller.source_lang.code
         tgtlang   = self.lang_controller.target_lang.code

--- a/virtaal/plugins/lookup/lookupview.py
+++ b/virtaal/plugins/lookup/lookupview.py
@@ -22,6 +22,7 @@ import logging
 
 from gi.repository import Gtk
 
+from virtaal.common.utils import get_unicode
 from virtaal.views.baseview import BaseView
 from virtaal.views.widgets.selectdialog import SelectDialog
 
@@ -123,7 +124,7 @@ class LookupView(BaseView):
         if not buf.get_has_selection():
             return
 
-        selection = buf.get_text(*buf.get_selection_bounds()).decode('utf-8').strip()
+        selection = get_unicode(buf.get_text(*buf.get_selection_bounds()), 'utf-8').strip()
         role      = textbox.role
         srclang   = self.lang_controller.source_lang.code
         tgtlang   = self.lang_controller.target_lang.code

--- a/virtaal/plugins/lookup/models/baselookupmodel.py
+++ b/virtaal/plugins/lookup/models/baselookupmodel.py
@@ -18,8 +18,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-from virtaal.models.basemodel import BaseModel
-
 
 class BaseLookupModel(object):
     """The base interface to be implemented by all look-up backend models."""
@@ -37,7 +35,7 @@ class BaseLookupModel(object):
 
     # METHODS #
     def create_menu_items(self, query, role, srclang, tgtlang):
-        """Create the a list C{gtk.MenuItem}s for the given parameters.
+        """Create the a list C{Gtk.MenuItem}s for the given parameters.
 
         @type  query: basestring
         @param query: The string to use in the look-up.

--- a/virtaal/plugins/lookup/models/weblookup.py
+++ b/virtaal/plugins/lookup/models/weblookup.py
@@ -166,7 +166,7 @@ class WebLookupConfigDialog(object):
 
         cell = Gtk.CellRendererText()
         col = Gtk.TreeViewColumn(_('Name'))
-        col.pack_start(cell, True, True, 0)
+        col.pack_start(cell, True)
         col.add_attribute(cell, 'text', self.COL_NAME)
         col.props.resizable = True
         col.set_sort_column_id(0)
@@ -175,7 +175,7 @@ class WebLookupConfigDialog(object):
         cell = Gtk.CellRendererText()
         cell.props.ellipsize = Pango.EllipsizeMode.MIDDLE
         col = Gtk.TreeViewColumn(_('URL'))
-        col.pack_start(cell, True, True, 0)
+        col.pack_start(cell, True)
         col.add_attribute(cell, 'text', self.COL_URL)
         col.props.resizable = True
         col.set_expand(True)
@@ -186,7 +186,7 @@ class WebLookupConfigDialog(object):
         cell.set_radio(False)
         #l10n: Whether the selected text should be surrounded by "quotes"
         col = Gtk.TreeViewColumn(_('Quote Query'))
-        col.pack_start(cell, True, True, 0)
+        col.pack_start(cell, True)
         col.add_attribute(cell, 'active', self.COL_QUOTE)
         self.tvw_urls.append_column(col)
 

--- a/virtaal/plugins/lookup/models/weblookup.py
+++ b/virtaal/plugins/lookup/models/weblookup.py
@@ -19,7 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-import urllib
+from six.moves.urllib import parse
 from os import path
 
 from gi.repository import Gtk
@@ -100,7 +100,7 @@ class LookupModel(BaseLookupModel):
     def create_menu_items(self, query, role, srclang, tgtlang):
         querylang = role == 'source' and srclang or tgtlang
         nonquerylang = role != 'source' and srclang or tgtlang
-        query = urllib.quote(query.encode('utf-8'))
+        query = parse.quote(query.encode('utf-8'))
         items = []
         for urlinfo in self.URLDATA:
             uquery = query

--- a/virtaal/plugins/lookup/models/weblookup.py
+++ b/virtaal/plugins/lookup/models/weblookup.py
@@ -19,10 +19,11 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-import gtk
-import pango
 import urllib
 from os import path
+
+from gi.repository import Gtk
+from gi.repository import Pango
 
 from virtaal.common import pan_app
 from virtaal.views.baseview import BaseView
@@ -106,7 +107,7 @@ class LookupModel(BaseLookupModel):
             if 'quoted' in urlinfo and urlinfo['quoted']:
                 uquery = '"' + uquery + '"'
 
-            i = gtk.MenuItem(urlinfo['display_name'])
+            i = Gtk.MenuItem(urlinfo['display_name'])
             lookup_str = urlinfo['url'] % {
                 'query':        uquery,
                 'querylang':    querylang,
@@ -143,7 +144,7 @@ class WebLookupConfigDialog(object):
         )
 
         self._get_widgets()
-        if isinstance(parent, gtk.Widget):
+        if isinstance(parent, Gtk.Widget):
             self.dialog.set_transient_for(parent)
             self.dialog.set_icon(parent.get_toplevel().get_icon())
 
@@ -160,32 +161,32 @@ class WebLookupConfigDialog(object):
         self.add_dialog = WebLookupAddDialog(self.dialog)
 
     def _init_treeview(self):
-        self.lst_urls = gtk.ListStore(str, str, bool, object)
+        self.lst_urls = Gtk.ListStore(str, str, bool, object)
         self.tvw_urls.set_model(self.lst_urls)
 
-        cell = gtk.CellRendererText()
-        col = gtk.TreeViewColumn(_('Name'))
-        col.pack_start(cell)
+        cell = Gtk.CellRendererText()
+        col = Gtk.TreeViewColumn(_('Name'))
+        col.pack_start(cell, True, True, 0)
         col.add_attribute(cell, 'text', self.COL_NAME)
         col.props.resizable = True
         col.set_sort_column_id(0)
         self.tvw_urls.append_column(col)
 
-        cell = gtk.CellRendererText()
-        cell.props.ellipsize = pango.ELLIPSIZE_MIDDLE
-        col = gtk.TreeViewColumn(_('URL'))
-        col.pack_start(cell)
+        cell = Gtk.CellRendererText()
+        cell.props.ellipsize = Pango.EllipsizeMode.MIDDLE
+        col = Gtk.TreeViewColumn(_('URL'))
+        col.pack_start(cell, True, True, 0)
         col.add_attribute(cell, 'text', self.COL_URL)
         col.props.resizable = True
         col.set_expand(True)
         col.set_sort_column_id(1)
         self.tvw_urls.append_column(col)
 
-        cell = gtk.CellRendererToggle()
+        cell = Gtk.CellRendererToggle()
         cell.set_radio(False)
         #l10n: Whether the selected text should be surrounded by "quotes"
-        col = gtk.TreeViewColumn(_('Quote Query'))
-        col.pack_start(cell)
+        col = Gtk.TreeViewColumn(_('Quote Query'))
+        col.pack_start(cell, True, True, 0)
         col.add_attribute(cell, 'active', self.COL_QUOTE)
         self.tvw_urls.append_column(col)
 
@@ -206,7 +207,7 @@ class WebLookupConfigDialog(object):
 
     # METHODS #
     def run(self, parent=None):
-        if isinstance(parent, gtk.Widget):
+        if isinstance(parent, Gtk.Widget):
             self.dialog.set_transient_for(parent)
 
         self.dialog.show()
@@ -240,7 +241,7 @@ class WebLookupAddDialog(object):
         )
         self._get_widgets()
 
-        if isinstance(parent, gtk.Window):
+        if isinstance(parent, Gtk.Window):
             self.dialog.set_transient_for(parent)
             self.dialog.set_icon(parent.get_toplevel().get_icon())
 
@@ -263,7 +264,7 @@ class WebLookupAddDialog(object):
         response = self.dialog.run()
         self.dialog.hide()
 
-        if response != gtk.RESPONSE_OK:
+        if response != Gtk.ResponseType.OK:
             return None
 
         self.url = {

--- a/virtaal/plugins/migration.py
+++ b/virtaal/plugins/migration.py
@@ -34,8 +34,8 @@ import struct
 import sys
 from os import path
 
-import ConfigParser
-import StringIO
+from six.moves import cStringIO as StringIO
+from six.moves import configparser as ConfigParser
 
 try:
     from sqlite3 import dbapi2

--- a/virtaal/plugins/migration.py
+++ b/virtaal/plugins/migration.py
@@ -28,13 +28,15 @@ try:
     import bsddb
 except ImportError:
     bsddb = None
-import ConfigParser
 import logging
 import os
-import StringIO
 import struct
 import sys
 from os import path
+
+import ConfigParser
+import StringIO
+
 try:
     from sqlite3 import dbapi2
 except ImportError:
@@ -120,7 +122,7 @@ class Plugin(BasePlugin):
         if not path.exists(config_filename):
             try:
                 import _winreg
-            except Exception, e:
+            except Exception as e:
                 return
 
             def get_thing(section, item):
@@ -137,9 +139,9 @@ class Plugin(BasePlugin):
                         name, data, type = _winreg.EnumValue(key, i)
                         if name == item:
                             break
-                except EnvironmentError, e:
+                except EnvironmentError as e:
                     pass
-                except Exception, e:
+                except Exception as e:
                     logging.exception("Error obtaining from registry: %s, %s", section, item)
                 return data
 

--- a/virtaal/plugins/spellchecker.py
+++ b/virtaal/plugins/spellchecker.py
@@ -27,16 +27,8 @@ from gettext import dgettext
 
 from gi.repository import GObject
 
-from virtaal.common import pan_app
 from virtaal.controllers.baseplugin import PluginUnsupported, BasePlugin
 
-if not pan_app.DEBUG:
-    try:
-        import psyco
-    except:
-        psyco = None
-else:
-    psyco = None
 
 _dict_add_re = re.compile('Add "(.*)" to Dictionary')
 
@@ -244,8 +236,6 @@ class Plugin(BasePlugin):
         if not spell is None:
             spell.detach()
         text_view.spell_lang = None
-    if psyco:
-        psyco.cannotcompile(_disable_checking)
 
 
     # SIGNAL HANDLERS #
@@ -299,8 +289,7 @@ class Plugin(BasePlugin):
         GObject.idle_add(self._activate_checker, text_view, language, priority=GObject.PRIORITY_LOW)
 
     def _activate_checker(self, text_view, language):
-        # All the expensive stuff in here called on idle. We mush also isolate
-        # this away from psyco
+        # All the expensive stuff in here called on idle.
         try:
             spell = None
             try:
@@ -320,10 +309,6 @@ class Plugin(BasePlugin):
             logging.exception("Could not initialize spell checking: %s", e)
             self.gtkspell = None
             #TODO: unload plugin
-    if psyco:
-        # Some of the gtkspell stuff can't work with psyco and will dump core
-        # if we don't avoid psyco compilation
-        psyco.cannotcompile(_activate_checker)
 
     def _on_populate_popup(self, textbox, menu):
         # We can't work with the menu immediately, since gtkspell only adds its

--- a/virtaal/plugins/spellchecker.py
+++ b/virtaal/plugins/spellchecker.py
@@ -236,7 +236,7 @@ class Plugin(BasePlugin):
         spell = None
         try:
             spell = self.gtkspell.get_from_text_view(text_view)
-        except SystemError, e:
+        except SystemError as e:
             # At least on Mandriva .get_from_text_view() sometimes returns
             # a SystemError without a description. Things seem to work fine
             # anyway, so let's ignore it and hope for the best.
@@ -305,7 +305,7 @@ class Plugin(BasePlugin):
             spell = None
             try:
                 spell = self.gtkspell.get_from_text_view(text_view)
-            except SystemError, e:
+            except SystemError as e:
                 # At least on Mandriva .get_from_text_view() sometimes returns
                 # a SystemError without a description. Things seem to work fine
                 # anyway, so let's ignore it and hope for the best.
@@ -316,7 +316,7 @@ class Plugin(BasePlugin):
                 spell.set_language(language)
                 spell.recheck_all()
             text_view.spell_lang = language
-        except Exception, e:
+        except Exception as e:
             logging.exception("Could not initialize spell checking: %s", e)
             self.gtkspell = None
             #TODO: unload plugin

--- a/virtaal/plugins/spellchecker.py
+++ b/virtaal/plugins/spellchecker.py
@@ -24,9 +24,19 @@ import os.path
 import re
 import sys
 from gettext import dgettext
-import gobject
 
+from gi.repository import GObject
+
+from virtaal.common import pan_app
 from virtaal.controllers.baseplugin import PluginUnsupported, BasePlugin
+
+if not pan_app.DEBUG:
+    try:
+        import psyco
+    except:
+        psyco = None
+else:
+    psyco = None
 
 _dict_add_re = re.compile('Add "(.*)" to Dictionary')
 
@@ -234,6 +244,8 @@ class Plugin(BasePlugin):
         if not spell is None:
             spell.detach()
         text_view.spell_lang = None
+    if psyco:
+        psyco.cannotcompile(_disable_checking)
 
 
     # SIGNAL HANDLERS #
@@ -284,10 +296,11 @@ class Plugin(BasePlugin):
         if getattr(text_view, 'spell_lang', None) == language:
             # No change necessary - already enabled
             return
-        gobject.idle_add(self._activate_checker, text_view, language, priority=gobject.PRIORITY_LOW)
+        GObject.idle_add(self._activate_checker, text_view, language, priority=GObject.PRIORITY_LOW)
 
     def _activate_checker(self, text_view, language):
-        # All the expensive stuff in here called on idle.
+        # All the expensive stuff in here called on idle. We mush also isolate
+        # this away from psyco
         try:
             spell = None
             try:
@@ -307,11 +320,15 @@ class Plugin(BasePlugin):
             logging.exception("Could not initialize spell checking: %s", e)
             self.gtkspell = None
             #TODO: unload plugin
+    if psyco:
+        # Some of the gtkspell stuff can't work with psyco and will dump core
+        # if we don't avoid psyco compilation
+        psyco.cannotcompile(_activate_checker)
 
     def _on_populate_popup(self, textbox, menu):
         # We can't work with the menu immediately, since gtkspell only adds its
         # entries in the event handler.
-        gobject.idle_add(self._fix_menu, menu)
+        GObject.idle_add(self._fix_menu, menu)
 
     def _fix_menu(self, menu):
         _entries_above_separator = False

--- a/virtaal/plugins/terminology/__init__.py
+++ b/virtaal/plugins/terminology/__init__.py
@@ -18,10 +18,10 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import, print_function, unicode_literals
 
 from virtaal.controllers.baseplugin import BasePlugin
-
-from termcontroller import TerminologyController
+from .termcontroller import TerminologyController
 
 
 class Plugin(BasePlugin):
@@ -30,7 +30,7 @@ class Plugin(BasePlugin):
     version = 0.1
     default_config = {
         'backends_dialog_width': 400,
-        'disabled_models': '',
+        'disabled_models': 'opentran',
         'max_matches': '5',
         'min_quality': '70'
     }

--- a/virtaal/plugins/terminology/models/autoterm.py
+++ b/virtaal/plugins/terminology/models/autoterm.py
@@ -17,10 +17,12 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import, print_function, unicode_literals
 
 import logging
 import os
 import time
+
 from translate.search.match import terminologymatcher
 from translate.storage import factory
 from translate.storage.base import TranslationStore
@@ -28,8 +30,7 @@ from translate.storage.placeables.terminology import TerminologyPlaceable
 
 from virtaal.common import pan_app
 from virtaal.support.httpclient import HTTPClient
-
-from basetermmodel import BaseTerminologyModel
+from .basetermmodel import BaseTerminologyModel
 
 THREE_DAYS = 60 * 60 * 24 * 3
 

--- a/virtaal/plugins/terminology/models/basetermmodel.py
+++ b/virtaal/plugins/terminology/models/basetermmodel.py
@@ -19,17 +19,19 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 import os
-import gobject
 
-from virtaal.models.basemodel import BaseModel
+from gi.repository import GObject
+
 from virtaal.common import pan_app
+from virtaal.models.basemodel import BaseModel
+
 
 class BaseTerminologyModel(BaseModel):
     """The base interface to be implemented by all terminology backend models."""
 
     __gtype_name__ = None
     __gsignals__ = {
-        'match-found': (gobject.SIGNAL_RUN_FIRST, gobject.TYPE_NONE, (gobject.TYPE_STRING, gobject.TYPE_PYOBJECT,))
+        'match-found': (GObject.SignalFlags.RUN_FIRST, None, (GObject.TYPE_STRING, GObject.TYPE_PYOBJECT,))
     }
 
     configure_func = None

--- a/virtaal/plugins/terminology/models/localfile/__init__.py
+++ b/virtaal/plugins/terminology/models/localfile/__init__.py
@@ -17,20 +17,23 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import, unicode_literals, print_function
 
 import logging
 import os
+
 from translate.search.match import terminologymatcher
-from translate.storage.placeables.terminology import TerminologyPlaceable
 from translate.storage import factory
+from translate.storage.placeables.terminology import TerminologyPlaceable
 
 from virtaal.common import pan_app
+
 try:
     from virtaal.plugins.terminology.models.basetermmodel import BaseTerminologyModel
 except ImportError:
     from virtaal_plugins.terminology.models.basetermmodel import BaseTerminologyModel
 
-from localfileview import LocalFileView
+from .localfileview import LocalFileView
 
 
 class TerminologyModel(BaseTerminologyModel):

--- a/virtaal/plugins/terminology/models/localfile/localfileview.py
+++ b/virtaal/plugins/terminology/models/localfile/localfileview.py
@@ -347,7 +347,6 @@ class TermAddDialog:
         self.lst_termfiles = Gtk.ListStore(str)
         self.cmb_termfile.set_model(self.lst_termfiles)
         self.cmb_termfile.pack_start(cellr, True)
-        self.cmb_termfile.add_attribute(cellr, 'text', 0)
 
         self.ent_source.connect('changed', self._on_entry_changed)
         self.ent_target.connect('changed', self._on_entry_changed)

--- a/virtaal/plugins/terminology/models/localfile/localfileview.py
+++ b/virtaal/plugins/terminology/models/localfile/localfileview.py
@@ -18,6 +18,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
+import locale
+
 from gi.repository import Gdk
 from gi.repository import Gtk
 from gi.repository import Pango
@@ -189,7 +191,7 @@ class FileSelectDialog:
         dlg.add_filter(all_supported_filter)
         supported_files_dict = dict([ (_(name), (extension, mimetype)) for name, extension, mimetype in store_factory.supported_files() ])
         supported_file_names = list(supported_files_dict.keys())
-        supported_file_names.sort()
+        supported_file_names.sort(key=locale.strxfrm)
         for name in supported_file_names:
             extensions, mimetypes = supported_files_dict[name]
             #XXX: we can't open generic .csv formats, so listing it is probably

--- a/virtaal/plugins/terminology/models/localfile/localfileview.py
+++ b/virtaal/plugins/terminology/models/localfile/localfileview.py
@@ -143,7 +143,7 @@ class FileSelectDialog:
         cell = Gtk.CellRendererText()
         cell.props.ellipsize = Pango.EllipsizeMode.MIDDLE
         col = Gtk.TreeViewColumn(_('File'))
-        col.pack_start(cell, True, True, 0)
+        col.pack_start(cell, True)
         col.add_attribute(cell, 'text', self.COL_FILE)
         col.set_expand(True)
         col.set_sort_column_id(0)
@@ -153,7 +153,7 @@ class FileSelectDialog:
         cell.set_radio(True)
         cell.connect('toggled', self._on_toggle)
         col = Gtk.TreeViewColumn(_('Extendable'))
-        col.pack_start(cell, True, True, 0)
+        col.pack_start(cell, True)
         col.add_attribute(cell, 'active', self.COL_EXTEND)
         col.set_expand(False)
         self.tvw_termfiles.append_column(col)
@@ -345,7 +345,7 @@ class TermAddDialog:
         cellr.props.ellipsize = Pango.EllipsizeMode.MIDDLE
         self.lst_termfiles = Gtk.ListStore(str)
         self.cmb_termfile.set_model(self.lst_termfiles)
-        self.cmb_termfile.pack_start(cellr, True, True, 0)
+        self.cmb_termfile.pack_start(cellr, True)
         self.cmb_termfile.add_attribute(cellr, 'text', 0)
 
         self.ent_source.connect('changed', self._on_entry_changed)

--- a/virtaal/plugins/terminology/models/localfile/localfileview.py
+++ b/virtaal/plugins/terminology/models/localfile/localfileview.py
@@ -364,7 +364,7 @@ class TermAddDialog:
         unit.target = target
 
         buff = self.txt_comment.get_buffer()
-        comments = buff.get_text(buff.get_start_iter(), buff.get_end_iter())
+        comments = buff.get_text(buff.get_start_iter(), buff.get_end_iter(), True)
         if comments:
             unit.addnote(comments)
 

--- a/virtaal/plugins/terminology/models/localfile/localfileview.py
+++ b/virtaal/plugins/terminology/models/localfile/localfileview.py
@@ -18,13 +18,12 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-import gtk
-import pango
-from gtk import gdk
+from gi.repository import Gdk
+from gi.repository import Gtk
+from gi.repository import Pango
 from translate.storage import factory as store_factory
 
 from virtaal.views.baseview import BaseView
-from virtaal.views import rendering
 from virtaal.views.theme import current_theme
 
 
@@ -66,10 +65,10 @@ class LocalFileView:
             self.mnu_add_term.connect('activate', self._on_add_term)
         ))
 
-        gtk.accel_map_add_entry("<Virtaal>/Terminology/Add Term", gtk.keysyms.t, gdk.CONTROL_MASK)
+        Gtk.AccelMap.add_entry("<Virtaal>/Terminology/Add Term", Gdk.KEY_t, Gdk.ModifierType.CONTROL_MASK)
         accel_group = self.menu.get_accel_group()
         if accel_group is None:
-            accel_group = gtk.AccelGroup()
+            accel_group = Gtk.AccelGroup()
             self.menu.set_accel_group(accel_group)
         self.mnu_add_term.set_accel_path("<Virtaal>/Terminology/Add Term")
         self.menu.set_accel_group(accel_group)
@@ -138,23 +137,23 @@ class FileSelectDialog:
         self.tvw_termfiles.get_selection().connect('changed', self._on_selection_changed)
 
     def _init_treeview(self):
-        self.lst_files = gtk.ListStore(str, bool)
+        self.lst_files = Gtk.ListStore(str, bool)
         self.tvw_termfiles.set_model(self.lst_files)
 
-        cell = gtk.CellRendererText()
-        cell.props.ellipsize = pango.ELLIPSIZE_MIDDLE
-        col = gtk.TreeViewColumn(_('File'))
-        col.pack_start(cell)
+        cell = Gtk.CellRendererText()
+        cell.props.ellipsize = Pango.EllipsizeMode.MIDDLE
+        col = Gtk.TreeViewColumn(_('File'))
+        col.pack_start(cell, True, True, 0)
         col.add_attribute(cell, 'text', self.COL_FILE)
         col.set_expand(True)
         col.set_sort_column_id(0)
         self.tvw_termfiles.append_column(col)
 
-        cell = gtk.CellRendererToggle()
+        cell = Gtk.CellRendererToggle()
         cell.set_radio(True)
         cell.connect('toggled', self._on_toggle)
-        col = gtk.TreeViewColumn(_('Extendable'))
-        col.pack_start(cell)
+        col = Gtk.TreeViewColumn(_('Extendable'))
+        col.pack_start(cell, True, True, 0)
         col.add_attribute(cell, 'active', self.COL_EXTEND)
         col.set_expand(False)
         self.tvw_termfiles.append_column(col)
@@ -178,14 +177,14 @@ class FileSelectDialog:
     def _init_add_chooser(self):
         # The following code was mostly copied from virtaal.views.MainView._create_dialogs()
         #TODO: use native dialogues
-        dlg = gtk.FileChooserDialog(
+        dlg = Gtk.FileChooserDialog(
             _('Add Files'),
             self.controller.main_controller.view.main_window,
-            gtk.FILE_CHOOSER_ACTION_OPEN,
-            (gtk.STOCK_CANCEL, gtk.RESPONSE_CANCEL, gtk.STOCK_OPEN, gtk.RESPONSE_OK)
+            Gtk.FileChooserAction.OPEN,
+            (Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL, Gtk.STOCK_OPEN, Gtk.ResponseType.OK)
         )
-        dlg.set_default_response(gtk.RESPONSE_OK)
-        all_supported_filter = gtk.FileFilter()
+        dlg.set_default_response(Gtk.ResponseType.OK)
+        all_supported_filter = Gtk.FileFilter()
         all_supported_filter.set_name(_("All Supported Files"))
         dlg.add_filter(all_supported_filter)
         supported_files_dict = dict([ (_(name), (extension, mimetype)) for name, extension, mimetype in store_factory.supported_files() ])
@@ -198,7 +197,7 @@ class FileSelectDialog:
             # more harmful than good.
             if "csv" in extensions:
                 continue
-            new_filter = gtk.FileFilter()
+            new_filter = Gtk.FileFilter()
             new_filter.set_name(name)
             if extensions:
                 for extension in extensions:
@@ -212,7 +211,7 @@ class FileSelectDialog:
                     new_filter.add_mime_type(mimetype)
                     all_supported_filter.add_mime_type(mimetype)
             dlg.add_filter(new_filter)
-        all_filter = gtk.FileFilter()
+        all_filter = Gtk.FileFilter()
         all_filter.set_name(_("All Files"))
         all_filter.add_pattern("*")
         dlg.add_filter(all_filter)
@@ -226,7 +225,7 @@ class FileSelectDialog:
         self.tvw_termfiles.get_selection().unselect_all()
 
     def run(self, parent=None):
-        if isinstance(parent, gtk.Widget):
+        if isinstance(parent, Gtk.Widget):
             self.dialog.set_transient_for(parent)
 
         self.clear_selection()
@@ -242,7 +241,7 @@ class FileSelectDialog:
         response = self.add_chooser.run()
         self.add_chooser.hide()
 
-        if response != gtk.RESPONSE_OK:
+        if response != Gtk.ResponseType.OK:
             return
 
         mainview = self.term_model.controller.main_controller.view
@@ -342,11 +341,11 @@ class TermAddDialog:
 
         self.dialog = self.gui.get_object('TermAddDlg')
 
-        cellr = gtk.CellRendererText()
-        cellr.props.ellipsize = pango.ELLIPSIZE_MIDDLE
-        self.lst_termfiles = gtk.ListStore(str)
+        cellr = Gtk.CellRendererText()
+        cellr.props.ellipsize = Pango.EllipsizeMode.MIDDLE
+        self.lst_termfiles = Gtk.ListStore(str)
         self.cmb_termfile.set_model(self.lst_termfiles)
-        self.cmb_termfile.pack_start(cellr)
+        self.cmb_termfile.pack_start(cellr, True, True, 0)
         self.cmb_termfile.add_attribute(cellr, 'text', 0)
 
         self.ent_source.connect('changed', self._on_entry_changed)
@@ -424,7 +423,7 @@ class TermAddDialog:
     def run(self, parent=None):
         self.reset()
 
-        if isinstance(parent, gtk.Widget):
+        if isinstance(parent, Gtk.Widget):
             self.dialog.set_transient_for(parent)
 
         self.dialog.show()
@@ -433,7 +432,7 @@ class TermAddDialog:
         response = self.dialog.run()
         self.dialog.hide()
 
-        if response != gtk.RESPONSE_OK:
+        if response != Gtk.ResponseType.OK:
             return
 
         self.add_term_unit(self.ent_source.get_text(), self.ent_target.get_text())
@@ -450,7 +449,7 @@ class TermAddDialog:
         dup = self.term_model.get_duplicates(src_text, tgt_text)
         if dup:
             self.lbl_add_term_errors.set_text(_('Identical entry already exists.'))
-            self.eb_add_term_errors.modify_bg(gtk.STATE_NORMAL, gdk.color_parse(current_theme['warning_bg']))
+            self.eb_add_term_errors.modify_bg(Gtk.StateType.NORMAL, Gdk.color_parse(current_theme['warning_bg']))
             self.eb_add_term_errors.show_all()
             self.btn_add_term.props.sensitive = False
             return
@@ -469,6 +468,6 @@ class TermAddDialog:
                 'translations': translations
             }
             self.lbl_add_term_errors.set_markup(errormsg)
-            self.eb_add_term_errors.modify_bg(gtk.STATE_NORMAL, gdk.color_parse(current_theme['warning_bg']))
+            self.eb_add_term_errors.modify_bg(Gtk.StateType.NORMAL, Gdk.color_parse(current_theme['warning_bg']))
             self.eb_add_term_errors.show_all()
             return

--- a/virtaal/plugins/terminology/models/localfile/localfileview.py
+++ b/virtaal/plugins/terminology/models/localfile/localfileview.py
@@ -188,9 +188,8 @@ class FileSelectDialog:
         all_supported_filter.set_name(_("All Supported Files"))
         dlg.add_filter(all_supported_filter)
         supported_files_dict = dict([ (_(name), (extension, mimetype)) for name, extension, mimetype in store_factory.supported_files() ])
-        supported_file_names = supported_files_dict.keys()
-        from locale import strcoll
-        supported_file_names.sort(cmp=strcoll)
+        supported_file_names = list(supported_files_dict.keys())
+        supported_file_names.sort()
         for name in supported_file_names:
             extensions, mimetypes = supported_files_dict[name]
             #XXX: we can't open generic .csv formats, so listing it is probably
@@ -257,7 +256,7 @@ class FileSelectDialog:
                 store = store_factory.getobject(filename)
                 currfiles.append(filename)
                 self.lst_files.append([filename, False])
-            except Exception, exc:
+            except Exception as exc:
                 message = _('Unable to load %(filename)s:\n\n%(errormsg)s') % {'filename': filename, 'errormsg': str(exc)}
                 mainview.show_error_dialog(title=_('Error opening file'), message=message)
 

--- a/virtaal/plugins/terminology/termcontroller.py
+++ b/virtaal/plugins/terminology/termcontroller.py
@@ -18,17 +18,17 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-import gobject
 import os.path
+
+from gi.repository import GObject
 from translate.storage.placeables import terminology
 
+from models.basetermmodel import BaseTerminologyModel
+from termview import TerminologyGUIInfo, TerminologyView
 from virtaal.common import GObjectWrapper
 from virtaal.controllers.basecontroller import BaseController
 from virtaal.controllers.plugincontroller import PluginController
 from virtaal.views import placeablesguiinfo
-
-from models.basetermmodel import BaseTerminologyModel
-from termview import TerminologyGUIInfo, TerminologyView
 
 
 class TerminologyController(BaseController):
@@ -36,7 +36,7 @@ class TerminologyController(BaseController):
 
     __gtype_name__ = 'TerminologyController'
     __gsignals__ = {
-        'start-query': (gobject.SIGNAL_RUN_FIRST, gobject.TYPE_NONE, (gobject.TYPE_STRING,))
+        'start-query': (GObject.SignalFlags.RUN_FIRST, None, (GObject.TYPE_STRING,))
     }
 
     # INITIALIZERS #

--- a/virtaal/plugins/terminology/termcontroller.py
+++ b/virtaal/plugins/terminology/termcontroller.py
@@ -17,18 +17,19 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import, print_function, unicode_literals
 
 import os.path
 
 from gi.repository import GObject
 from translate.storage.placeables import terminology
 
-from models.basetermmodel import BaseTerminologyModel
-from termview import TerminologyGUIInfo, TerminologyView
 from virtaal.common import GObjectWrapper
 from virtaal.controllers.basecontroller import BaseController
 from virtaal.controllers.plugincontroller import PluginController
 from virtaal.views import placeablesguiinfo
+from .models.basetermmodel import BaseTerminologyModel
+from .termview import TerminologyGUIInfo, TerminologyView
 
 
 class TerminologyController(BaseController):

--- a/virtaal/plugins/terminology/termcontroller.py
+++ b/virtaal/plugins/terminology/termcontroller.py
@@ -53,6 +53,7 @@ class TerminologyController(BaseController):
         self.placeables_controller.non_target_placeables.append(terminology.TerminologyPlaceable)
         self.placeables_controller.connect('parsers-changed', self._on_placeables_changed)
         main_controller.view.main_window.connect('style-set', self._on_style_set)
+        main_controller.view.main_window.connect('style-updated', self._on_style_set)
         self._on_style_set(main_controller.view.main_window, None)
 
         if not (terminology.TerminologyPlaceable, TerminologyGUIInfo) in placeablesguiinfo.element_gui_map:
@@ -99,5 +100,5 @@ class TerminologyController(BaseController):
             if term_parser not in placeables_controller.parsers:
                 placeables_controller.add_parsers(term_parser)
 
-    def _on_style_set(self, widget, prev_style):
+    def _on_style_set(self, widget, prev_style=None):
         TerminologyGUIInfo.update_style(widget)

--- a/virtaal/plugins/terminology/termview.py
+++ b/virtaal/plugins/terminology/termview.py
@@ -56,8 +56,9 @@ class TerminologyGUIInfo(StringElemGUI):
     @classmethod
     def update_style(self, widget):
         from gi.repository import Gtk
-        fg = widget.style.fg[Gtk.StateType.NORMAL]
-        bg = widget.style.base[Gtk.StateType.NORMAL]
+        _style = widget.get_style_context()
+        fg = _style.get_color(Gtk.StateType.NORMAL)
+        bg = _style.get_background_color(Gtk.StateType.NORMAL)
         if is_inverse(fg, bg):
             self.fg = _inverse_fg
             self.bg = _inverse_bg

--- a/virtaal/plugins/terminology/termview.py
+++ b/virtaal/plugins/terminology/termview.py
@@ -178,7 +178,7 @@ class TerminologyView(BaseView):
                 continue
             try:
                 info = plugin_controller.get_plugin_info(plugin_name)
-            except Exception, e:
+            except Exception as e:
                 logging.debug('Problem getting information for plugin %s' % plugin_name)
                 continue
             enabled = plugin_name in plugin_controller.plugins

--- a/virtaal/plugins/terminology/termview.py
+++ b/virtaal/plugins/terminology/termview.py
@@ -18,15 +18,15 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-import gtk
 import logging
 
-from virtaal.views.baseview import BaseView
-from virtaal.views import rendering
-from virtaal.views.theme import is_inverse
-from virtaal.views.placeablesguiinfo import StringElemGUI
-from virtaal.views.widgets.selectdialog import SelectDialog
+from gi.repository import Gtk
 
+from virtaal.views import rendering
+from virtaal.views.baseview import BaseView
+from virtaal.views.placeablesguiinfo import StringElemGUI
+from virtaal.views.theme import is_inverse
+from virtaal.views.widgets.selectdialog import SelectDialog
 
 _default_fg = '#006600'
 _default_bg = '#eeffee'
@@ -55,9 +55,9 @@ class TerminologyGUIInfo(StringElemGUI):
 
     @classmethod
     def update_style(self, widget):
-        import gtk
-        fg = widget.style.fg[gtk.STATE_NORMAL]
-        bg = widget.style.base[gtk.STATE_NORMAL]
+        from gi.repository import Gtk
+        fg = widget.style.fg[Gtk.StateType.NORMAL]
+        bg = widget.style.base[Gtk.StateType.NORMAL]
         if is_inverse(fg, bg):
             self.fg = _inverse_fg
             self.bg = _inverse_bg
@@ -66,7 +66,7 @@ class TerminologyGUIInfo(StringElemGUI):
             self.bg = _default_bg
 
 
-class TerminologyCombo(gtk.ComboBox):
+class TerminologyCombo(Gtk.ComboBox):
     """
     A combo box containing translation matches.
     """
@@ -90,13 +90,13 @@ class TerminologyCombo(gtk.ComboBox):
         self.menu.connect('selection-done', self._on_selection_done)
 
     def __init_combo(self):
-        self._model = gtk.ListStore(str)
+        self._model = Gtk.ListStore(str)
         for trans in self.elem.translations:
             self._model.append([trans])
 
         self.set_model(self._model)
-        self._renderer = gtk.CellRendererText()
-        self.pack_start(self._renderer)
+        self._renderer = Gtk.CellRendererText()
+        self.pack_start(self._renderer, True, True, 0)
         self.add_attribute(self._renderer, 'text', 0)
 
         # Force the "appears-as-list" style property to 0
@@ -107,7 +107,7 @@ class TerminologyCombo(gtk.ComboBox):
             }
             class "GtkComboBox" style "not-a-list"
             """
-        gtk.rc_parse_string(rc_string)
+        Gtk.rc_parse_string(rc_string)
 
 
     # METHODS #

--- a/virtaal/plugins/tm/__init__.py
+++ b/virtaal/plugins/tm/__init__.py
@@ -18,10 +18,10 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import, print_function, unicode_literals
 
 from virtaal.controllers.baseplugin import BasePlugin
-
-from tmcontroller import TMController
+from .tmcontroller import TMController
 
 
 class Plugin(BasePlugin):
@@ -29,7 +29,7 @@ class Plugin(BasePlugin):
     description = _('Translation memory suggestions')
     version = 0.1
     default_config = {
-        'disabled_models': '_dummytm,remotetm,tinytm,apertium,google_translate,moses',
+        'disabled_models': '_dummytm,libtranslate,remotetm,tinytm,apertium,google_translate,moses,microsoft_translator,opentran',
         'max_matches': '5',
         'min_quality': '70'
     }

--- a/virtaal/plugins/tm/models/amagama.py
+++ b/virtaal/plugins/tm/models/amagama.py
@@ -17,10 +17,10 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import, print_function, unicode_literals
 
-
-from basetmmodel import BaseTMModel
-import remotetm
+from . import remotetm
+from .basetmmodel import BaseTMModel
 
 
 class TMModel(remotetm.TMModel):

--- a/virtaal/plugins/tm/models/apertium.py
+++ b/virtaal/plugins/tm/models/apertium.py
@@ -31,7 +31,7 @@ try:
 except ImportError:
     import json #available since Python 2.6
 
-from basetmmodel import BaseTMModel, unescape_html_entities
+from .basetmmodel import BaseTMModel, unescape_html_entities
 
 from virtaal.common.utils import get_unicode
 from virtaal.support.httpclient import HTTPClient, RESTRequest

--- a/virtaal/plugins/tm/models/apertium.py
+++ b/virtaal/plugins/tm/models/apertium.py
@@ -24,7 +24,7 @@ Machine Translation.
 http://wiki.apertium.org/wiki/Apertium_web_service
 """
 
-import urllib
+from six.moves.urllib.parse import urlencode
 # These two json modules are API compatible
 try:
     import simplejson as json #should be a bit faster; needed for Python < 2.6
@@ -88,7 +88,7 @@ class TMModel(BaseTMModel):
                 'markUnknown': "no",
                 'format': 'html',
             }
-            req = RESTRequest(self.url_translate + "?" + urllib.urlencode(values), '')
+            req = RESTRequest(self.url_translate + "?" + urlencode(values), '')
             self.client.add(req)
             req.connect(
                 'http-success',

--- a/virtaal/plugins/tm/models/basetmmodel.py
+++ b/virtaal/plugins/tm/models/basetmmodel.py
@@ -17,12 +17,13 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
+from __future__ import print_function, unicode_literals, absolute_import
 
-import htmlentitydefs
 import os
 import re
 
 from gi.repository import GObject
+from six.moves import html_entities as htmlentitydefs
 
 from virtaal.common import pan_app
 from virtaal.models.basemodel import BaseModel

--- a/virtaal/plugins/tm/models/basetmmodel.py
+++ b/virtaal/plugins/tm/models/basetmmodel.py
@@ -18,13 +18,14 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-import os
-import gobject
 import htmlentitydefs
+import os
 import re
 
-from virtaal.models.basemodel import BaseModel
+from gi.repository import GObject
+
 from virtaal.common import pan_app
+from virtaal.models.basemodel import BaseModel
 
 
 #http://effbot.org/zone/re-sub.htm#unescape-html
@@ -48,7 +49,7 @@ class BaseTMModel(BaseModel):
 
     __gtype_name__ = None
     __gsignals__ = {
-        'match-found': (gobject.SIGNAL_RUN_FIRST, gobject.TYPE_NONE, (gobject.TYPE_STRING, gobject.TYPE_PYOBJECT,))
+        'match-found': (GObject.SignalFlags.RUN_FIRST, None, (GObject.TYPE_STRING, GObject.TYPE_PYOBJECT,))
     }
 
     description = ""

--- a/virtaal/plugins/tm/models/basetmmodel.py
+++ b/virtaal/plugins/tm/models/basetmmodel.py
@@ -37,11 +37,11 @@ def unescape_html_entities(text):
         if not entity:
             if text[:2] == "&#":
                 try:
-                    return unichr(int(text[2:-1]))
+                    return chr(int(text[2:-1]))
                 except ValueError:
                     pass
         else:
-            return unicode(entity, "iso-8859-1")
+            return entity
     return re.sub("&(#[0-9]+|\w+);", fixup, text)
 
 

--- a/virtaal/plugins/tm/models/currentfile.py
+++ b/virtaal/plugins/tm/models/currentfile.py
@@ -17,10 +17,12 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import, print_function, unicode_literals
 
+from six import text_type
 from translate.search import match
 
-from basetmmodel import BaseTMModel
+from .basetmmodel import BaseTMModel
 
 
 class TMModel(BaseTMModel):
@@ -88,8 +90,8 @@ class TMModel(BaseTMModel):
         matches = []
 
         query_str = unit.source
-        if not isinstance(query_str, unicode):
-            query_str = unicode(query_str, 'utf-8')
+        if not isinstance(query_str, text_type):
+            query_str = query_str.decode('utf-8')
 
         for candidate in self.matcher.matches(query_str):
             m = match.unit2dict(candidate)
@@ -130,7 +132,7 @@ class TMModel(BaseTMModel):
                             meta = dict((pi.target, pi.text) for pi in extras)
                             tmsource = [meta.get("contact-name", ""), meta.get("category", ""), os.path.splitext(meta.get("original", ""))[0]]
                             tmsource = u"\n".join(filter(None, tmsource))
-                        except Exception, e:
+                        except Exception as e:
                             import logging
                             logging.info(e)
 

--- a/virtaal/plugins/tm/models/currentfile.py
+++ b/virtaal/plugins/tm/models/currentfile.py
@@ -162,4 +162,4 @@ class TMModel(BaseTMModel):
                 l = len(key)
                 return l < start or l > stop
 
-            self.cache = dict((k,v) for (k,v) in self.cache.iteritems() if unaffected(k))
+            self.cache = dict((k,v) for (k,v) in self.cache.items() if unaffected(k))

--- a/virtaal/plugins/tm/models/google_translate.py
+++ b/virtaal/plugins/tm/models/google_translate.py
@@ -31,7 +31,7 @@ except ImportError:
     import json #available since Python 2.6
 
 from virtaal.common.utils import get_unicode
-from basetmmodel import BaseTMModel, unescape_html_entities
+from .basetmmodel import BaseTMModel, unescape_html_entities
 from virtaal.support.httpclient import HTTPClient, RESTRequest
 
 

--- a/virtaal/plugins/tm/models/google_translate.py
+++ b/virtaal/plugins/tm/models/google_translate.py
@@ -21,7 +21,9 @@
 
 import logging
 import urllib
+
 import pycurl
+
 # These two json modules are API compatible
 try:
     import simplejson as json #should be a bit faster; needed for Python < 2.6
@@ -130,7 +132,7 @@ class TMModel(BaseTMModel):
             data['data']
             data['data']['translations']
             text = data['data']['translations'][0]['translatedText']
-        except Exception, e:
+        except Exception as e:
             self._disable_all("Error with json response: %s" % e)
             return
 
@@ -152,7 +154,7 @@ class TMModel(BaseTMModel):
             data = json.loads(val)
             data['data']
             languages = data['data']['languages']
-        except Exception, e:
+        except Exception as e:
             self._disable_all("Error with json response: %s" % e)
             return
         self._languages = set([l['language'] for l in languages])

--- a/virtaal/plugins/tm/models/google_translate.py
+++ b/virtaal/plugins/tm/models/google_translate.py
@@ -30,6 +30,7 @@ try:
 except ImportError:
     import json #available since Python 2.6
 
+from virtaal.common.utils import get_unicode
 from basetmmodel import BaseTMModel, unescape_html_entities
 from virtaal.support.httpclient import HTTPClient, RESTRequest
 
@@ -137,8 +138,7 @@ class TMModel(BaseTMModel):
             return
 
         target_unescaped = unescape_html_entities(text)
-        if not isinstance(target_unescaped, unicode):
-            target_unescaped = unicode(target_unescaped, 'utf-8')
+        target_unescaped = get_unicode(target_unescaped, 'utf-8')
         match = {
             'source': query_str,
             'target': target_unescaped,

--- a/virtaal/plugins/tm/models/localtm.py
+++ b/virtaal/plugins/tm/models/localtm.py
@@ -17,15 +17,15 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import, print_function, unicode_literals
 
 import logging
 import os
-import sys
 import socket
 
 from virtaal.common import pan_app
-from basetmmodel import BaseTMModel
-import remotetm
+from . import remotetm
+from .basetmmodel import BaseTMModel
 
 
 class TMModel(remotetm.TMModel):
@@ -60,10 +60,10 @@ class TMModel(remotetm.TMModel):
             executable = u"tmserver"
 
         command = [
-            executable.encode(sys.getfilesystemencoding()),
+            executable,
             "-b", self.config["tmserver_bind"],
             "-p", str(port),
-            "-d", self.config["tmdb"].encode(sys.getfilesystemencoding()),
+            "-d", self.config["tmdb"],
             "--min-similarity=%d" % controller.min_quality,
             "--max-candidates=%d" % controller.max_matches,
         ]
@@ -71,7 +71,7 @@ class TMModel(remotetm.TMModel):
         if pan_app.DEBUG:
             command.append("--debug")
 
-        logging.debug("launching tmserver with command %s" % " ".join(command))
+        logging.debug("launching tmserver with command {}".format(" ".join(command)))
         try:
             import subprocess
             from virtaal.support import tmclient
@@ -79,7 +79,7 @@ class TMModel(remotetm.TMModel):
             url = "http://%s:%d/tmserver" % (self.config["tmserver_bind"], port)
 
             self.tmclient = tmclient.TMClient(url)
-        except OSError, e:
+        except OSError as e:
             message = "Failed to start TM server: %s" % str(e)
             logging.exception('Failed to start TM server')
             raise

--- a/virtaal/plugins/tm/models/localtm.py
+++ b/virtaal/plugins/tm/models/localtm.py
@@ -114,7 +114,7 @@ def test_port(host, port):
 
 def find_free_port(host, min_port, max_port):
     import random
-    port_range = range(min_port, max_port)
+    port_range = list(range(min_port, max_port))
     random.shuffle(port_range)
     for port in port_range:
         if test_port(host, port):

--- a/virtaal/plugins/tm/models/microsoft_translator.py
+++ b/virtaal/plugins/tm/models/microsoft_translator.py
@@ -23,7 +23,7 @@ Machine Translations."""
 
 import urllib
 
-from basetmmodel import BaseTMModel
+from .basetmmodel import BaseTMModel
 
 from virtaal.support.httpclient import HTTPClient, RESTRequest
 

--- a/virtaal/plugins/tm/models/microsoft_translator.py
+++ b/virtaal/plugins/tm/models/microsoft_translator.py
@@ -83,7 +83,7 @@ class TMModel(BaseTMModel):
             return
 
         query_str = unit.source
-        if self.cache.has_key(query_str):
+        if query_str in self.cache:
             self.emit('match-found', query_str, self.cache[query_str])
         else:
             values = {

--- a/virtaal/plugins/tm/models/microsoft_translator.py
+++ b/virtaal/plugins/tm/models/microsoft_translator.py
@@ -21,7 +21,7 @@
 """A TM provider that can query the web service for Micrsoft Translator
 Machine Translations."""
 
-import urllib
+from six.moves.urllib import parse as urllib
 
 from .basetmmodel import BaseTMModel
 

--- a/virtaal/plugins/tm/models/microsoft_translator.py
+++ b/virtaal/plugins/tm/models/microsoft_translator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright 2009-2010 Zuza Software Foundation
+# Copyright 2009 Zuza Software Foundation
 #
 # This file is part of Virtaal.
 #
@@ -18,52 +18,56 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-"""A TM provider that can query the web service for the Apertium software for
-Machine Translation.
-
-http://wiki.apertium.org/wiki/Apertium_web_service
-"""
+"""A TM provider that can query the web service for Micrsoft Translator
+Machine Translations."""
 
 import urllib
-# These two json modules are API compatible
-try:
-    import simplejson as json #should be a bit faster; needed for Python < 2.6
-except ImportError:
-    import json #available since Python 2.6
 
-from basetmmodel import BaseTMModel, unescape_html_entities
+from basetmmodel import BaseTMModel
 
-from virtaal.common.utils import get_unicode
 from virtaal.support.httpclient import HTTPClient, RESTRequest
 
+from six import text_type as unicode
+
+# Code corrections
+code_translation = {
+    'zh_CN': 'zh-CHS', # Simplified
+    'zh_TW': 'zh-CHT', # Traditional
+    'nb': 'no', # Norwegian (Nyorks) uses no not nb
+}
+
+def strip_bom(string):
+    if string[0] == u'\ufeff':
+        return string[1:]
+    return string
 
 class TMModel(BaseTMModel):
     """This is the translation memory model."""
 
-    __gtype_name__ = 'ApertiumTMModel'
-    display_name = _('Apertium')
-    description = _('Unreviewed machine translations from Apertium')
+    __gtype_name__ = 'MicrosoftTranslatorTMModel'
+    display_name = _('Microsoft Translator')
+    description = _('Unreviewed machine translations from Microsoft Translator')
 
-    url = "http://api.apertium.org/json"
     default_config = {
-        "appid" : "",
+        "url" : "http://api.microsofttranslator.com/V1/Http.svc",
+        "appid" : "7286B45B8C4816BDF75DC007C1952DDC11C646C1",
     }
 
     # INITIALISERS #
     def __init__(self, internal_name, controller):
         self.internal_name = internal_name
-        self.language_pairs = []
+        self.languages = []
         self.load_config()
 
         self.client = HTTPClient()
-        self.url_getpairs = "%(url)s/listPairs?appId=%(appid)s" % {"url": self.url, "appid": self.config["appid"]}
-        self.url_translate = "%(url)s/translate" % {"url": self.url}
+        self.url_getlanguages = "%(url)s/GetLanguages?appId=%(appid)s" % {"url": self.config['url'], "appid": self.config["appid"]}
+        self.url_translate = "%(url)s/Translate" % {"url": self.config['url']}
         self.appid = self.config['appid']
-        langreq = RESTRequest(self.url_getpairs, '')
+        langreq = RESTRequest(self.url_getlanguages, '')
         self.client.add(langreq)
         langreq.connect(
             'http-success',
-            lambda langreq, response: self.got_language_pairs(response)
+            lambda langreq, response: self.got_languages(response)
         )
 
         super(TMModel, self).__init__(controller)
@@ -73,8 +77,9 @@ class TMModel(BaseTMModel):
     def query(self, tmcontroller, unit):
         """Send the query to the web service. The response is handled by means
         of a call-back because it happens asynchronously."""
-        pair = (self.source_lang, self.target_lang)
-        if pair not in self.language_pairs:
+        source_lang = code_translation.get(self.source_lang, self.source_lang)
+        target_lang = code_translation.get(self.target_lang, self.target_lang)
+        if source_lang not in self.languages or target_lang not in self.languages:
             return
 
         query_str = unit.source
@@ -83,10 +88,9 @@ class TMModel(BaseTMModel):
         else:
             values = {
                 'appId': self.appid,
-                'q': query_str,
-                'langpair': "%s|%s" % (self.source_lang, self.target_lang),
-                'markUnknown': "no",
-                'format': 'html',
+                'text': query_str,
+                'from': source_lang,
+                'to': target_lang
             }
             req = RESTRequest(self.url_translate + "?" + urllib.urlencode(values), '')
             self.client.add(req)
@@ -95,35 +99,21 @@ class TMModel(BaseTMModel):
                 lambda req, response: self.got_translation(response, query_str)
             )
 
-    def got_language_pairs(self, val):
+    def got_languages(self, val):
         """Handle the response from the web service to set up language pairs."""
-        data = json.loads(val)
-        if data['responseStatus'] != 200:
-            import logging
-            logging.debug("Failed to get languages:\n%s", (data['responseDetails']))
-            return
-
-        self.language_pairs = [(pair['sourceLanguage'], pair['targetLanguage']) for pair in data['responseData']]
+        val = strip_bom(val.decode('utf-8')).strip()
+        self.languages = [lang for lang in val.split('\r\n')]
 
     def got_translation(self, val, query_str):
         """Handle the response from the web service now that it came in."""
-        data = json.loads(val)
-
-        if data['responseStatus'] != 200:
-            import logging
-            logging.debug("Failed to translate '%s':\n%s", (query_str, data['responseDetails']))
-            return
-
-        target = data['responseData']['translatedText']
-        target = unescape_html_entities(target)
-        if target.endswith("\n") and not query_str.endswith("\n"):
-            target = target[:-1]# chop of \n
-        target = get_unicode(target, 'utf-8')
+        if not isinstance(val, unicode):
+            val = unicode(val, 'utf-8')
+        val = strip_bom(val)
         match = {
             'source': query_str,
-            'target': target,
+            'target': val,
             #l10n: Try to keep this as short as possible. Feel free to transliterate in CJK languages for optimal vertical display.
-            'tmsource': _('Apertium'),
+            'tmsource': _('Microsoft'),
         }
         self.cache[query_str] = [match]
 

--- a/virtaal/plugins/tm/models/moses.py
+++ b/virtaal/plugins/tm/models/moses.py
@@ -18,6 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
+from six import text_type
 
 from basetmmodel import BaseTMModel
 
@@ -63,7 +64,7 @@ class TMModel(BaseTMModel):
     # METHODS #
     def query(self, tmcontroller, unit):
         if self.source_lang in self.clients and self.target_lang in self.clients[self.source_lang]:
-            query_str = unicode(unit.source) # cast in case of multistrings
+            query_str = text_type(unit.source) # cast in case of multistrings
             if query_str in self.cache:
                 self.emit('match-found', query_str, [self.cache[query_str]])
                 return

--- a/virtaal/plugins/tm/models/moses.py
+++ b/virtaal/plugins/tm/models/moses.py
@@ -20,7 +20,7 @@
 
 from six import text_type
 
-from basetmmodel import BaseTMModel
+from .basetmmodel import BaseTMModel
 
 
 class TMModel(BaseTMModel):

--- a/virtaal/plugins/tm/models/opentran.py
+++ b/virtaal/plugins/tm/models/opentran.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2008-2009 Zuza Software Foundation
+#
+# This file is part of Virtaal.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+
+from virtaal.support import opentranclient
+
+from virtaal.common import pan_app
+
+from .basetmmodel import BaseTMModel
+
+# Some names are a bit too long, so let's "translate" them to something shorter
+new_names = {
+        'OpenOffice.org': 'OpenOffice',
+        'Debian Installer': 'Debian Inst.',
+}
+
+class TMModel(BaseTMModel):
+    """This is the translation memory model."""
+
+    __gtype_name__ = 'OpenTranTMModel'
+    display_name = _('Open-Tran.eu')
+    description = _('Previous translations for Free and Open Source Software')
+
+    # INITIALIZERS #
+    def __init__(self, internal_name, controller):
+        self.internal_name = internal_name
+        self.load_config()
+
+        self.tmclient = opentranclient.OpenTranClient(
+            max_candidates=controller.max_matches,
+            min_similarity=controller.min_quality
+        )
+
+        super(TMModel, self).__init__(controller)
+
+
+    # METHODS #
+    def set_source_lang(self, language):
+        self.tmclient.set_source_lang(language)
+
+    def set_target_lang(self, language):
+        self.tmclient.set_target_lang(language)
+
+    def query(self, tmcontroller, unit):
+        query_str = unit.source
+        if self.cache.has_key(query_str):
+            self.emit('match-found', query_str, self.cache[query_str])
+        else:
+            self.tmclient.translate_unit(query_str, self._handle_matches)
+
+    def _handle_matches(self, widget, query_str, matches):
+        """Handle the matches when returned from self.tmclient."""
+        for match in matches:
+            if not isinstance(match['target'], unicode):
+                match['target'] = unicode(match['target'], 'utf-8')
+            if 'tmsource' in match:
+                # Try to replace some long names like "OpenOffice.org" which
+                # doesn't display nicely:
+                match['tmsource'] = new_names.get(match['tmsource']) or match['tmsource']
+                #l10n: Try to keep this as short as possible. Feel free to transliterate in CJK languages for vertical display optimization.
+                match['tmsource'] = _('OpenTran') + '\n' + match['tmsource']
+            else:
+                match['tmsource'] = _('OpenTran')
+        self.cache[query_str] = matches
+        self.emit('match-found', query_str, matches)

--- a/virtaal/plugins/tm/models/remotetm.py
+++ b/virtaal/plugins/tm/models/remotetm.py
@@ -17,8 +17,9 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import, print_function, unicode_literals
 
-from basetmmodel import BaseTMModel
+from .basetmmodel import BaseTMModel
 
 
 class TMModel(BaseTMModel):

--- a/virtaal/plugins/tm/models/remotetm.py
+++ b/virtaal/plugins/tm/models/remotetm.py
@@ -19,6 +19,7 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 from __future__ import absolute_import, print_function, unicode_literals
 
+from virtaal.common.utils import get_unicode
 from .basetmmodel import BaseTMModel
 
 
@@ -73,8 +74,7 @@ class TMModel(BaseTMModel):
         if matches:
             for match in matches:
                 match['tmsource'] = self.shortname
-                if not isinstance(match['target'], unicode):
-                    match['target'] = unicode(match['target'], 'utf-8')
+                match['target'] = get_unicode(match['target'], 'utf-8')
             self.emit('match-found', query_str, matches)
 
     def push_store(self, store_controller):

--- a/virtaal/plugins/tm/models/test_basetmmodel.py
+++ b/virtaal/plugins/tm/models/test_basetmmodel.py
@@ -18,7 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-from basetmmodel import unescape_html_entities
+from .basetmmodel import unescape_html_entities
 
 def test_unescape_html_entities():
     """Test the unescaping of &amp; and &#39; type HTML escapes"""

--- a/virtaal/plugins/tm/models/tinytm.py
+++ b/virtaal/plugins/tm/models/tinytm.py
@@ -24,7 +24,7 @@ import logging
 from gi.repository import Gtk
 
 from virtaal.common.utils import get_unicode
-from basetmmodel import BaseTMModel
+from .basetmmodel import BaseTMModel
 from virtaal.controllers.baseplugin import PluginUnsupported
 
 

--- a/virtaal/plugins/tm/models/tinytm.py
+++ b/virtaal/plugins/tm/models/tinytm.py
@@ -23,8 +23,10 @@ import logging
 
 from gi.repository import Gtk
 
+from virtaal.common.utils import get_unicode
 from basetmmodel import BaseTMModel
 from virtaal.controllers.baseplugin import PluginUnsupported
+
 
 MAX_ERRORS = 5
 
@@ -105,8 +107,7 @@ class TMModel(BaseTMModel):
         self.wait()
         for result in cursor.fetchall():
             quality, source, target = result[:3]
-            if not isinstance(target, unicode):
-                target = unicode(target, 'utf-8')
+            target = get_unicode(target, 'utf-8')
             matches.append({
                 'source': source,
                 'target': target,

--- a/virtaal/plugins/tm/models/tinytm.py
+++ b/virtaal/plugins/tm/models/tinytm.py
@@ -71,7 +71,7 @@ class TMModel(BaseTMModel):
             user=self.config["username"],
             password=self.config["password"],
             host=self.config["server"],
-            async=1,
+            async_=1,
             port=self.config["port"],
         )
         self.wait()

--- a/virtaal/plugins/tm/models/tinytm.py
+++ b/virtaal/plugins/tm/models/tinytm.py
@@ -19,14 +19,12 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-import gtk
 import logging
 
-from virtaal.common import pan_app
+from gi.repository import Gtk
 
 from basetmmodel import BaseTMModel
 from virtaal.controllers.baseplugin import PluginUnsupported
-
 
 MAX_ERRORS = 5
 
@@ -121,8 +119,8 @@ class TMModel(BaseTMModel):
     def wait(self):
         import select
         while 1:
-            while gtk.events_pending():
-                gtk.main_iteration()
+            while Gtk.events_pending():
+                Gtk.main_iteration()
             try:
                 state = self._db_con.poll()
             except self.psycopg2.Error, e:

--- a/virtaal/plugins/tm/models/tinytm.py
+++ b/virtaal/plugins/tm/models/tinytm.py
@@ -102,7 +102,7 @@ class TMModel(BaseTMModel):
             #cursor.execute("""select pg_sleep(2); SELECT 99, 'source', 'target';""")
             # Uncomment this if you don't trust the results
             #cursor.execute("""SELECT * FROM tinytm_get_fuzzy_matches('en', 'de', 'THE EUROPEAN ECONOMIC COMMUNITY', '', '')""")
-        except self.psycopg2.Error, e:
+        except self.psycopg2.Error as e:
             self.error(e)
         self.wait()
         for result in cursor.fetchall():
@@ -124,7 +124,7 @@ class TMModel(BaseTMModel):
                 Gtk.main_iteration()
             try:
                 state = self._db_con.poll()
-            except self.psycopg2.Error, e:
+            except self.psycopg2.Error as e:
                 self.error(e)
 
             if state == self.psycopg2.extensions.POLL_OK:

--- a/virtaal/plugins/tm/tmcontroller.py
+++ b/virtaal/plugins/tm/tmcontroller.py
@@ -19,8 +19,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-import gobject
 import os.path
+
+from gi.repository import GObject
 from translate.lang.data import forceunicode, normalize
 
 from virtaal.controllers.basecontroller import BaseController
@@ -31,7 +32,7 @@ class TMController(BaseController):
 
     __gtype_name__ = 'TMController'
     __gsignals__ = {
-        'start-query': (gobject.SIGNAL_RUN_FIRST, None, (object,))
+        'start-query': (GObject.SignalFlags.RUN_FIRST, None, (object,))
     }
 
     QUERY_DELAY = 300
@@ -197,8 +198,8 @@ class TMController(BaseController):
             return False
 
         if self._delay_id:
-            gobject.source_remove(self._delay_id)
-        self._delay_id = gobject.timeout_add(self.QUERY_DELAY, start_query)
+            GObject.source_remove(self._delay_id)
+        self._delay_id = GObject.timeout_add(self.QUERY_DELAY, start_query)
 
 
     # EVENT HANDLERS #
@@ -240,7 +241,8 @@ class TMController(BaseController):
         def handle_first_unit():
             self._on_cursor_changed(self.storecursor)
             return False
-        gobject.idle_add(handle_first_unit)
+
+        GObject.idle_add(handle_first_unit)
 
     def _on_target_focused(self, unitcontroller, target_n):
         #import logging

--- a/virtaal/plugins/tm/tmcontroller.py
+++ b/virtaal/plugins/tm/tmcontroller.py
@@ -18,6 +18,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import, print_function, unicode_literals
 
 import os.path
 
@@ -54,7 +55,7 @@ class TMController(BaseController):
         self._signal_ids = {}
         # tm query delay:
         self._delay_id = None
-        from tmview import TMView
+        from .tmview import TMView
         self.storecursor = None
         self.view = TMView(self, self.max_matches)
         self._load_models()
@@ -80,7 +81,7 @@ class TMController(BaseController):
            new_dirs.append(os.path.join(dir, 'tm', 'models'))
         self.plugin_controller.PLUGIN_DIRS = new_dirs
 
-        from models.basetmmodel import BaseTMModel
+        from .models.basetmmodel import BaseTMModel
         self.plugin_controller.PLUGIN_INTERFACE = BaseTMModel
         self.plugin_controller.PLUGIN_MODULES = ['virtaal_plugins.tm.models', 'virtaal.plugins.tm.models']
         self.plugin_controller.get_disabled_plugins = lambda *args: self.disabled_model_names

--- a/virtaal/plugins/tm/tmview.py
+++ b/virtaal/plugins/tm/tmview.py
@@ -20,6 +20,8 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 from __future__ import absolute_import, print_function, unicode_literals
 
+import logging
+
 from gi.repository import Gdk
 
 from virtaal.common import GObjectWrapper

--- a/virtaal/plugins/tm/tmview.py
+++ b/virtaal/plugins/tm/tmview.py
@@ -19,15 +19,13 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-import gtk
-import gobject
-import logging
-from gtk import gdk
-
-from virtaal.common import GObjectWrapper
-from virtaal.views.baseview import BaseView
+from gi.repository import GObject
+from gi.repository import Gdk
+from gi.repository import Gtk
 
 from tmwidgets import *
+from virtaal.common import GObjectWrapper
+from virtaal.views.baseview import BaseView
 
 
 class TMView(BaseView, GObjectWrapper):
@@ -35,7 +33,7 @@ class TMView(BaseView, GObjectWrapper):
 
     __gtype_name__ = 'TMView'
     __gsignals__ = {
-        'tm-match-selected': (gobject.SIGNAL_RUN_FIRST, gobject.TYPE_NONE, (gobject.TYPE_PYOBJECT,)),
+        'tm-match-selected': (GObject.SignalFlags.RUN_FIRST, None, (GObject.TYPE_PYOBJECT,)),
     }
 
     # INITIALIZERS #
@@ -87,16 +85,16 @@ class TMView(BaseView, GObjectWrapper):
     def _setup_key_bindings(self):
         """Setup Gtk+ key bindings (accelerators)."""
 
-        gtk.accel_map_add_entry("<Virtaal>/TM/Hide TM", gtk.keysyms.Escape, 0)
+        Gtk.AccelMap.add_entry("<Virtaal>/TM/Hide TM", Gdk.KEY_Escape, 0)
 
-        self.accel_group = gtk.AccelGroup()
+        self.accel_group = Gtk.AccelGroup()
         self.accel_group.connect_by_path("<Virtaal>/TM/Hide TM", self._on_hide_tm)
 
         # Connect Ctrl+n (1 <= n <= 9) to select match n.
         for i in range(1, 10):
             numstr = str(i)
-            numkey = gtk.keysyms._0 + i
-            gtk.accel_map_add_entry("<Virtaal>/TM/Select match " + numstr, numkey, gdk.CONTROL_MASK)
+            numkey = Gdk.KEY__0 + i
+            Gtk.AccelMap.add_entry("<Virtaal>/TM/Select match " + numstr, numkey, Gdk.ModifierType.CONTROL_MASK)
             self.accel_group.connect_by_path("<Virtaal>/TM/Select match " + numstr, self._on_select_match)
 
         mainview = self.controller.main_controller.view
@@ -108,11 +106,11 @@ class TMView(BaseView, GObjectWrapper):
         self.mnui_view = mainview.gui.get_object('menuitem_view')
         self.menu = self.mnui_view.get_submenu()
 
-        self.mnu_suggestions = gtk.CheckMenuItem(label=_('Translation _Suggestions'))
+        self.mnu_suggestions = Gtk.CheckMenuItem(label=_('Translation _Suggestions'))
         self.mnu_suggestions.show()
         self.menu.append(self.mnu_suggestions)
 
-        gtk.accel_map_add_entry("<Virtaal>/TM/Toggle Show TM", gtk.keysyms.F9, 0)
+        Gtk.AccelMap.add_entry("<Virtaal>/TM/Toggle Show TM", Gdk.KEY_F9, 0)
         accel_group = self.menu.get_accel_group()
         if accel_group is None:
             accel_group = self.accel_group
@@ -222,7 +220,7 @@ class TMView(BaseView, GObjectWrapper):
 
     def select_match_index(self, index):
         """Select the TM match with the given index (first match is 1).
-            This method causes a row in the TM window's C{gtk.TreeView} to be
+            This method causes a row in the TM window's C{Gtk.TreeView} to be
             selected and activated. This runs this class's C{_on_select_match()}
             method which runs C{select_match()}."""
         if index < 0 or not self.isvisible:
@@ -258,7 +256,8 @@ class TMView(BaseView, GObjectWrapper):
             selected = self._get_selected_unit_view()
             if selected:
                 self.tmwindow.update_geometry(selected)
-        gobject.idle_add(update)
+
+        GObject.idle_add(update)
 
     def _get_selected_unit_view(self):
         n = self.controller.main_controller.unit_controller.view.focused_target_n
@@ -309,7 +308,7 @@ class TMView(BaseView, GObjectWrapper):
         self.select_match(match_data)
 
     def _on_select_match(self, accel_group, acceleratable, keyval, modifier):
-        self.select_match_index(int(keyval - gtk.keysyms._0))
+        self.select_match_index(int(keyval - Gdk.KEY__0))
 
     def _on_store_closed(self, storecontroller):
         self.hide()

--- a/virtaal/plugins/tm/tmview.py
+++ b/virtaal/plugins/tm/tmview.py
@@ -307,7 +307,7 @@ class TMView(BaseView, GObjectWrapper):
         self.select_match(match_data)
 
     def _on_select_match(self, accel_group, acceleratable, keyval, modifier):
-        self.select_match_index(int(keyval - Gdk.KEY__0))
+        self.select_match_index(int(keyval - Gdk.KEY_0))
 
     def _on_store_closed(self, storecontroller):
         self.hide()

--- a/virtaal/plugins/tm/tmview.py
+++ b/virtaal/plugins/tm/tmview.py
@@ -19,9 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-from gi.repository import GObject
 from gi.repository import Gdk
-from gi.repository import Gtk
 
 from tmwidgets import *
 from virtaal.common import GObjectWrapper
@@ -93,7 +91,7 @@ class TMView(BaseView, GObjectWrapper):
         # Connect Ctrl+n (1 <= n <= 9) to select match n.
         for i in range(1, 10):
             numstr = str(i)
-            numkey = Gdk.KEY__0 + i
+            numkey = Gdk.KEY_0 + i
             Gtk.AccelMap.add_entry("<Virtaal>/TM/Select match " + numstr, numkey, Gdk.ModifierType.CONTROL_MASK)
             self.accel_group.connect_by_path("<Virtaal>/TM/Select match " + numstr, self._on_select_match)
 

--- a/virtaal/plugins/tm/tmview.py
+++ b/virtaal/plugins/tm/tmview.py
@@ -18,12 +18,13 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import, print_function, unicode_literals
 
 from gi.repository import Gdk
 
-from tmwidgets import *
 from virtaal.common import GObjectWrapper
 from virtaal.views.baseview import BaseView
+from .tmwidgets import *
 
 
 class TMView(BaseView, GObjectWrapper):
@@ -183,7 +184,7 @@ class TMView(BaseView, GObjectWrapper):
                 continue
             try:
                 info = plugin_controller.get_plugin_info(plugin_name)
-            except Exception, e:
+            except Exception as e:
                 logging.debug('Problem getting information for plugin %s' % plugin_name)
                 continue
             enabled = plugin_name in plugin_controller.plugins

--- a/virtaal/plugins/tm/tmview.py
+++ b/virtaal/plugins/tm/tmview.py
@@ -105,7 +105,7 @@ class TMView(BaseView, GObjectWrapper):
         self.mnui_view = mainview.gui.get_object('menuitem_view')
         self.menu = self.mnui_view.get_submenu()
 
-        self.mnu_suggestions = Gtk.CheckMenuItem(label=_('Translation _Suggestions'))
+        self.mnu_suggestions = Gtk.CheckMenuItem.new_with_mnemonic(label=_('Translation _Suggestions'))
         self.mnu_suggestions.show()
         self.menu.append(self.mnu_suggestions)
 

--- a/virtaal/plugins/tm/tmwidgets.py
+++ b/virtaal/plugins/tm/tmwidgets.py
@@ -18,6 +18,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
+import logging
+
 from gi.repository import GObject
 from gi.repository import Gtk
 from gi.repository import Pango

--- a/virtaal/plugins/tm/tmwidgets.py
+++ b/virtaal/plugins/tm/tmwidgets.py
@@ -18,22 +18,21 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-import gobject
-import gtk
-import logging
-import pango
+from gi.repository import GObject
+from gi.repository import Gtk
+from gi.repository import Pango
 
 from virtaal.views import markup, rendering
 
 
-class TMWindow(gtk.Window):
+class TMWindow(Gtk.Window):
     """Constructs the main TM window and all its children."""
 
     MAX_HEIGHT = 300
 
     # INITIALIZERS #
     def __init__(self, view):
-        super(TMWindow, self).__init__(gtk.WINDOW_POPUP)
+        super(TMWindow, self).__init__(Gtk.WindowType.POPUP)
         self.view = view
 
         self.set_has_frame(True)
@@ -41,9 +40,9 @@ class TMWindow(gtk.Window):
         self._build_gui()
 
     def _build_gui(self):
-        self.scrolled_window = gtk.ScrolledWindow()
-        self.scrolled_window.set_policy(gtk.POLICY_NEVER, gtk.POLICY_AUTOMATIC)
-        self.scrolled_window.set_shadow_type(gtk.SHADOW_IN)
+        self.scrolled_window = Gtk.ScrolledWindow()
+        self.scrolled_window.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+        self.scrolled_window.set_shadow_type(Gtk.ShadowType.IN)
 
         self.treeview = self._create_treeview()
 
@@ -51,22 +50,22 @@ class TMWindow(gtk.Window):
         self.add(self.scrolled_window)
 
     def _create_treeview(self):
-        self.liststore = gtk.ListStore(gobject.TYPE_PYOBJECT, gobject.TYPE_STRING)
-        treeview = gtk.TreeView(model=self.liststore)
+        self.liststore = Gtk.ListStore(GObject.TYPE_PYOBJECT, GObject.TYPE_STRING)
+        treeview = Gtk.TreeView(model=self.liststore)
         treeview.set_rules_hint(False)
         treeview.set_headers_visible(False)
 
-        self.perc_renderer = gtk.CellRendererProgress()
+        self.perc_renderer = Gtk.CellRendererProgress()
         self.match_renderer = TMMatchRenderer(self.view)
         self.tm_source_renderer = TMSourceColRenderer(self.view)
 
         # l10n: match quality column label
-        self.tvc_perc = gtk.TreeViewColumn(_('%'), self.perc_renderer)
+        self.tvc_perc = Gtk.TreeViewColumn(_('%'), self.perc_renderer)
         self.tvc_perc.set_cell_data_func(self.perc_renderer, self._percent_data_func)
-        self.tvc_match = gtk.TreeViewColumn(_('Matches'), self.match_renderer, matchdata=0)
-        self.tvc_match.set_sizing(gtk.TREE_VIEW_COLUMN_AUTOSIZE)
-        self.tvc_tm_source = gtk.TreeViewColumn(_('TM Source'), self.tm_source_renderer, matchdata=0)
-        self.tvc_tm_source.set_sizing(gtk.TREE_VIEW_COLUMN_AUTOSIZE)
+        self.tvc_match = Gtk.TreeViewColumn(_('Matches'), self.match_renderer, matchdata=0)
+        self.tvc_match.set_sizing(Gtk.TreeViewColumnSizing.AUTOSIZE)
+        self.tvc_tm_source = Gtk.TreeViewColumn(_('TM Source'), self.tm_source_renderer, matchdata=0)
+        self.tvc_tm_source.set_sizing(Gtk.TreeViewColumnSizing.AUTOSIZE)
 
         treeview.append_column(self.tvc_perc)
         treeview.append_column(self.tvc_match)
@@ -98,7 +97,7 @@ class TMWindow(gtk.Window):
             return
 
         widget_alloc = widget.parent.get_allocation()
-        gdkwin = widget.get_window(gtk.TEXT_WINDOW_WIDGET)
+        gdkwin = widget.get_window(Gtk.TextWindowType.WIDGET)
         if gdkwin is None:
             return
         vscrollbar = self.scrolled_window.get_vscrollbar()
@@ -106,7 +105,7 @@ class TMWindow(gtk.Window):
 
         x, y = gdkwin.get_origin()
 
-        if widget.get_direction() == gtk.TEXT_DIR_LTR:
+        if widget.get_direction() == Gtk.TextDirection.LTR:
             x -= self.tvc_perc.get_width()
         else:
             x -= self.tvc_tm_source.get_width() + scrollbar_width
@@ -138,7 +137,7 @@ class TMWindow(gtk.Window):
             cell_renderer.set_property('text', _("%(match_quality)s%%") % \
                     {"match_quality": quality})
             return
-        elif gtk.gtk_version < (2,16,0):
+        elif Gtk.gtk_version < (2, 16, 0):
             # Rendering bug with some older versions of GTK if a progress is at
             # 0%. GNOME bug 567253.
             cell_renderer.set_property('value', 3)
@@ -148,7 +147,7 @@ class TMWindow(gtk.Window):
         cell_renderer.set_property('text', _(u"?"))
 
 
-class TMSourceColRenderer(gtk.GenericCellRenderer):
+class TMSourceColRenderer(Gtk.GenericCellRenderer):
     """
     Renders the TM source for the row.
     """
@@ -156,10 +155,10 @@ class TMSourceColRenderer(gtk.GenericCellRenderer):
     __gtype_name__ = "TMSourceColRenderer"
     __gproperties__ = {
         "matchdata": (
-            gobject.TYPE_PYOBJECT,
+            GObject.TYPE_PYOBJECT,
             "The match data.",
             "The match data that this renderer is currently handling",
-            gobject.PARAM_READWRITE
+            GObject.PARAM_READWRITE
         ),
     }
 
@@ -167,7 +166,7 @@ class TMSourceColRenderer(gtk.GenericCellRenderer):
 
     # INITIALIZERS #
     def __init__(self, view):
-        gtk.GenericCellRenderer.__init__(self)
+        GObject.GObject.__init__(self)
 
         self.view = view
         self.matchdata = None
@@ -178,9 +177,9 @@ class TMSourceColRenderer(gtk.GenericCellRenderer):
         if 'tmsource' not in self.matchdata:
             return 0, 0, 0, 0
 
-        label = gtk.Label()
+        label = Gtk.Label()
         label.set_markup(u'<small>%s</small>' % self.matchdata['tmsource'])
-        label.get_pango_context().set_base_gravity(pango.GRAVITY_AUTO)
+        label.get_pango_context().set_base_gravity(Pango.GRAVITY_AUTO)
         label.set_angle(270)
         size = label.size_request()
         return 0, 0, size[0], size[1] + self.YPAD*2
@@ -200,19 +199,19 @@ class TMSourceColRenderer(gtk.GenericCellRenderer):
         x = cell_area.x + x_offset
         y = cell_area.y + y_offset + self.YPAD
 
-        label = gtk.Label()
+        label = Gtk.Label()
         label.set_markup(u'<small>%s</small>' % self.matchdata['tmsource'])
-        label.get_pango_context().set_base_dir(pango.DIRECTION_TTB_LTR)
-        if widget.get_direction() == gtk.TEXT_DIR_RTL:
+        label.get_pango_context().set_base_dir(Pango.DIRECTION_TTB_LTR)
+        if widget.get_direction() == Gtk.TextDirection.RTL:
             label.set_angle(90)
         else:
             label.set_angle(270)
         label.set_alignment(0.5, 0.5)
-        widget.get_style().paint_layout(window, gtk.STATE_NORMAL, False,
-                cell_area, widget, '', x, y, label.get_layout())
+        widget.get_style().paint_layout(window, Gtk.StateType.NORMAL, False,
+                                        cell_area, widget, '', x, y, label.get_layout())
 
 
-class TMMatchRenderer(gtk.GenericCellRenderer):
+class TMMatchRenderer(Gtk.GenericCellRenderer):
     """
     Renders translation memory matches.
 
@@ -222,10 +221,10 @@ class TMMatchRenderer(gtk.GenericCellRenderer):
     __gtype_name__ = 'TMMatchRenderer'
     __gproperties__ = {
         "matchdata": (
-            gobject.TYPE_PYOBJECT,
+            GObject.TYPE_PYOBJECT,
             "The match data.",
             "The match data that this renderer is currently handling",
-            gobject.PARAM_READWRITE
+            GObject.PARAM_READWRITE
         ),
     }
 
@@ -239,7 +238,7 @@ class TMMatchRenderer(gtk.GenericCellRenderer):
 
     # INITIALIZERS #
     def __init__(self, view):
-        gtk.GenericCellRenderer.__init__(self)
+        GObject.GObject.__init__(self)
 
         self.view = view
         self.layout = None
@@ -273,8 +272,8 @@ class TMMatchRenderer(gtk.GenericCellRenderer):
         if not self.source_layout:
             # We do less for MT results
             target_y = cell_area.y
-            widget.get_style().paint_layout(window, gtk.STATE_NORMAL, False,
-                    cell_area, widget, '', x, target_y, self.target_layout)
+            widget.get_style().paint_layout(window, Gtk.StateType.NORMAL, False,
+                                            cell_area, widget, '', x, target_y, self.target_layout)
             return
 
         source_height = self.source_layout.get_pixel_size()[1]
@@ -283,12 +282,12 @@ class TMMatchRenderer(gtk.GenericCellRenderer):
 
         source_dx = target_dx = self.BOX_MARGIN
 
-        widget.get_style().paint_box(window, gtk.STATE_NORMAL, gtk.SHADOW_ETCHED_IN,
-                cell_area, widget, '', x, source_y-self.BOX_MARGIN, width-self.BOX_MARGIN, source_height+(self.LINE_SEPARATION/2))
-        widget.get_style().paint_layout(window, gtk.STATE_NORMAL, False,
-                cell_area, widget, '', x + source_dx, source_y, self.source_layout)
-        widget.get_style().paint_layout(window, gtk.STATE_NORMAL, False,
-                cell_area, widget, '', x + target_dx, target_y, self.target_layout)
+        widget.get_style().paint_box(window, Gtk.StateType.NORMAL, Gtk.ShadowType.ETCHED_IN,
+                                     cell_area, widget, '', x, source_y - self.BOX_MARGIN, width - self.BOX_MARGIN, source_height + (self.LINE_SEPARATION/2))
+        widget.get_style().paint_layout(window, Gtk.StateType.NORMAL, False,
+                                        cell_area, widget, '', x + source_dx, source_y, self.source_layout)
+        widget.get_style().paint_layout(window, Gtk.StateType.NORMAL, False,
+                                        cell_area, widget, '', x + target_dx, target_y, self.target_layout)
 
     # METHODS #
     def _compute_cell_height(self, widget, width):
@@ -324,14 +323,14 @@ class TMMatchRenderer(gtk.GenericCellRenderer):
         # We can't use widget.get_pango_context() because we'll end up
         # overwriting the language and font settings if we don't have a
         # new one
-        layout = pango.Layout(widget.create_pango_context())
+        layout = Pango.Layout(widget.create_pango_context())
         layout.set_font_description(font_description)
-        layout.set_wrap(pango.WRAP_WORD_CHAR)
-        layout.set_width(width * pango.SCALE)
+        layout.set_wrap(Pango.WrapMode.WORD_CHAR)
+        layout.set_width(width * Pango.SCALE)
         #XXX - plurals?
         layout.set_markup(markup.markuptext(text, diff_text=diff_text))
         # This makes no sense, but has the desired effect to align things correctly for
         # both LTR and RTL languages:
-        if widget.get_direction() == gtk.TEXT_DIR_RTL:
-            layout.set_alignment(pango.ALIGN_RIGHT)
+        if widget.get_direction() == Gtk.TextDirection.RTL:
+            layout.set_alignment(Pango.Alignment.RIGHT)
         return layout

--- a/virtaal/plugins/tm/tmwidgets.py
+++ b/virtaal/plugins/tm/tmwidgets.py
@@ -178,7 +178,7 @@ class TMSourceColRenderer(Gtk.CellRenderer):
 
 
     # INTERFACE METHODS #
-    def on_get_size(self, widget, cell_area):
+    def do_get_size(self, widget, cell_area):
         if 'tmsource' not in self.matchdata:
             return 0, 0, 0, 0
 
@@ -186,8 +186,8 @@ class TMSourceColRenderer(Gtk.CellRenderer):
         label.set_markup(u'<small>%s</small>' % self.matchdata['tmsource'])
         label.get_pango_context().set_base_gravity(Pango.Gravity.AUTO)
         label.set_angle(270)
-        size = label.size_request()
-        return 0, 0, size[0], size[1] + self.YPAD*2
+        size = label.get_layout().get_pixel_size()
+        return 0, 0, size.height, size.width + self.YPAD*2
 
     def do_get_property(self, pspec):
         return getattr(self, pspec.name)
@@ -195,7 +195,7 @@ class TMSourceColRenderer(Gtk.CellRenderer):
     def do_set_property(self, pspec, value):
         setattr(self, pspec.name, value)
 
-    def on_render(self, window, widget, _background_area, cell_area, _expose_area, _flags):
+    def do_render(self, window, widget, _background_area, cell_area, _flags):
         if 'tmsource' not in self.matchdata:
             return
         x_offset = 0
@@ -212,8 +212,9 @@ class TMSourceColRenderer(Gtk.CellRenderer):
         else:
             label.set_angle(270)
         label.set_alignment(0.5, 0.5)
-        widget.get_style().paint_layout(window, Gtk.StateType.NORMAL, False,
-                                        cell_area, widget, '', x, y, label.get_layout())
+        layout = label.get_layout()
+        size = layout.get_pixel_size()
+        Gtk.render_layout(widget.get_style_context(), window, x+size.height, y, layout)
 
 
 class TMMatchRenderer(Gtk.CellRenderer):

--- a/virtaal/plugins/tm/tmwidgets.py
+++ b/virtaal/plugins/tm/tmwidgets.py
@@ -125,12 +125,13 @@ class TMWindow(Gtk.Window):
         #logging.debug('TMWindow.update_geometry(%dx%d +%d+%d)' % (width, height, x, y))
         self.resize(width, height)
         self.scrolled_window.set_size_request(width, height)
-        self.window.move_resize(0,0, width,height)
-        self.window.get_toplevel().move_resize(x,y, width,height)
+        window = self.get_window()
+        window.move_resize(0,0, width,height)
+        window.get_toplevel().move_resize(x,y, width,height)
 
 
     # EVENT HANLDERS #
-    def _percent_data_func(self, column, cell_renderer, tree_model, iter):
+    def _percent_data_func(self, column, cell_renderer, tree_model, iter, user_data):
         match_data = tree_model.get_value(iter, 0)
         if match_data.get('quality', None) is not None:
             quality = int(match_data['quality'])
@@ -181,7 +182,7 @@ class TMSourceColRenderer(Gtk.CellRenderer):
 
         label = Gtk.Label()
         label.set_markup(u'<small>%s</small>' % self.matchdata['tmsource'])
-        label.get_pango_context().set_base_gravity(Pango.GRAVITY_AUTO)
+        label.get_pango_context().set_base_gravity(Pango.Gravity.AUTO)
         label.set_angle(270)
         size = label.size_request()
         return 0, 0, size[0], size[1] + self.YPAD*2
@@ -203,7 +204,7 @@ class TMSourceColRenderer(Gtk.CellRenderer):
 
         label = Gtk.Label()
         label.set_markup(u'<small>%s</small>' % self.matchdata['tmsource'])
-        label.get_pango_context().set_base_dir(Pango.DIRECTION_TTB_LTR)
+        label.get_pango_context().set_base_dir(Pango.Direction.TTB_LTR)
         if widget.get_direction() == Gtk.TextDirection.RTL:
             label.set_angle(90)
         else:

--- a/virtaal/plugins/tm/tmwidgets.py
+++ b/virtaal/plugins/tm/tmwidgets.py
@@ -35,7 +35,8 @@ class TMWindow(Gtk.Window):
         super(TMWindow, self).__init__(Gtk.WindowType.POPUP)
         self.view = view
 
-        self.set_has_frame(True)
+        # set_has_frame is the method of Gtk.Enter, not found on Gtk.Window
+        # self.set_has_frame(True)
 
         self._build_gui()
 
@@ -147,7 +148,7 @@ class TMWindow(Gtk.Window):
         cell_renderer.set_property('text', _(u"?"))
 
 
-class TMSourceColRenderer(Gtk.GenericCellRenderer):
+class TMSourceColRenderer(Gtk.CellRenderer):
     """
     Renders the TM source for the row.
     """
@@ -211,7 +212,7 @@ class TMSourceColRenderer(Gtk.GenericCellRenderer):
                                         cell_area, widget, '', x, y, label.get_layout())
 
 
-class TMMatchRenderer(Gtk.GenericCellRenderer):
+class TMMatchRenderer(Gtk.CellRenderer):
     """
     Renders translation memory matches.
 

--- a/virtaal/plugins/tm/tmwidgets.py
+++ b/virtaal/plugins/tm/tmwidgets.py
@@ -251,7 +251,7 @@ class TMMatchRenderer(Gtk.CellRenderer):
 
 
     # INTERFACE METHODS #
-    def on_get_size(self, widget, cell_area):
+    def do_get_size(self, widget, cell_area):
         width = self.view.get_target_width() - self.BOX_MARGIN
         height = self._compute_cell_height(widget, width)
         height = min(height, 600)
@@ -267,18 +267,19 @@ class TMMatchRenderer(Gtk.CellRenderer):
     def do_set_property(self, pspec, value):
         setattr(self, pspec.name, value)
 
-    def on_render(self, window, widget, _background_area, cell_area, _expose_area, _flags):
+    def do_render(self, window, widget, _background_area, cell_area, _flags):
         x_offset = 0
         y_offset = self.BOX_MARGIN
         width = cell_area.width
         height = self._compute_cell_height(widget, width)
+        style_context = widget.get_style_context()
 
         x = cell_area.x + x_offset
         if not self.source_layout:
             # We do less for MT results
             target_y = cell_area.y
-            widget.get_style().paint_layout(window, Gtk.StateType.NORMAL, False,
-                                            cell_area, widget, '', x, target_y, self.target_layout)
+            # x + source_dx?
+            Gtk.render_layout(style_context, window, x, target_y, self.target_layout)
             return
 
         source_height = self.source_layout.get_pixel_size()[1]
@@ -287,12 +288,12 @@ class TMMatchRenderer(Gtk.CellRenderer):
 
         source_dx = target_dx = self.BOX_MARGIN
 
-        widget.get_style().paint_box(window, Gtk.StateType.NORMAL, Gtk.ShadowType.ETCHED_IN,
-                                     cell_area, widget, '', x, source_y - self.BOX_MARGIN, width - self.BOX_MARGIN, source_height + (self.LINE_SEPARATION/2))
-        widget.get_style().paint_layout(window, Gtk.StateType.NORMAL, False,
-                                        cell_area, widget, '', x + source_dx, source_y, self.source_layout)
-        widget.get_style().paint_layout(window, Gtk.StateType.NORMAL, False,
-                                        cell_area, widget, '', x + target_dx, target_y, self.target_layout)
+        style_context.save()
+        style_context.add_class(Gtk.STYLE_CLASS_TROUGH)
+        Gtk.render_background(style_context, window, x, source_y - self.BOX_MARGIN, width, source_height + (self.LINE_SEPARATION/2))
+        Gtk.render_layout(style_context, window, x + source_dx, source_y, self.source_layout)
+        Gtk.render_layout(style_context, window, x + target_dx, target_y, self.target_layout)
+        style_context.restore()
 
     # METHODS #
     def _compute_cell_height(self, widget, width):

--- a/virtaal/plugins/tm/tmwidgets.py
+++ b/virtaal/plugins/tm/tmwidgets.py
@@ -97,14 +97,15 @@ class TMWindow(Gtk.Window):
         if not self.props.visible:
             return
 
-        widget_alloc = widget.parent.get_allocation()
+        widget_alloc = widget.get_parent().get_allocation()
         gdkwin = widget.get_window(Gtk.TextWindowType.WIDGET)
         if gdkwin is None:
             return
         vscrollbar = self.scrolled_window.get_vscrollbar()
         scrollbar_width = vscrollbar.props.visible and vscrollbar.get_allocation().width + 1 or 0
 
-        x, y = gdkwin.get_origin()
+        origin = gdkwin.get_origin()
+        x, y = origin.x, origin.y
 
         if widget.get_direction() == Gtk.TextDirection.LTR:
             x -= self.tvc_perc.get_width()

--- a/virtaal/plugins/tm/tmwidgets.py
+++ b/virtaal/plugins/tm/tmwidgets.py
@@ -167,7 +167,7 @@ class TMSourceColRenderer(Gtk.CellRenderer):
 
     # INITIALIZERS #
     def __init__(self, view):
-        GObject.GObject.__init__(self)
+        super(TMSourceColRenderer, self).__init__()
 
         self.view = view
         self.matchdata = None
@@ -239,7 +239,7 @@ class TMMatchRenderer(Gtk.CellRenderer):
 
     # INITIALIZERS #
     def __init__(self, view):
-        GObject.GObject.__init__(self)
+        super(TMMatchRenderer, self).__init__()
 
         self.view = view
         self.layout = None

--- a/virtaal/support/depcheck.py
+++ b/virtaal/support/depcheck.py
@@ -116,6 +116,6 @@ def check_dependencies(module_names=import_checks):
 if __name__ == '__main__':
     failed = check_dependencies()
     if not failed:
-        print 'All dependencies met.'
+        print('All dependencies met.')
     else:
-        print 'Dependencies not met: %s' % (', '.join(failed))
+        print('Dependencies not met: %s' % (', '.join(failed)))

--- a/virtaal/support/depcheck.py
+++ b/virtaal/support/depcheck.py
@@ -29,11 +29,13 @@ import_checks = ['translate', 'gtk', 'lxml.etree', 'json', 'pycurl', 'sqlite3', 
 #########################
 # Specific Module Tests #
 #########################
-MIN_GTK_VERSION = (2, 18, 0)
+MIN_GTK_VERSION = (3, 0, 0)
 def test_gtk_version():
     try:
+        import gi
+        gi.require_version('Gtk', '3.0')
         from gi.repository import Gtk
-        return Gtk.ver >= MIN_GTK_VERSION
+        return not Gtk.check_version(*MIN_GTK_VERSION)
         # GtkBuilder was in GTK+ earlier already, but at least this bug is
         # quite nasty:
         # https://bugzilla.gnome.org/show_bug.cgi?id=582025

--- a/virtaal/support/depcheck.py
+++ b/virtaal/support/depcheck.py
@@ -32,8 +32,8 @@ import_checks = ['translate', 'gtk', 'lxml.etree', 'json', 'pycurl', 'sqlite3', 
 MIN_GTK_VERSION = (2, 18, 0)
 def test_gtk_version():
     try:
-        import gtk
-        return gtk.ver >= MIN_GTK_VERSION
+        from gi.repository import Gtk
+        return Gtk.ver >= MIN_GTK_VERSION
         # GtkBuilder was in GTK+ earlier already, but at least this bug is
         # quite nasty:
         # https://bugzilla.gnome.org/show_bug.cgi?id=582025

--- a/virtaal/support/httpclient.py
+++ b/virtaal/support/httpclient.py
@@ -19,11 +19,12 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 import StringIO
-import urllib
 import logging
+import urllib
 
-import gobject
 import pycurl
+from gi.repository import GObject
+
 try:
     import libproxy
     proxy_factory = libproxy.ProxyFactory()
@@ -40,10 +41,10 @@ class HTTPRequest(GObjectWrapper):
 
     __gtype_name__ = 'HttpClientRequest'
     __gsignals__ = {
-        "http-success":      (gobject.SIGNAL_RUN_LAST, None, (object,)),
-        "http-redirect":     (gobject.SIGNAL_RUN_LAST, None, (object,)),
-        "http-client-error": (gobject.SIGNAL_RUN_LAST, None, (object,)),
-        "http-server-error": (gobject.SIGNAL_RUN_LAST, None, (object,)),
+        "http-success": (GObject.SignalFlags.RUN_LAST, None, (object,)),
+        "http-redirect": (GObject.SignalFlags.RUN_LAST, None, (object,)),
+        "http-client-error": (GObject.SignalFlags.RUN_LAST, None, (object,)),
+        "http-server-error": (GObject.SignalFlags.RUN_LAST, None, (object,)),
     }
 
     def __init__(self, url, method='GET', data=None, headers=None,
@@ -203,7 +204,7 @@ class HTTPClient(object):
     def run(self):
         """client should not be running when request queue is empty"""
         if self.running: return
-        gobject.timeout_add(100, self.perform)
+        GObject.timeout_add(100, self.perform)
         self.running = True
 
     def close_request(self, handle):

--- a/virtaal/support/httpclient.py
+++ b/virtaal/support/httpclient.py
@@ -22,7 +22,7 @@ import logging
 
 import pycurl
 from gi.repository import GObject
-from six import StringIO
+from six import BytesIO as StringIO
 from six.moves.urllib import request, parse
 
 try:

--- a/virtaal/support/httpclient.py
+++ b/virtaal/support/httpclient.py
@@ -100,6 +100,9 @@ class HTTPRequest(GObjectWrapper):
 
         if libproxy:
             for proxy in proxy_factory.getProxies(self.url):
+                # https://github.com/libproxy/libproxy/issues/65
+                if proxy.startswith("b'"):
+                    proxy = proxy[2:-1]
                 # if we connect to localhost (localtm) with proxy specifically
                 # set to direct://, libcurl connects fine, but then asks
                 #   GET http://localhost:55555/unit/en/af/whatever

--- a/virtaal/support/mosesclient.py
+++ b/virtaal/support/mosesclient.py
@@ -19,8 +19,8 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 import logging
-import xmlrpclib
 
+import xmlrpclib
 from gi.repository import GObject
 from translate.lang import data
 
@@ -107,12 +107,12 @@ class MosesClient(GObject.GObject, HTTPClient):
         """Does the loading of the XML-RPC response, but handles exceptions."""
         try:
             (data,), _fish = xmlrpclib.loads(response)
-        except xmlrpclib.Fault, exc:
+        except xmlrpclib.Fault as exc:
             if "Unknown translation system id" in exc.faultString:
                 self.set_multilang(False)
                 #TODO: consider redoing the request now that multilang is False
                 return None
-        except Exception, exc:
+        except Exception as exc:
             logging.debug('XML-RPC exception: %s' % (exc))
             return None
         return data

--- a/virtaal/support/mosesclient.py
+++ b/virtaal/support/mosesclient.py
@@ -66,7 +66,7 @@ class MosesClient(GObject.GObject, HTTPClient):
     }
 
     def __init__(self, url):
-        GObject.GObject.__init__(self)
+        super(MosesClient, self).__init__()
         HTTPClient.__init__(self)
 
         self.url = url + '/RPC2'

--- a/virtaal/support/mosesclient.py
+++ b/virtaal/support/mosesclient.py
@@ -27,7 +27,7 @@ from translate.lang import data
 from virtaal.support.httpclient import HTTPClient, HTTPRequest
 
 # Moses handles these characters as spaced out
-punc_symbols = ur'''.,?!:;'"“”‘’—)'''
+punc_symbols = '''.,?!:;'"“”‘’—)'''
 punc_tuples = [(c, u" %s" % c) for c in punc_symbols]
 
 

--- a/virtaal/support/mosesclient.py
+++ b/virtaal/support/mosesclient.py
@@ -18,10 +18,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-import gobject
 import logging
 import xmlrpclib
 
+from gi.repository import GObject
 from translate.lang import data
 
 from virtaal.support.httpclient import HTTPClient, HTTPRequest
@@ -56,17 +56,17 @@ def fixup(source, response):
     return response
 
 
-class MosesClient(gobject.GObject, HTTPClient):
+class MosesClient(GObject.GObject, HTTPClient):
     """A client to communicate with a moses XML RPC servers"""
 
     __gtype_name__ = 'MosesClient'
     __gsignals__ = {
-        'source-lang-changed': (gobject.SIGNAL_RUN_LAST, None, (str,)),
-        'target-lang-changed': (gobject.SIGNAL_RUN_LAST, None, (str,)),
+        'source-lang-changed': (GObject.SignalFlags.RUN_LAST, None, (str,)),
+        'target-lang-changed': (GObject.SignalFlags.RUN_LAST, None, (str,)),
     }
 
     def __init__(self, url):
-        gobject.GObject.__init__(self)
+        GObject.GObject.__init__(self)
         HTTPClient.__init__(self)
 
         self.url = url + '/RPC2'

--- a/virtaal/support/native_widgets.py
+++ b/virtaal/support/native_widgets.py
@@ -71,10 +71,10 @@ def _get_file_types():
     if _file_types:
         return _file_types
     from translate.storage import factory
-    from locale import strcoll
+    from locale import strxfrm
     all_supported_ext = []
     supported_files = []
-    _sorted = sorted(factory.supported_files(), cmp=strcoll, key=lambda x: x[0])
+    _sorted = sorted(factory.supported_files(), key=lambda x: strxfrm(x[0]))
     for name, extensions, mimetypes in _sorted:
         name = _(name)
         extension_filter = ["*.%s" % ext for ext in extensions]
@@ -233,9 +233,9 @@ def darwin_open_dialog(window, title, directory):
     from objc import NO
     from AppKit import NSOpenPanel
     from translate.storage import factory
-    from locale import strcoll
+    from locale import strxfrm
     file_types = []
-    _sorted = sorted(factory.supported_files(), cmp=strcoll, key=lambda x: x[0])
+    _sorted = sorted(factory.supported_files(), key=lambda x: strxfrm(x[0]))
     for name, extension, mimetype in _sorted:
         file_types.extend(extension)
     panel = NSOpenPanel.openPanel()

--- a/virtaal/support/native_widgets.py
+++ b/virtaal/support/native_widgets.py
@@ -48,7 +48,7 @@ def _dialog_to_use():
     elif os.environ.get('KDE_FULL_SESSION') == 'true' and ( \
                 pan_app.ui_language == 'en' or \
                 gettext.dgettext('kdelibs4', '') or \
-                not gettext.dgettext('gtk20', '')):
+                not gettext.dgettext('gtk30', '')):
             import distutils.spawn
             if distutils.spawn.find_executable("kdialog") is not None:
                 return 'kdialog'
@@ -150,7 +150,7 @@ def kdialog_save_dialog(window, title, current_filename):
         # confirm overwrite, since kdialog can't:
         args = [
             '--yesno',
-            #gettext.dgettext('gtk20.mo', 'A file named \"%s\" already exists.  Do you want to replace it?') % filename,
+            #gettext.dgettext('gtk30', 'A file named “%s” already exists.  Do you want to replace it?') % filename,
             gettext.dgettext('kdelibs4', 'A file named "%1" already exists. Are you sure you want to overwrite it?').replace('%1', '%s') % filename,
         ]
         (should_overwrite, _nothing) = _show_kdialog(window, "Overwrite", args)

--- a/virtaal/support/native_widgets.py
+++ b/virtaal/support/native_widgets.py
@@ -183,7 +183,7 @@ def win32_open_dialog(window, title, directory):
             CustomFilter=custom_filter,
             FilterIndex=1,              # Select the "All Supported Files"
         )
-    except pywintypes.error, e:
+    except pywintypes.error as e:
         if isinstance(e.args, tuple) and len(e.args) == 3:
             if e.args[0] == 0:
                 # cancel
@@ -215,7 +215,7 @@ def win32_save_dialog(window, title, current_filename):
             CustomFilter=custom_filter,
             FilterIndex=1,              # Select the relevant filter
         )
-    except pywintypes.error, e:
+    except pywintypes.error as e:
         if isinstance(e.args, tuple) and len(e.args) == 3:
             if e.args[0] == 0:
                 # cancel

--- a/virtaal/support/openmailto.py
+++ b/virtaal/support/openmailto.py
@@ -139,7 +139,6 @@ elif sys.platform == 'darwin':
 else:
 
     import subprocess
-    # @WARNING: use the private API of the webbrowser module (._iscommand)
     import webbrowser
 
     class KfmClient(Controller):
@@ -195,11 +194,12 @@ else:
 
 
     def register_X_controllers():
-        if webbrowser._iscommand('kfmclient'):
+        from distutils.spawn import find_executable
+        if find_executable('kfmclient'):
             _controllers['kde-open'] = KfmClient()
 
         for command in ('gnome-open', 'exo-open', 'xdg-open'):
-            if webbrowser._iscommand(command):
+            if find_executable(command):
                 _controllers[command] = Controller(command)
 
     def get():

--- a/virtaal/support/openmailto.py
+++ b/virtaal/support/openmailto.py
@@ -145,21 +145,6 @@ else:
 
         def __init__(self, kfmclient='kfmclient'):
             super(KfmClient, self).__init__(kfmclient, 'exec')
-            self.kde_version = self.detect_kde_version()
-
-        def detect_kde_version(self):
-            kde_version = None
-            try:
-                info = subprocess.check_output(['kde-config', '--version'], encoding='utf-8')
-
-                for line in info.splitlines():
-                    if line.startswith('KDE'):
-                        kde_version = line.split(':')[-1].strip()
-                        break
-            except (OSError, RuntimeError):
-                pass
-
-            return kde_version
 
 
     def detect_desktop_environment():

--- a/virtaal/support/openmailto.py
+++ b/virtaal/support/openmailto.py
@@ -215,7 +215,7 @@ else:
             return _controllers[controller_name].open
 
         except KeyError:
-            if _controllers.has_key('xdg-open'):
+            if 'xdg-open' in _controllers:
                 return _controllers['xdg-open'].open
             else:
                 return webbrowser.open
@@ -265,7 +265,7 @@ def mailto_format(**kwargs):
     kwargs = _fix_addersses(**kwargs)
     parts = []
     for headername in ('to', 'cc', 'bcc', 'subject', 'body', 'attach'):
-        if kwargs.has_key(headername):
+        if headername in kwargs:
             headervalue = kwargs[headername]
             if not headervalue:
                 continue

--- a/virtaal/support/openmailto.py
+++ b/virtaal/support/openmailto.py
@@ -36,6 +36,7 @@ import sys
 import logging
 
 from six import string_types
+
 # Some imports are only necessary on some platforms, and are postponed to try
 # to speed up startup
 
@@ -137,7 +138,7 @@ elif sys.platform == 'darwin':
 else:
 
     import subprocess
-    import webbrowser
+    import shutil
 
     class KfmClient(Controller):
         '''Controller for the KDE kfmclient program.'''
@@ -187,12 +188,11 @@ else:
 
 
     def register_X_controllers():
-        from distutils.spawn import find_executable
-        if find_executable('kfmclient'):
+        if shutil.which('kfmclient'):
             _controllers['kde-open'] = KfmClient()
 
         for command in ('gnome-open', 'exo-open', 'xdg-open'):
-            if find_executable(command):
+            if shutil.which(command):
                 _controllers[command] = Controller(command)
 
     def get():
@@ -212,6 +212,7 @@ else:
             if 'xdg-open' in _controllers:
                 return _controllers['xdg-open'].open
             else:
+                import webbrowser
                 return webbrowser.open
 
 

--- a/virtaal/support/openmailto.py
+++ b/virtaal/support/openmailto.py
@@ -34,6 +34,7 @@ __all__ = ['open', 'mailto']
 import os
 import sys
 import logging
+
 from six import string_types
 # Some imports are only necessary on some platforms, and are postponed to try
 # to speed up startup
@@ -72,7 +73,7 @@ class Controller(BaseController):
 
         if (os.environ.get('DISPLAY') or sys.platform[:3] == 'win' or
                                                     sys.platform == 'darwin'):
-            inout = file(os.devnull, 'r+')
+            inout = subprocess.DEVNULL
         else:
             # for TTY programs, we need stdin/out
             inout = None

--- a/virtaal/support/openmailto.py
+++ b/virtaal/support/openmailto.py
@@ -34,6 +34,7 @@ __all__ = ['open', 'mailto']
 import os
 import sys
 import logging
+from six import string_types
 # Some imports are only necessary on some platforms, and are postponed to try
 # to speed up startup
 
@@ -96,7 +97,7 @@ class Controller(BaseController):
         return not returncode
 
     def open(self, filename):
-        if isinstance(filename, basestring):
+        if isinstance(filename, string_types):
             cmdline = self.args + [filename]
         else:
             # assume it is a sequence
@@ -136,7 +137,7 @@ elif sys.platform == 'darwin':
 # Platform support for Unix
 else:
 
-    import commands
+    import subprocess
     # @WARNING: use the private API of the webbrowser module (._iscommand)
     import webbrowser
 
@@ -150,7 +151,7 @@ else:
         def detect_kde_version(self):
             kde_version = None
             try:
-                info = commands.getoutput('kde-config --version')
+                info = subprocess.check_output(['kde-config', '--version'], encoding='utf-8')
 
                 for line in info.splitlines():
                     if line.startswith('KDE'):
@@ -183,7 +184,7 @@ else:
             desktop_environment = 'gnome'
         else:
             try:
-                info = commands.getoutput('xprop -root _DT_SAVE_MODE')
+                info = subprocess.check_output(['xprop','-root', '_DT_SAVE_MODE'], encoding="utf-8")
                 if ' = "xfce4"' in info:
                     desktop_environment = 'xfce'
             except (OSError, RuntimeError):
@@ -238,7 +239,7 @@ def _fix_addersses(**kwargs):
             if not headervalue:
                 del kwargs[headername]
                 continue
-            elif not isinstance(headervalue, basestring):
+            elif not isinstance(headervalue, string_types):
                 # assume it is a sequence
                 headervalue = ','.join(headervalue)
 

--- a/virtaal/support/openmailto.py
+++ b/virtaal/support/openmailto.py
@@ -93,8 +93,6 @@ class Controller(BaseController):
         # exo-open, xdg-open and open for OSX) immediately exit after lauching
         # the specific application
         returncode = pipe.wait()
-        if hasattr(self, 'fixreturncode'):
-            returncode = self.fixreturncode(returncode)
         return not returncode
 
     def open(self, filename):
@@ -162,11 +160,6 @@ else:
 
             return kde_version
 
-        def fixreturncode(self, returncode):
-            if returncode is not None and self.kde_version > '3.5.4':
-                return returncode
-            else:
-                return os.EX_OK
 
     def detect_desktop_environment():
         '''Checks for known desktop environments

--- a/virtaal/support/opentranclient.py
+++ b/virtaal/support/opentranclient.py
@@ -137,7 +137,7 @@ class OpenTranClient(GObject.GObject, HTTPClient):
         """Does the loading of the JSON response, but handles exceptions."""
         try:
             data = json.loads(response)
-        except Exception, exc:
+        except Exception as exc:
             logging.debug('JSON exception: %s' % (exc))
             return None
         return data

--- a/virtaal/support/opentranclient.py
+++ b/virtaal/support/opentranclient.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2008-2011 Zuza Software Foundation
+#
+# This file is part of Virtaal.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+
+import logging
+
+from gi.repository import GObject
+
+# These two json modules are API compatible
+try:
+    import simplejson as json #should be a bit faster; needed for Python < 2.6
+except ImportError:
+    import json #available since Python 2.6
+
+from translate.lang import data
+from translate.search.lshtein import LevenshteinComparer
+
+from virtaal.support.httpclient import HTTPClient, RESTRequest
+
+
+class OpenTranClient(GObject.GObject, HTTPClient):
+    """CRUD operations for TM units and stores"""
+
+    __gtype_name__ = 'OpenTranClient'
+    __gsignals__ = {
+        'source-lang-changed': (GObject.SignalFlags.RUN_LAST, None, (str,)),
+        'target-lang-changed': (GObject.SignalFlags.RUN_LAST, None, (str,)),
+    }
+
+    def __init__(self, max_candidates=3, min_similarity=75, max_length=1000):
+        GObject.GObject.__init__(self)
+        HTTPClient.__init__(self)
+
+        self.max_candidates = max_candidates
+        self.min_similarity = min_similarity
+        self.comparer = LevenshteinComparer(max_length)
+        self.last_suggestions = []  # used by the open-tran terminology backend
+
+        self._languages = set()
+
+        self.source_lang = None
+        self.target_lang = None
+        #detect supported language
+
+        self.url_getlanguages = 'http://open-tran.eu/json/supported'
+        self.url_translate = 'http://%s.%s.open-tran.eu/json/suggest'
+        langreq = RESTRequest(self.url_getlanguages, id='')
+        self.add(langreq)
+        langreq.connect(
+            'http-success',
+            lambda langreq, response: self.got_languages(response)
+        )
+
+    def got_languages(self, val):
+        """Handle the response from the web service to set up language pairs."""
+        data = self._loads_safe(val)
+        self._languages = set(data)
+        self.set_source_lang(self.source_lang)
+        self.set_target_lang(self.target_lang)
+
+    def translate_unit(self, unit_source, callback=None):
+        if self.source_lang is None or self.target_lang is None:
+            return
+
+        if not self._languages:
+            # for some reason we don't (yet) have supported languages
+            return
+
+        query_str = unit_source
+        request = RESTRequest(self.url_translate % (self.source_lang, self.target_lang), id=query_str)
+        self.add(request)
+        def call_callback(request, response):
+            return callback(
+                request, request.id, self.format_suggestions(request.id, response)
+            )
+
+        if callback:
+            request.connect("http-success", call_callback)
+
+    def set_source_lang(self, language):
+        language = language.lower().replace('-', '_').replace('@', '_')
+        if not self._languages:
+            # for some reason we don't (yet) have supported languages
+            self.source_lang = language
+            # we'll redo this once we have languages
+            return
+
+        if language in self._languages:
+            self.source_lang = language
+            logging.debug("source language %s supported" % language)
+            self.emit('source-lang-changed', self.source_lang)
+        else:
+            lang = data.simplercode(language)
+            if lang:
+                self.set_source_lang(lang)
+            else:
+                self.source_lang = None
+                logging.debug("source language %s not supported" % language)
+
+    def set_target_lang(self, language):
+        language = language.lower().replace('-', '_').replace('@', '_')
+        if not self._languages:
+            # for some reason we don't (yet) have supported languages
+            self.target_lang = language
+            # we'll redo this once we have languages
+            return
+
+        if language in self._languages:
+            self.target_lang = language
+            logging.debug("target language %s supported" % language)
+            self.emit('target-lang-changed', self.target_lang)
+        else:
+            lang = data.simplercode(language)
+            if lang:
+                self.set_target_lang(lang)
+            else:
+                self.target_lang = None
+                logging.debug("target language %s not supported" % language)
+
+    def _loads_safe(self, response):
+        """Does the loading of the JSON response, but handles exceptions."""
+        try:
+            data = json.loads(response)
+        except Exception, exc:
+            logging.debug('JSON exception: %s' % (exc))
+            return None
+        return data
+
+    def format_suggestions(self, id, response):
+        """clean up open tran suggestion and use the same format as tmserver"""
+        suggestions = self._loads_safe(response)
+        if not suggestions:
+            return []
+        id = data.forceunicode(id)
+        self.last_suggestions.extend(suggestions)  # we keep it for the terminology back-end
+        results = []
+        for suggestion in suggestions:
+            #check for fuzzyness at the 'flag' member:
+            for project in suggestion['projects']:
+                if project['flags'] == 0:
+                    break
+            else:
+                continue
+            result = {}
+            result['target'] = data.forceunicode(suggestion['text'])
+            result['tmsource'] = suggestion['projects'][0]['name']
+            result['source'] = data.forceunicode(suggestion['projects'][0]['orig_phrase'])
+            #open-tran often gives too many results with many which can't really be
+            #considered to be suitable for translation memory
+            result['quality'] = self.comparer.similarity(id, result['source'], self.min_similarity)
+            if result['quality'] >= self.min_similarity:
+                results.append(result)
+        results.sort(key=lambda match: match['quality'], reverse=True)
+        results = results[:self.max_candidates]
+        return results

--- a/virtaal/support/set_enumerator.py
+++ b/virtaal/support/set_enumerator.py
@@ -40,7 +40,10 @@ class UnionSetEnumerator(GObject.GObject):
 
         if len(sets) > 0:
             self.sets = sets
-            self.set = reduce(lambda big_set, set: big_set.union(set), sets[1:], sets[0])
+            self.set = sets[0]
+            for set_ in sets[1:]:
+                # not nice, but hopefully correct for now
+                self.set = self.set.union(set_)
         else:
             self.sets = [SortedSet([])]
             self.set = SortedSet([])

--- a/virtaal/support/set_enumerator.py
+++ b/virtaal/support/set_enumerator.py
@@ -18,24 +18,25 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-import gobject
 from bisect import bisect_left
+
+from gi.repository import GObject
 
 from virtaal.support.sorted_set import SortedSet
 
 
 # FIXME: Add docstrings!
 
-class UnionSetEnumerator(gobject.GObject):
+class UnionSetEnumerator(GObject.GObject):
     __gtype_name__ = "UnionSetEnumerator"
 
     __gsignals__ = {
-        "remove": (gobject.SIGNAL_RUN_FIRST, gobject.TYPE_NONE, (gobject.TYPE_INT, gobject.TYPE_PYOBJECT)),
-        "add":    (gobject.SIGNAL_RUN_FIRST, gobject.TYPE_NONE, (gobject.TYPE_INT, gobject.TYPE_PYOBJECT))
+        "remove": (GObject.SignalFlags.RUN_FIRST, None, (GObject.TYPE_INT, GObject.TYPE_PYOBJECT)),
+        "add": (GObject.SignalFlags.RUN_FIRST, None, (GObject.TYPE_INT, GObject.TYPE_PYOBJECT))
     }
 
     def __init__(self, *sets):
-        gobject.GObject.__init__(self)
+        GObject.GObject.__init__(self)
 
         if len(sets) > 0:
             self.sets = sets

--- a/virtaal/support/simplegeneric.py
+++ b/virtaal/support/simplegeneric.py
@@ -19,10 +19,11 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
-
+from __future__ import absolute_import, print_function, unicode_literals
 __all__ = ["generic"]
 
-from types import ClassType, InstanceType
+from six import class_types as ClassType
+from types import FunctionType
 classtypes = type, ClassType
 
 
@@ -40,7 +41,7 @@ def generic(func):
         else:
             return func(*args, **kw)
 
-    _by_type = {object: func, InstanceType: _by_class}
+    _by_type = {object: func, FunctionType: _by_class}
     _gbt = _by_type.get
 
     def when_type(t):

--- a/virtaal/support/sorted_set.py
+++ b/virtaal/support/sorted_set.py
@@ -121,8 +121,8 @@ class SortedSet(GObject.GObject):
         return other.data
     _getotherdata = staticmethod(_getotherdata)
 
-    def __cmp__(self, other, cmp=cmp):
-        return cmp(self.data, SortedSet._getotherdata(other))
+    def __gt__(self, other):
+        return self.data > SortedSet._getotherdata(other)
 
     def union(self, other, find=bisect_left):
         i = j = 0

--- a/virtaal/support/sorted_set.py
+++ b/virtaal/support/sorted_set.py
@@ -63,21 +63,21 @@ ToDo:
 
 from bisect import bisect_left
 
-import gobject
+from gi.repository import GObject
 
 
-class SortedSet(gobject.GObject):
+class SortedSet(GObject.GObject):
     __gtype_name__ = "SortedSet"
 
     __gsignals__ = {
-        "removed":       (gobject.SIGNAL_RUN_FIRST, gobject.TYPE_NONE, (gobject.TYPE_INT, gobject.TYPE_PYOBJECT)),
-        "added":         (gobject.SIGNAL_RUN_FIRST, gobject.TYPE_NONE, (gobject.TYPE_INT, gobject.TYPE_PYOBJECT)),
-        "before-remove": (gobject.SIGNAL_RUN_FIRST, gobject.TYPE_NONE, (gobject.TYPE_INT, gobject.TYPE_PYOBJECT)),
-        "before-add":    (gobject.SIGNAL_RUN_FIRST, gobject.TYPE_NONE, (gobject.TYPE_INT, gobject.TYPE_PYOBJECT))
+        "removed": (GObject.SignalFlags.RUN_FIRST, None, (GObject.TYPE_INT, GObject.TYPE_PYOBJECT)),
+        "added": (GObject.SignalFlags.RUN_FIRST, None, (GObject.TYPE_INT, GObject.TYPE_PYOBJECT)),
+        "before-remove": (GObject.SignalFlags.RUN_FIRST, None, (GObject.TYPE_INT, GObject.TYPE_PYOBJECT)),
+        "before-add": (GObject.SignalFlags.RUN_FIRST, None, (GObject.TYPE_INT, GObject.TYPE_PYOBJECT))
     }
 
     def __init__(self, iterable):
-        gobject.GObject.__init__(self)
+        GObject.GObject.__init__(self)
 
         data = list(iterable)
         data.sort()

--- a/virtaal/support/thread.py
+++ b/virtaal/support/thread.py
@@ -19,9 +19,10 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 
-import gtk
-import threading
 import Queue
+import threading
+
+from gi.repository import Gtk
 
 
 def run_in_thread(widget, target, args):
@@ -39,7 +40,7 @@ def run_in_thread(widget, target, args):
     import time
     while thread.isAlive():
         # let gtk process events while target is still running
-        gtk.main_iteration(block=False)
+        Gtk.main_iteration(block=False)
         # Since we are not blocking, we're spinning, which isn't nice. We could
         # set block=True, but then the window might stay insensitive when the
         # thread finished, and only exit this loop when it gets another event

--- a/virtaal/support/thread.py
+++ b/virtaal/support/thread.py
@@ -19,7 +19,7 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 
-import Queue
+from six.moves import queue
 import threading
 
 from gi.repository import Gtk
@@ -27,7 +27,7 @@ from gi.repository import Gtk
 
 def run_in_thread(widget, target, args):
     # Idea from tortoisehg's gtklib.py
-    q = Queue.Queue()
+    q = queue.Queue()
     def func(*kwargs):
         q.put(target(*kwargs))
 

--- a/virtaal/test/test_scaffolding.py
+++ b/virtaal/test/test_scaffolding.py
@@ -77,7 +77,7 @@ msgid "PROFILE"
 msgstr "PROFIEL"
 """
         self.testfile = tempfile.mkstemp(suffix='.po', prefix='test_storemodel')
-        os.write(self.testfile[0], po_contents)
+        os.write(self.testfile[0], po_contents.encode('UTF-8'))
         os.close(self.testfile[0])
         self.trans_store = factory.getobject(self.testfile[1])
 

--- a/virtaal/test/test_unitcontroller.py
+++ b/virtaal/test/test_unitcontroller.py
@@ -32,11 +32,11 @@ class TestUnitController(TestScaffolding):
         test_unit = self.trans_store.getunits()[1]
         view = self.unit_controller.load_unit(test_unit)
 
-        assert unicode(self.unit_controller.view.targets[0].elem) == self.trans_store.getunits()[1].target
+        assert str(self.unit_controller.view.targets[0].elem) == self.trans_store.getunits()[1].target
 
     def test_set_target(self):
         test_unit = self.trans_store.getunits()[1]
         view = self.unit_controller.load_unit(test_unit)
 
         self.unit_controller.set_unit_target(0, [u'Test',])
-        assert unicode(self.unit_controller.view.targets[0].elem) == u'Test'
+        assert str(self.unit_controller.view.targets[0].elem) == u'Test'

--- a/virtaal/views/baseview.py
+++ b/virtaal/views/baseview.py
@@ -19,10 +19,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-from gtk import Builder
+from gi.repository.Gtk import Builder
 
 from virtaal.common import pan_app
-
 
 #cache builders so that we don't parse files repeatedly
 _builders = {}

--- a/virtaal/views/checksprojview.py
+++ b/virtaal/views/checksprojview.py
@@ -19,11 +19,11 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 import locale
-import gtk
 
-from virtaal.views.widgets.popupmenubutton import PopupMenuButton
+from gi.repository import Gtk
 
 from baseview import BaseView
+from virtaal.views.widgets.popupmenubutton import PopupMenuButton
 
 
 class ChecksProjectView(BaseView):
@@ -37,13 +37,13 @@ class ChecksProjectView(BaseView):
 
     def _create_project_button(self):
         self.btn_proj = PopupMenuButton(label=_('Project Type'))
-        menu = gtk.Menu()
+        menu = Gtk.Menu()
         names = []
         for checkercode in self.controller.checker_info:
             checkername = self.controller._checker_code_to_name[checkercode]
             names.append(checkername)
         for checkername in sorted(names, cmp=locale.strcoll):
-            mitem = gtk.MenuItem(checkername)
+            mitem = Gtk.MenuItem(checkername)
             mitem.show()
             mitem.connect('activate', self._on_menu_item_activate)
             menu.append(mitem)
@@ -57,7 +57,7 @@ class ChecksProjectView(BaseView):
         for child in statusbar.get_children():
             if child is self.btn_proj:
                 return
-        statusbar.pack_start(self.btn_proj, expand=False)
+        statusbar.pack_start(self.btn_proj, False, True, 0)
         statusbar.show_all()
 
     def set_checker_name(self, cname):
@@ -67,4 +67,4 @@ class ChecksProjectView(BaseView):
 
     # EVENT HANDLER #
     def _on_menu_item_activate(self, menuitem):
-        self.controller.set_checker_by_name(menuitem.child.get_label())
+        self.controller.set_checker_by_name(menuitem.get_child().get_label())

--- a/virtaal/views/checksprojview.py
+++ b/virtaal/views/checksprojview.py
@@ -17,13 +17,12 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
-
-import locale
+from __future__ import absolute_import, print_function, unicode_literals
 
 from gi.repository import Gtk
 
-from baseview import BaseView
 from virtaal.views.widgets.popupmenubutton import PopupMenuButton
+from .baseview import BaseView
 
 
 class ChecksProjectView(BaseView):
@@ -42,7 +41,7 @@ class ChecksProjectView(BaseView):
         for checkercode in self.controller.checker_info:
             checkername = self.controller._checker_code_to_name[checkercode]
             names.append(checkername)
-        for checkername in sorted(names, cmp=locale.strcoll):
+        for checkername in sorted(names):
             mitem = Gtk.MenuItem(checkername)
             mitem.show()
             mitem.connect('activate', self._on_menu_item_activate)

--- a/virtaal/views/checksprojview.py
+++ b/virtaal/views/checksprojview.py
@@ -19,6 +19,8 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 from __future__ import absolute_import, print_function, unicode_literals
 
+import locale
+
 from gi.repository import Gtk
 
 from virtaal.views.widgets.popupmenubutton import PopupMenuButton
@@ -41,7 +43,7 @@ class ChecksProjectView(BaseView):
         for checkercode in self.controller.checker_info:
             checkername = self.controller._checker_code_to_name[checkercode]
             names.append(checkername)
-        for checkername in sorted(names):
+        for checkername in sorted(names, key=locale.strxfrm):
             mitem = Gtk.MenuItem(checkername)
             mitem.show()
             mitem.connect('activate', self._on_menu_item_activate)

--- a/virtaal/views/checksunitview.py
+++ b/virtaal/views/checksunitview.py
@@ -19,6 +19,8 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 from __future__ import absolute_import, print_function, unicode_literals
 
+import locale
+
 from gi.repository import Gtk
 from gi.repository import Pango
 from translate.lang import factory as lang_factory
@@ -118,7 +120,7 @@ class ChecksUnitView(BaseView):
 
         self.lst_checks.clear()
         nice_name = self.controller.get_check_name
-        sorted_failures = sorted(failures.items(), key=lambda x: nice_name(x[0]))
+        sorted_failures = sorted(failures.items(), key=lambda x: locale.strxfrm(nice_name(x[0])))
         names = []
         for testname, desc in sorted_failures:
             testname = nice_name(testname)

--- a/virtaal/views/checksunitview.py
+++ b/virtaal/views/checksunitview.py
@@ -96,7 +96,7 @@ class ChecksUnitView(BaseView):
     # METHODS #
     def show(self):
         parent = self.controller.main_controller.unit_controller.view._widgets['vbox_right']
-        parent.pack_start(self.btn_checks, expand=False, fill=True)
+        parent.pack_start(self.btn_checks, False, True, 0)
         self.btn_checks.show()
 
     def hide(self):

--- a/virtaal/views/checksunitview.py
+++ b/virtaal/views/checksunitview.py
@@ -17,16 +17,15 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
-
-import locale
+from __future__ import absolute_import, print_function, unicode_literals
 
 from gi.repository import Gtk
 from gi.repository import Pango
 from translate.lang import factory as lang_factory
 
-from baseview import BaseView
 from virtaal.common.pan_app import ui_language
 from virtaal.views.widgets.popupwidgetbutton import PopupWidgetButton, POS_SE_NE
+from .baseview import BaseView
 
 
 class ChecksUnitView(BaseView):
@@ -119,7 +118,7 @@ class ChecksUnitView(BaseView):
 
         self.lst_checks.clear()
         nice_name = self.controller.get_check_name
-        sorted_failures = sorted(failures.iteritems(), key=lambda x: nice_name(x[0]), cmp=locale.strcoll)
+        sorted_failures = sorted(failures.items(), key=lambda x: nice_name(x[0]))
         names = []
         for testname, desc in sorted_failures:
             testname = nice_name(testname)

--- a/virtaal/views/checksunitview.py
+++ b/virtaal/views/checksunitview.py
@@ -20,14 +20,13 @@
 
 import locale
 
-import gtk
-import pango
+from gi.repository import Gtk
+from gi.repository import Pango
 from translate.lang import factory as lang_factory
 
+from baseview import BaseView
 from virtaal.common.pan_app import ui_language
 from virtaal.views.widgets.popupwidgetbutton import PopupWidgetButton, POS_SE_NE
-
-from baseview import BaseView
 
 
 class ChecksUnitView(BaseView):
@@ -51,11 +50,11 @@ class ChecksUnitView(BaseView):
         self._listsep = lang_factory.getlanguage(ui_language).listseperator
 
     def _create_checks_button(self, widget, main_window):
-        self.lbl_btnchecks = gtk.Label()
+        self.lbl_btnchecks = Gtk.Label()
         self.lbl_btnchecks.show()
-        self.lbl_btnchecks.set_ellipsize(pango.ELLIPSIZE_END)
+        self.lbl_btnchecks.set_ellipsize(Pango.EllipsizeMode.END)
         self.btn_checks = PopupWidgetButton(widget, label=None, popup_pos=POS_SE_NE, main_window=main_window, sticky=True)
-        self.btn_checks.set_property('relief', gtk.RELIEF_NONE)
+        self.btn_checks.set_property('relief', Gtk.ReliefStyle.NONE)
         self.btn_checks.set_update_popup_geometry_func(self.update_geometry)
         self.btn_checks.add(self.lbl_btnchecks)
 
@@ -65,31 +64,31 @@ class ChecksUnitView(BaseView):
         self.mnu_checks.connect('activate', self._on_activated)
 
     def _create_popup_content(self):
-        vb = gtk.VBox()
-        frame = gtk.Frame()
-        frame.set_shadow_type(gtk.SHADOW_ETCHED_IN)
+        vb = Gtk.VBox()
+        frame = Gtk.Frame()
+        frame.set_shadow_type(Gtk.ShadowType.ETCHED_IN)
         frame.add(vb)
 
-        self.lbl_empty = gtk.Label('<i>' + _('No issues') + '</i>')
+        self.lbl_empty = Gtk.Label(label='<i>' + _('No issues') + '</i>')
         self.lbl_empty.set_use_markup(True)
         self.lbl_empty.hide()
-        vb.pack_start(self.lbl_empty)
+        vb.pack_start(self.lbl_empty, True, True, 0)
 
-        self.lst_checks = gtk.ListStore(str, str)
-        self.tvw_checks = gtk.TreeView()
-        name_column = gtk.TreeViewColumn(_('Quality Check'), gtk.CellRendererText(), text=self.COL_CHECKNAME)
-        name_column.set_sizing(gtk.TREE_VIEW_COLUMN_AUTOSIZE)
+        self.lst_checks = Gtk.ListStore(str, str)
+        self.tvw_checks = Gtk.TreeView()
+        name_column = Gtk.TreeViewColumn(_('Quality Check'), Gtk.CellRendererText(), text=self.COL_CHECKNAME)
+        name_column.set_sizing(Gtk.TreeViewColumnSizing.AUTOSIZE)
         self.tvw_checks.append_column(name_column)
 
-        description_renderer = gtk.CellRendererText()
-        #description_renderer.set_property('wrap-mode', pango.WRAP_WORD_CHAR)
-        description_column = gtk.TreeViewColumn(_('Description'), description_renderer, text=self.COL_DESC)
-        description_column.set_sizing(gtk.TREE_VIEW_COLUMN_AUTOSIZE)
+        description_renderer = Gtk.CellRendererText()
+        # description_renderer.set_property('wrap-mode', Pango.WrapMode.WORD_CHAR)
+        description_column = Gtk.TreeViewColumn(_('Description'), description_renderer, text=self.COL_DESC)
+        description_column.set_sizing(Gtk.TreeViewColumnSizing.AUTOSIZE)
         self.tvw_checks.append_column(description_column)
         self.tvw_checks.set_model(self.lst_checks)
-        self.tvw_checks.get_selection().set_mode(gtk.SELECTION_NONE)
+        self.tvw_checks.get_selection().set_mode(Gtk.SelectionMode.NONE)
 
-        vb.pack_start(self.tvw_checks)
+        vb.pack_start(self.tvw_checks, True, True, 0)
 
         return frame
 

--- a/virtaal/views/langview.py
+++ b/virtaal/views/langview.py
@@ -21,7 +21,6 @@
 import logging
 import os
 
-import Gtk.gdk
 from gi.repository import GObject
 from gi.repository import Gtk
 
@@ -137,7 +136,7 @@ class LanguageView(BaseView):
         # Clear all menu items
         for i in range(self.controller.NUM_RECENT):
             item = self.recent_items[i]
-            if item.parent is self.menu:
+            if item.get_parent() is self.menu:
                 item.get_child().set_text('')
                 self.menu.remove(item)
 

--- a/virtaal/views/langview.py
+++ b/virtaal/views/langview.py
@@ -60,6 +60,9 @@ class LanguageView(BaseView):
         self.controller.main_controller.view.main_window.connect(
             'style-set', self._on_style_set
         )
+        self.controller.main_controller.view.main_window.connect(
+            'style-updated', self._on_style_set
+        )
         if self.controller.recent_pairs:
             self.popupbutton.text = self._get_display_string(*self.controller.recent_pairs[0])
 
@@ -77,11 +80,6 @@ class LanguageView(BaseView):
         self.other_item.connect('activate', self._on_other_activated)
         [self.menu.append(item) for item in (seperator, self.other_item)]
         self.update_recent_pairs()
-
-        self.controller.main_controller.view.main_window.connect(
-            'style-set', self._on_style_set
-        )
-
 
     # METHODS #
     def _get_display_string(self, srclang, tgtlang):
@@ -225,6 +223,6 @@ class LanguageView(BaseView):
         self.controller.set_language_pair(*pair)
         self.controller.main_controller.unit_controller.view.targets[0].grab_focus()
 
-    def _on_style_set(self, widget, prev_style):
+    def _on_style_set(self, widget, prev_style=None):
         if not hasattr(self, 'popup_default_fg'):
-            self.popup_default_fg = widget.style.fg
+            self.popup_default_fg = widget.get_style_context().get_color(Gtk.StateType.NORMAL)

--- a/virtaal/views/langview.py
+++ b/virtaal/views/langview.py
@@ -73,7 +73,7 @@ class LanguageView(BaseView):
             item.connect('activate', self._on_pairitem_activated, i)
             self.recent_items.append(item)
         seperator = Gtk.SeparatorMenuItem()
-        self.other_item = Gtk.MenuItem(_('_New Language Pair...'))
+        self.other_item = Gtk.MenuItem.new_with_mnemonic(_('_New Language Pair...'))
         self.other_item.connect('activate', self._on_other_activated)
         [self.menu.append(item) for item in (seperator, self.other_item)]
         self.update_recent_pairs()

--- a/virtaal/views/langview.py
+++ b/virtaal/views/langview.py
@@ -17,6 +17,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import, print_function, unicode_literals
 
 import logging
 import os
@@ -24,9 +25,9 @@ import os
 from gi.repository import GObject
 from gi.repository import Gtk
 
-from baseview import BaseView
 from virtaal.models.langmodel import LanguageModel
-from widgets.popupmenubutton import PopupMenuButton
+from .baseview import BaseView
+from .widgets.popupmenubutton import PopupMenuButton
 
 
 class LanguageView(BaseView):
@@ -41,8 +42,8 @@ class LanguageView(BaseView):
         self._init_gui()
 
     def _create_dialogs(self):
-        from widgets.langselectdialog import LanguageSelectDialog
-        from widgets.langadddialog import LanguageAddDialog
+        from .widgets.langselectdialog import LanguageSelectDialog
+        from .widgets.langadddialog import LanguageAddDialog
         langs = [LanguageModel(lc) for lc in LanguageModel.languages]
         langs.sort(key=lambda x: x.name)
         self.select_dialog = LanguageSelectDialog(langs, parent=self.controller.main_controller.view.main_window)

--- a/virtaal/views/langview.py
+++ b/virtaal/views/langview.py
@@ -19,6 +19,7 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 from __future__ import absolute_import, print_function, unicode_literals
 
+import locale
 import logging
 import os
 
@@ -45,7 +46,7 @@ class LanguageView(BaseView):
         from .widgets.langselectdialog import LanguageSelectDialog
         from .widgets.langadddialog import LanguageAddDialog
         langs = [LanguageModel(lc) for lc in LanguageModel.languages]
-        langs.sort(key=lambda x: x.name)
+        langs.sort(key=lambda x: locale.strxfrm(x.name))
         self.select_dialog = LanguageSelectDialog(langs, parent=self.controller.main_controller.view.main_window)
         self.select_dialog.btn_add.connect('clicked', self._on_addlang_clicked)
 
@@ -192,7 +193,7 @@ class LanguageView(BaseView):
         # Reload the language data in the selection dialog.
         self.select_dialog.clear_langs()
         langs = [LanguageModel(lc) for lc in LanguageModel.languages]
-        langs.sort(key=lambda x: x.name)
+        langs.sort(key=lambda x: locale.strxfrm(x.name))
         self.select_dialog.update_languages(langs)
 
     def _on_button_toggled(self, popupbutton):

--- a/virtaal/views/langview.py
+++ b/virtaal/views/langview.py
@@ -24,6 +24,7 @@ import logging
 import os
 
 from gi.repository import GObject
+from gi.repository import Gdk
 from gi.repository import Gtk
 
 from virtaal.models.langmodel import LanguageModel
@@ -57,12 +58,6 @@ class LanguageView(BaseView):
         self.popupbutton = PopupMenuButton()
         self.popupbutton.connect('toggled', self._on_button_toggled)
 
-        self.controller.main_controller.view.main_window.connect(
-            'style-set', self._on_style_set
-        )
-        self.controller.main_controller.view.main_window.connect(
-            'style-updated', self._on_style_set
-        )
         if self.controller.recent_pairs:
             self.popupbutton.text = self._get_display_string(*self.controller.recent_pairs[0])
 
@@ -102,22 +97,15 @@ class LanguageView(BaseView):
     def notify_same_langs(self):
         def notify():
             for s in [Gtk.StateType.ACTIVE, Gtk.StateType.NORMAL, Gtk.StateType.PRELIGHT, Gtk.StateType.SELECTED]:
-                self.popupbutton.get_child().modify_fg(s, Gdk.color_parse('#f66'))
+                self.popupbutton.modify_fg(s, Gdk.color_parse('#f66'))
 
         GObject.idle_add(notify)
 
     def notify_diff_langs(self):
         def notify():
             states = [Gtk.StateFlags.ACTIVE, Gtk.StateFlags.NORMAL, Gtk.StateFlags.PRELIGHT, Gtk.StateFlags.SELECTED]
-            if hasattr(self, 'popup_default_fg'):
-                fgcol = self.popup_default_fg
-            else:
-                default_style_context = Gtk.StyleContext()
-                fgcol = {}
-                for state in states:
-                    fgcol[state] = default_style_context.get_color(state)
-            for s in states:
-                self.popupbutton.get_child().override_color(s, fgcol[s])
+            for state in states:
+                self.popupbutton.modify_fg(state, None)
 
         GObject.idle_add(notify)
 
@@ -222,7 +210,3 @@ class LanguageView(BaseView):
         pair = self.controller.recent_pairs[item_n]
         self.controller.set_language_pair(*pair)
         self.controller.main_controller.unit_controller.view.targets[0].grab_focus()
-
-    def _on_style_set(self, widget, prev_style=None):
-        if not hasattr(self, 'popup_default_fg'):
-            self.popup_default_fg = widget.get_style_context().get_color(Gtk.StateType.NORMAL)

--- a/virtaal/views/langview.py
+++ b/virtaal/views/langview.py
@@ -18,16 +18,15 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-import os
-import gobject
-import gtk
-import gtk.gdk
 import logging
+import os
 
-from virtaal.common import GObjectWrapper
-from virtaal.models.langmodel import LanguageModel
+import Gtk.gdk
+from gi.repository import GObject
+from gi.repository import Gtk
 
 from baseview import BaseView
+from virtaal.models.langmodel import LanguageModel
 from widgets.popupmenubutton import PopupMenuButton
 
 
@@ -64,16 +63,16 @@ class LanguageView(BaseView):
             self.popupbutton.text = self._get_display_string(*self.controller.recent_pairs[0])
 
     def _init_menu(self):
-        self.menu = gtk.Menu()
+        self.menu = Gtk.Menu()
         self.popupbutton.set_menu(self.menu)
 
         self.recent_items = []
         for i in range(self.controller.NUM_RECENT):
-            item = gtk.MenuItem('')
+            item = Gtk.MenuItem('')
             item.connect('activate', self._on_pairitem_activated, i)
             self.recent_items.append(item)
-        seperator = gtk.SeparatorMenuItem()
-        self.other_item = gtk.MenuItem(_('_New Language Pair...'))
+        seperator = Gtk.SeparatorMenuItem()
+        self.other_item = Gtk.MenuItem(_('_New Language Pair...'))
         self.other_item.connect('activate', self._on_other_activated)
         [self.menu.append(item) for item in (seperator, self.other_item)]
         self.update_recent_pairs()
@@ -85,7 +84,7 @@ class LanguageView(BaseView):
 
     # METHODS #
     def _get_display_string(self, srclang, tgtlang):
-        if self.popupbutton.get_direction() == gtk.TEXT_DIR_RTL:
+        if self.popupbutton.get_direction() == Gtk.TextDirection.RTL:
             # We need to make sure we get the direction correct if the
             # language names are untranslated. The right-to-left embedding
             # (RLE) characters ensure that untranslated language names will
@@ -103,19 +102,21 @@ class LanguageView(BaseView):
 
     def notify_same_langs(self):
         def notify():
-            for s in [gtk.STATE_ACTIVE, gtk.STATE_NORMAL, gtk.STATE_PRELIGHT, gtk.STATE_SELECTED]:
-                self.popupbutton.child.modify_fg(s, gtk.gdk.color_parse('#f66'))
-        gobject.idle_add(notify)
+            for s in [Gtk.StateType.ACTIVE, Gtk.StateType.NORMAL, Gtk.StateType.PRELIGHT, Gtk.StateType.SELECTED]:
+                self.popupbutton.get_child().modify_fg(s, Gdk.color_parse('#f66'))
+
+        GObject.idle_add(notify)
 
     def notify_diff_langs(self):
         def notify():
             if hasattr(self, 'popup_default_fg'):
                 fgcol = self.popup_default_fg
             else:
-                fgcol = gtk.widget_get_default_style().fg
-            for s in [gtk.STATE_ACTIVE, gtk.STATE_NORMAL, gtk.STATE_PRELIGHT, gtk.STATE_SELECTED]:
-                self.popupbutton.child.modify_fg(s, fgcol[s])
-        gobject.idle_add(notify)
+                fgcol = Gtk.widget_get_default_style().fg
+            for s in [Gtk.StateType.ACTIVE, Gtk.StateType.NORMAL, Gtk.StateType.PRELIGHT, Gtk.StateType.SELECTED]:
+                self.popupbutton.get_child().modify_fg(s, fgcol[s])
+
+        GObject.idle_add(notify)
 
     def show(self):
         """Add the managed C{PopupMenuButton} to the C{MainView}'s status bar."""
@@ -124,7 +125,7 @@ class LanguageView(BaseView):
         for child in statusbar.get_children():
             if child is self.popupbutton:
                 return
-        statusbar.pack_end(self.popupbutton, expand=False)
+        statusbar.pack_end(self.popupbutton, False, True, 0)
         statusbar.show_all()
 
     def focus(self):

--- a/virtaal/views/langview.py
+++ b/virtaal/views/langview.py
@@ -108,12 +108,16 @@ class LanguageView(BaseView):
 
     def notify_diff_langs(self):
         def notify():
+            states = [Gtk.StateFlags.ACTIVE, Gtk.StateFlags.NORMAL, Gtk.StateFlags.PRELIGHT, Gtk.StateFlags.SELECTED]
             if hasattr(self, 'popup_default_fg'):
                 fgcol = self.popup_default_fg
             else:
-                fgcol = Gtk.widget_get_default_style().fg
-            for s in [Gtk.StateType.ACTIVE, Gtk.StateType.NORMAL, Gtk.StateType.PRELIGHT, Gtk.StateType.SELECTED]:
-                self.popupbutton.get_child().modify_fg(s, fgcol[s])
+                default_style_context = Gtk.StyleContext()
+                fgcol = {}
+                for state in states:
+                    fgcol[state] = default_style_context.get_color(state)
+            for s in states:
+                self.popupbutton.get_child().override_color(s, fgcol[s])
 
         GObject.idle_add(notify)
 

--- a/virtaal/views/mainview.py
+++ b/virtaal/views/mainview.py
@@ -28,6 +28,7 @@ from gi.repository import Gtk
 from six import string_types
 
 from virtaal.common import pan_app
+from virtaal.common.utils import get_unicode
 from virtaal.views import theme
 from .baseview import BaseView
 
@@ -72,7 +73,7 @@ class EntryDialog(Gtk.Dialog):
         self.ent_input.grab_focus()
         response = super(EntryDialog, self).run()
 
-        return response, self.ent_input.get_text().decode('utf-8')
+        return response, get_unicode(self.ent_input.get_text(), 'utf-8')
 
     def set_message(self, message):
         self.lbl_message.set_markup(message)
@@ -371,7 +372,7 @@ class MainView(BaseView):
 
             # the data comes as a string with each URI on a line; lines
             # terminated with '\r\n. For now we just take the first one:
-            filename = data.data.split("\r\n")[0]
+            filename = get_unicode(data.get_data().split(b"\r\n")[0], 'utf-8')
             if filename.startswith("file://"):
                 # This is a URI, so we handle encoded characters like spaces:
                 import urllib
@@ -601,7 +602,7 @@ class MainView(BaseView):
     def show_open_dialog(self, title=''):
         """@returns: The selected file name and URI if the OK button was clicked.
             C{None} otherwise."""
-        last_path = (pan_app.settings.general["lastdir"] or "").decode(sys.getdefaultencoding())
+        last_path = get_unicode(pan_app.settings.general["lastdir"]) or u""
 
         # Do native dialogs in a thread so that GTK can continue drawing.
         from virtaal.support import native_widgets
@@ -633,9 +634,9 @@ class MainView(BaseView):
         self._top_window = old_top
 
         if response:
-            filename = self.open_chooser.get_filename().decode('utf-8')
+            filename = get_unicode(self.open_chooser.get_filename())
             pan_app.settings.general["lastdir"] = os.path.dirname(filename)
-            return (filename, self.open_chooser.get_uri().decode('utf-8'))
+            return (filename, get_unicode(self.open_chooser.get_uri(), 'utf-8'))
         else:
             return ()
 
@@ -711,7 +712,7 @@ class MainView(BaseView):
         self._top_window = old_top
 
         if response == Gtk.ResponseType.OK:
-            filename = self.save_chooser.get_filename().decode('utf-8')
+            filename = get_unicode(self.save_chooser.get_filename())
             #FIXME: do we need uri here?
             return filename
 
@@ -826,7 +827,7 @@ class MainView(BaseView):
             # For now we only handle local files, and limited the recent
             # manager to only give us those anyway, so we can get the filename
             self._uri = item.get_uri()
-            self.controller.open_file(item.get_uri_display().decode('utf-8'), uri=item.get_uri().decode('utf-8'))
+            self.controller.open_file(item.get_uri_display(), uri=get_unicode(item.get_uri(), 'utf-8'))
 
     def _on_report_bug(self, _widget=None):
         from virtaal.support import openmailto

--- a/virtaal/views/mainview.py
+++ b/virtaal/views/mainview.py
@@ -492,7 +492,7 @@ class MainView(BaseView):
             return None
 
         parent_menu = parent_item.get_submenu()
-        menuitem = Gtk.MenuItem(name)
+        menuitem = Gtk.MenuItem.new_with_mnemonic(name)
         if after is None:
             parent_menu.add(menuitem)
         else:

--- a/virtaal/views/mainview.py
+++ b/virtaal/views/mainview.py
@@ -267,8 +267,8 @@ class MainView(BaseView):
             self._open_chooser.add_filter(all_supported_filter)
             from translate.storage import factory as storage_factory
             supported_files_dict = dict([ (_(name), (extensions, mimetypes)) for name, extensions, mimetypes in storage_factory.supported_files() ])
-            supported_file_names = supported_files_dict.keys()
-            supported_file_names.sort(cmp=locale.strcoll)
+            supported_file_names = list(supported_files_dict.keys())
+            supported_file_names.sort(key=locale.strxfrm)
             for name in supported_file_names:
                 extensions, mimetypes = supported_files_dict[name]
                 #XXX: we can't open generic .csv formats, so listing it is probably

--- a/virtaal/views/mainview.py
+++ b/virtaal/views/mainview.py
@@ -365,7 +365,7 @@ class MainView(BaseView):
         self.main_window.connect("drag_data_received", self._on_drag_data_received)
 
     def _on_drag_data_received(self, w, context, x, y, data, info, time):
-        if sys.platform == 'darwin' or Gtk.targets_include_uri(context.targets):
+        if sys.platform == 'darwin' or Gtk.targets_include_uri(context.list_targets()):
             # We don't check for valid targets on Mac (darwin) since there is
             # a bug in target_incude_uri on that platform, no adverse situations
             # seem to arise but we leave other platforms to do the right thing.
@@ -869,7 +869,7 @@ class MainView(BaseView):
         mnu_fullscreen.set_active(event.new_window_state & Gdk.WindowState.FULLSCREEN)
 
     def _on_app_pressed(self, btn):
-        self.app_menu.popup(None, None, None, 0, 0)
+        self.app_menu.popup(None, None, None, 0, 0, Gtk.get_current_event_time())
 
     def _on_osx_openfile_event(self, macapp, filename):
         # Note! A limitation of the current GTK-OSX code

--- a/virtaal/views/mainview.py
+++ b/virtaal/views/mainview.py
@@ -17,6 +17,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import, print_function, unicode_literals
 
 import locale
 import os
@@ -24,10 +25,11 @@ import sys
 
 from gi.repository import Gdk
 from gi.repository import Gtk
+from six import string_types
 
-from baseview import BaseView
 from virtaal.common import pan_app
 from virtaal.views import theme
+from .baseview import BaseView
 
 
 def fill_dialog(dialog, title='', message='', markup=''):
@@ -151,7 +153,7 @@ class MainView(BaseView):
                 osxapp.ready()
                 osxapp.connect("NSApplicationOpenFile", self._on_osx_openfile_event)
                 osxapp.connect("NSApplicationBlockTermination", self._on_quit)
-            except ImportError, e:
+            except ImportError as e:
                 import logging
                 logging.debug("gtk_osxapplication module not found. Expect zero integration with the Mac desktop.")
 
@@ -450,7 +452,7 @@ class MainView(BaseView):
                 try:
                     nplurals = self.show_input_dialog(message=_("Please enter the number of noun forms (plurals) to use"))
                     return int(nplurals)
-                except ValueError, _e:
+                except ValueError as _e:
                     pass
 
         def ask_for_plurals_equation():
@@ -478,7 +480,7 @@ class MainView(BaseView):
     def append_menu_item(self, name, menu, after=None):
         """Add a new menu item with the given name to the menu with the given
             name (C{menu})."""
-        if isinstance(after, (str, unicode)):
+        if isinstance(after, (str, string_types)):
             after = self.find_menu(after)
 
         parent_item = None
@@ -811,7 +813,7 @@ class MainView(BaseView):
         openmailto.open("http://translate.sourceforge.net/wiki/guide/start")
 
     def _on_help_about(self, _widget=None):
-        from widgets.aboutdialog import AboutDialog
+        from .widgets.aboutdialog import AboutDialog
         AboutDialog(self.main_window)
 
     def _on_quit(self, *args):

--- a/virtaal/views/mainview.py
+++ b/virtaal/views/mainview.py
@@ -18,16 +18,17 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-import gtk
 import locale
 import os
 import sys
-from gtk import gdk
 
-from virtaal.views import theme
-from virtaal.common import pan_app
+from gi.repository import Gdk
+from gi.repository import Gtk
 
 from baseview import BaseView
+from virtaal.common import pan_app
+from virtaal.views import theme
+
 
 def fill_dialog(dialog, title='', message='', markup=''):
     if title:
@@ -38,23 +39,23 @@ def fill_dialog(dialog, title='', message='', markup=''):
         dialog.set_markup(message.replace('<', '&lt;'))
 
 
-class EntryDialog(gtk.Dialog):
+class EntryDialog(Gtk.Dialog):
     """A simple dialog containing a dialog for user input."""
 
     def __init__(self, parent):
         super(EntryDialog, self).__init__(title='Input Dialog', parent=parent)
         self.set_size_request(450, 100)
 
-        self.lbl_message = gtk.Label()
-        self.vbox.pack_start(self.lbl_message)
+        self.lbl_message = Gtk.Label()
+        self.vbox.pack_start(self.lbl_message, True, True, 0)
 
-        self.ent_input = gtk.Entry()
+        self.ent_input = Gtk.Entry()
         self.ent_input.set_activates_default(True)
-        self.vbox.pack_start(self.ent_input)
+        self.vbox.pack_start(self.ent_input, True, True, 0)
 
-        self.add_button(gtk.STOCK_CANCEL, gtk.RESPONSE_CANCEL)
-        self.add_button(gtk.STOCK_OK, gtk.RESPONSE_OK)
-        self.set_default_response(gtk.RESPONSE_OK)
+        self.add_button(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL)
+        self.add_button(Gtk.STOCK_OK, Gtk.ResponseType.OK)
+        self.set_default_response(Gtk.ResponseType.OK)
 
     def run(self, title=None, message=None, keepInput=False):
         if message:
@@ -98,7 +99,7 @@ class MainView(BaseView):
                 }
                 class "GtkTreeView" style "show-rules"
                 """
-            gtk.rc_parse_string(rc_string)
+            Gtk.rc_parse_string(rc_string)
 
         # Set the GtkBuilder file
         self.gui = self.load_builder_file(["virtaal", "virtaal.ui"], root='MainWindow', domain="virtaal")
@@ -117,7 +118,7 @@ class MainView(BaseView):
 
         if sys.platform == 'darwin':
             try:
-                gtk.rc_parse(pan_app.get_abs_data_filename(["themes", "OSX_Leopard_theme", "gtkrc"]))
+                Gtk.rc_parse(pan_app.get_abs_data_filename(["themes", "OSX_Leopard_theme", "gtkrc"]))
             except:
                 import logging
                 logging.exception("Couldn't find OSX_Leopard_theme")
@@ -142,11 +143,11 @@ class MainView(BaseView):
                 osxapp.insert_app_menu_item(mnu_about, 0)
                 self.gui.get_object("separator_mnu_help_1").hide()
                 # Move the preferences menu item
-                osxapp.insert_app_menu_item(gtk.SeparatorMenuItem(), 1)
+                osxapp.insert_app_menu_item(Gtk.SeparatorMenuItem(), 1)
                 mnu_prefs = self.gui.get_object("mnu_prefs")
                 osxapp.insert_app_menu_item(mnu_prefs, 2)
                 self.gui.get_object("separator_mnu_edit_3").hide()
-                gtk.accel_map_load(pan_app.get_abs_data_filename(["virtaal", "virtaal.accel"]))
+                Gtk.AccelMap.load(pan_app.get_abs_data_filename(["virtaal", "virtaal.accel"]))
                 osxapp.ready()
                 osxapp.connect("NSApplicationOpenFile", self._on_osx_openfile_event)
                 osxapp.connect("NSApplicationBlockTermination", self._on_quit)
@@ -188,8 +189,8 @@ class MainView(BaseView):
         self._setup_key_bindings()
         self._track_window_state()
         self._setup_dnd()
-        import gobject
-        gobject.idle_add(self._setup_recent_files, priority=gobject.PRIORITY_LOW)
+        from gi.repository import GObject
+        GObject.idle_add(self._setup_recent_files, priority=GObject.PRIORITY_LOW)
         self.main_window.connect('style-set', self._on_style_set)
 
     def _create_dialogs(self):
@@ -218,10 +219,10 @@ class MainView(BaseView):
     def error_dialog(self):
         if not self._error_dialog:
         # Error dialog
-            self._error_dialog = gtk.MessageDialog(self.main_window,
-                gtk.DIALOG_MODAL,
-                gtk.MESSAGE_ERROR,
-                gtk.BUTTONS_OK)
+        self._error_dialog = Gtk.MessageDialog(self.main_window,
+                                               Gtk.DialogFlags.MODAL,
+                                               Gtk.MessageType.ERROR,
+                                               Gtk.ButtonsType.OK)
             self._error_dialog.set_title(_("Error"))
         return self._error_dialog
 
@@ -229,37 +230,37 @@ class MainView(BaseView):
     def prompt_dialog(self):
         # Yes/No prompt dialog
         if not self._prompt_dialog:
-            self._prompt_dialog = gtk.MessageDialog(self.main_window,
-                gtk.DIALOG_MODAL,
-                gtk.MESSAGE_QUESTION,
-                gtk.BUTTONS_YES_NO,
-            )
-            self._prompt_dialog.set_default_response(gtk.RESPONSE_NO)
+            self._prompt_dialog = Gtk.MessageDialog(self.main_window,
+                                                    Gtk.DialogFlags.MODAL,
+                                                    Gtk.MessageType.QUESTION,
+                                                    Gtk.ButtonsType.YES_NO,
+                                                    )
+            self._prompt_dialog.set_default_response(Gtk.ResponseType.NO)
         return self._prompt_dialog
 
     @property
     def info_dialog(self):
         # Informational dialog
         if not self._info_dialog:
-            self._info_dialog = gtk.MessageDialog(self.main_window,
-                gtk.DIALOG_MODAL,
-                gtk.MESSAGE_INFO,
-                gtk.BUTTONS_OK,
-            )
+            self._info_dialog = Gtk.MessageDialog(self.main_window,
+                                                  Gtk.DialogFlags.MODAL,
+                                                  Gtk.MessageType.INFO,
+                                                  Gtk.ButtonsType.OK,
+                                                  )
         return self._info_dialog
 
     @property
     def open_chooser(self):
         # Open (file chooser) dialog
         if not self._open_chooser:
-            self._open_chooser = gtk.FileChooserDialog(
+            self._open_chooser = Gtk.FileChooserDialog(
                 _('Choose a Translation File'),
                 self.main_window,
-                gtk.FILE_CHOOSER_ACTION_OPEN,
-                (gtk.STOCK_CANCEL, gtk.RESPONSE_CANCEL, gtk.STOCK_OPEN, gtk.RESPONSE_OK)
+                Gtk.FileChooserAction.OPEN,
+                (Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL, Gtk.STOCK_OPEN, Gtk.ResponseType.OK)
             )
-            self._open_chooser.set_default_response(gtk.RESPONSE_OK)
-            all_supported_filter = gtk.FileFilter()
+            self._open_chooser.set_default_response(Gtk.ResponseType.OK)
+            all_supported_filter = Gtk.FileFilter()
             all_supported_filter.set_name(_("All Supported Files"))
             self._open_chooser.add_filter(all_supported_filter)
             from translate.storage import factory as storage_factory
@@ -272,7 +273,7 @@ class MainView(BaseView):
                 # more harmful than good.
                 if "csv" in extensions:
                     continue
-                new_filter = gtk.FileFilter()
+                new_filter = Gtk.FileFilter()
                 new_filter.set_name(name)
                 if extensions:
                     for extension in extensions:
@@ -287,7 +288,7 @@ class MainView(BaseView):
                         all_supported_filter.add_mime_type(mimetype)
                 self._open_chooser.add_filter(new_filter)
 
-            #doc_filter = gtk.FileFilter()
+            # doc_filter = Gtk.FileFilter()
             #doc_filter.set_name(_('Translatable documents'))
             #from translate.convert import factory as convert_factory
             #for extension in convert_factory.converters.keys():
@@ -297,13 +298,13 @@ class MainView(BaseView):
             #    all_supported_filter.add_pattern('*.' + extension)
             #self._open_chooser.add_filter(doc_filter)
 
-            #proj_filter = gtk.FileFilter()
+            #proj_filter = Gtk.FileFilter()
             #proj_filter.set_name(_('Translate project bundles'))
             #proj_filter.add_pattern('*.zip')
             #all_supported_filter.add_pattern('*.zip')
             #self._open_chooser.add_filter(proj_filter)
 
-            all_filter = gtk.FileFilter()
+            all_filter = Gtk.FileFilter()
             all_filter.set_name(_("All Files"))
             all_filter.add_pattern("*")
             self._open_chooser.add_filter(all_filter)
@@ -314,54 +315,54 @@ class MainView(BaseView):
     def save_chooser(self):
         # Save (file chooser) dialog
         if not self._save_chooser:
-            self._save_chooser = gtk.FileChooserDialog(
+            self._save_chooser = Gtk.FileChooserDialog(
                 _("Save"),
                 self.main_window,
-                gtk.FILE_CHOOSER_ACTION_SAVE,
-                (gtk.STOCK_CANCEL, gtk.RESPONSE_CANCEL, gtk.STOCK_SAVE, gtk.RESPONSE_OK)
+                Gtk.FileChooserAction.SAVE,
+                (Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL, Gtk.STOCK_SAVE, Gtk.ResponseType.OK)
             )
             self._save_chooser.set_do_overwrite_confirmation(True)
-            self._save_chooser.set_default_response(gtk.RESPONSE_OK)
+            self._save_chooser.set_default_response(Gtk.ResponseType.OK)
         return self._save_chooser
 
     @property
     def confirm_dialog(self):
         # Save confirmation dialog (Save/Discard/Cancel buttons)
         if not self._confirm_dialog:
-            (RESPONSE_SAVE, RESPONSE_DISCARD) = (gtk.RESPONSE_YES, gtk.RESPONSE_NO)
-            self._confirm_dialog = gtk.MessageDialog(
+            (RESPONSE_SAVE, RESPONSE_DISCARD) = (Gtk.ResponseType.YES, Gtk.ResponseType.NO)
+            self._confirm_dialog = Gtk.MessageDialog(
                 self.main_window,
-                gtk.DIALOG_MODAL,
-                gtk.MESSAGE_QUESTION,
-                gtk.BUTTONS_NONE,
+                Gtk.DialogFlags.MODAL,
+                Gtk.MessageType.QUESTION,
+                Gtk.ButtonsType.NONE,
                 _("The current file has been modified.\nDo you want to save your changes?")
             )
-            self._confirm_dialog.__save_button = self._confirm_dialog.add_button(gtk.STOCK_SAVE, RESPONSE_SAVE)
+            self._confirm_dialog.__save_button = self._confirm_dialog.add_button(Gtk.STOCK_SAVE, RESPONSE_SAVE)
             self._confirm_dialog.add_button(_("_Discard"), RESPONSE_DISCARD)
-            self._confirm_dialog.add_button(gtk.STOCK_CANCEL, gtk.RESPONSE_CANCEL)
+            self._confirm_dialog.add_button(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL)
             self._confirm_dialog.set_default_response(RESPONSE_SAVE)
         return self._confirm_dialog
 
     def _setup_key_bindings(self):
-        self.accel_group = gtk.AccelGroup()
+        self.accel_group = Gtk.AccelGroup()
         self.main_window.add_accel_group(self.accel_group)
 
     def _track_window_state(self):
         self._window_is_maximized = False
 
         def on_state_event(widget, event):
-            self._window_is_maximized = bool(event.new_window_state & gtk.gdk.WINDOW_STATE_MAXIMIZED)
+            self._window_is_maximized = bool(event.new_window_state & Gdk.WindowState.MAXIMIZED)
         self.main_window.connect('window-state-event', on_state_event)
 
     def _setup_dnd(self):
         """configures drag and drop"""
-        targets = gtk.target_list_add_uri_targets()
-        # Konqueror needs gtk.gdk.ACTION_MOVE
-        self.main_window.drag_dest_set(gtk.DEST_DEFAULT_ALL, targets, gtk.gdk.ACTION_COPY | gtk.gdk.ACTION_MOVE)
+        targets = Gtk.target_list_add_uri_targets()
+        # Konqueror needs Gdk.DragAction.MOVE
+        self.main_window.drag_dest_set(Gtk.DestDefaults.ALL, targets, Gdk.DragAction.COPY | Gdk.DragAction.MOVE)
         self.main_window.connect("drag_data_received", self._on_drag_data_received)
 
     def _on_drag_data_received(self, w, context, x, y, data, info, time):
-        if sys.platform == 'darwin' or gtk.targets_include_uri(context.targets):
+        if sys.platform == 'darwin' or Gtk.targets_include_uri(context.targets):
             # We don't check for valid targets on Mac (darwin) since there is
             # a bug in target_incude_uri on that platform, no adverse situations
             # seem to arise but we leave other platforms to do the right thing.
@@ -393,13 +394,13 @@ class MainView(BaseView):
                 }
                 widget "gtk-tooltip*" style "better-tooltips"
                 """ % tooltip_text
-            gtk.rc_parse_string(rc_string)
+            Gtk.rc_parse_string(rc_string)
 
 
     # ACCESSORS #
     def add_accel_group(self, accel_group):
         """Add the given accelerator group to the main window.
-            @type accel_group: gtk.AccelGroup"""
+            @type accel_group: Gtk.AccelGroup"""
         self.main_window.add_accel_group(accel_group)
 
     def set_saveable(self, value):
@@ -466,8 +467,8 @@ class MainView(BaseView):
 
     def append_menu(self, name):
         """Add a menu with the given name to the menu bar."""
-        menu = gtk.Menu()
-        menuitem = gtk.MenuItem(name)
+        menu = Gtk.Menu()
+        menuitem = Gtk.MenuItem(name)
         menuitem.set_submenu(menu)
         self.menu_structure.append(menuitem)
         if self.menu_structure.get_property('visible'):
@@ -481,7 +482,7 @@ class MainView(BaseView):
             after = self.find_menu(after)
 
         parent_item = None
-        if isinstance(menu, gtk.MenuItem):
+        if isinstance(menu, Gtk.MenuItem):
             parent_item = menu
         else:
             parent_item = self.find_menu(menu)
@@ -489,7 +490,7 @@ class MainView(BaseView):
             return None
 
         parent_menu = parent_item.get_submenu()
-        menuitem = gtk.MenuItem(name)
+        menuitem = Gtk.MenuItem(name)
         if after is None:
             parent_menu.add(menuitem)
         else:
@@ -516,7 +517,7 @@ class MainView(BaseView):
 
             @param label: The label of the menu item to find.
             @param menu: The (optional) (name of the) menu to search in."""
-        if not isinstance(menu, gtk.MenuItem):
+        if not isinstance(menu, Gtk.MenuItem):
             menu = self.find_menu(label)
         if menu is not None:
             menus = [menu]
@@ -544,8 +545,8 @@ class MainView(BaseView):
     def hide(self):
         """Hide and don't return until it is really hidden."""
         self.main_window.hide()
-        while gtk.events_pending():
-            gtk.main_iteration()
+        while Gtk.events_pending():
+            Gtk.main_iteration()
 
     def quit(self):
         if self._window_is_maximized:
@@ -556,7 +557,7 @@ class MainView(BaseView):
             pan_app.settings.general['windowheight'] = height
             pan_app.settings.general['maximized'] = ''
         pan_app.settings.write()
-        gtk.main_quit()
+        Gtk.main_quit()
 
     def show(self):
         if pan_app.settings.general['maximized']:
@@ -567,19 +568,19 @@ class MainView(BaseView):
 
         # Uncomment this line to measure startup time until the window shows.
         # It causes the program to quit immediately when the window is shown:
-        #self.main_window.connect('expose-event', lambda widget, event: gtk.main_quit())
+        #self.main_window.connect('expose-event', lambda widget, event: Gtk.main_quit())
 
         # Uncomment these lines to measure true startup time. It causes the
         # program to quit immediately when the last thing added to the gobject
         # idle queue during startup, is done.
         #from gobject import idle_add, PRIORITY_LOW
-        #idle_add(gtk.main_quit, priority=PRIORITY_LOW)
+        #idle_add(Gtk.main_quit, priority=PRIORITY_LOW)
 
         # Uncomment these lines to see which modules have already been imported
         # at this stage. Keep in mind that something like pprint could affect
         # the list.
         #print "\n".join(sorted(sys.modules.keys()))
-        gtk.main()
+        Gtk.main()
 
     def show_input_dialog(self, title='', message=''):
         """Shows a simple dialog containing a text entry.
@@ -591,7 +592,7 @@ class MainView(BaseView):
         self.input_dialog.hide()
         self._top_window = old_top
 
-        if response == gtk.RESPONSE_OK:
+        if response == Gtk.ResponseType.OK:
             return text
         return None
 
@@ -625,7 +626,7 @@ class MainView(BaseView):
         self.open_chooser.set_transient_for(self._top_window)
         old_top = self._top_window
         self._top_window = self.open_chooser
-        response = self.open_chooser.run() == gtk.RESPONSE_OK
+        response = self.open_chooser.run() == Gtk.ResponseType.OK
         self.open_chooser.hide()
         self._top_window = old_top
 
@@ -656,7 +657,7 @@ class MainView(BaseView):
         self.prompt_dialog.hide()
         self._top_window = old_top
 
-        return response == gtk.RESPONSE_YES
+        return response == Gtk.ResponseType.YES
 
     def show_info_dialog(self, title='', message='', markup=''):
         """shows a simple info dialog containing a message and an OK button"""
@@ -707,7 +708,7 @@ class MainView(BaseView):
         self.save_chooser.hide()
         self._top_window = old_top
 
-        if response == gtk.RESPONSE_OK:
+        if response == Gtk.ResponseType.OK:
             filename = self.save_chooser.get_filename().decode('utf-8')
             #FIXME: do we need uri here?
             return filename
@@ -723,9 +724,9 @@ class MainView(BaseView):
         self.confirm_dialog.hide()
         self._top_window = old_top
 
-        if response == gtk.RESPONSE_YES:
+        if response == Gtk.ResponseType.YES:
             return 'save'
-        elif response == gtk.RESPONSE_NO:
+        elif response == Gtk.ResponseType.NO:
             return 'discard'
         return 'cancel'
 
@@ -734,7 +735,7 @@ class MainView(BaseView):
             self.btn_app = self.gui.get_object('btn_app')
             image = self.gui.get_object('img_app')
             image.set_from_file(pan_app.get_abs_data_filename(['icons', 'hicolor', '24x24', 'mimetypes', 'x-translation.png']))
-            self.app_menu = gtk.Menu()
+            self.app_menu = Gtk.Menu()
             self.btn_app.connect('pressed', self._on_app_pressed)
             self.btn_app.show()
         for child in self.menu_structure:
@@ -862,7 +863,7 @@ class MainView(BaseView):
 
     def _on_window_state_event(self, widget, event):
         mnu_fullscreen = self.gui.get_object('mnu_fullscreen')
-        mnu_fullscreen.set_active(event.new_window_state & gdk.WINDOW_STATE_FULLSCREEN)
+        mnu_fullscreen.set_active(event.new_window_state & Gdk.WindowState.FULLSCREEN)
 
     def _on_app_pressed(self, btn):
         self.app_menu.popup(None, None, None, 0, 0)

--- a/virtaal/views/mainview.py
+++ b/virtaal/views/mainview.py
@@ -195,6 +195,7 @@ class MainView(BaseView):
         from gi.repository import GObject
         GObject.idle_add(self._setup_recent_files, priority=GObject.PRIORITY_LOW)
         self.main_window.connect('style-set', self._on_style_set)
+        self.main_window.connect('style-updated', self._on_style_set)
 
     def _create_dialogs(self):
         self._input_dialog = None
@@ -382,7 +383,7 @@ class MainView(BaseView):
 
         return True
 
-    def _on_style_set(self, widget, prev_style):
+    def _on_style_set(self, widget, prev_style=None):
         theme.update_style(widget)
         # on windows the tooltip colour is wrong in inverse themes (bug 1923)
         if os.name == 'nt':

--- a/virtaal/views/mainview.py
+++ b/virtaal/views/mainview.py
@@ -218,11 +218,11 @@ class MainView(BaseView):
     @property
     def error_dialog(self):
         if not self._error_dialog:
-        # Error dialog
-        self._error_dialog = Gtk.MessageDialog(self.main_window,
-                                               Gtk.DialogFlags.MODAL,
-                                               Gtk.MessageType.ERROR,
-                                               Gtk.ButtonsType.OK)
+            # Error dialog
+            self._error_dialog = Gtk.MessageDialog(self.main_window,
+                                                   Gtk.DialogFlags.MODAL,
+                                                   Gtk.MessageType.ERROR,
+                                                   Gtk.ButtonsType.OK)
             self._error_dialog.set_title(_("Error"))
         return self._error_dialog
 
@@ -356,7 +356,7 @@ class MainView(BaseView):
 
     def _setup_dnd(self):
         """configures drag and drop"""
-        targets = Gtk.target_list_add_uri_targets()
+        targets = Gtk.TargetList().add_uri_targets(0)
         # Konqueror needs Gdk.DragAction.MOVE
         self.main_window.drag_dest_set(Gtk.DestDefaults.ALL, targets, Gdk.DragAction.COPY | Gdk.DragAction.MOVE)
         self.main_window.connect("drag_data_received", self._on_drag_data_received)
@@ -526,7 +526,7 @@ class MainView(BaseView):
 
         for menuitem in menus:
             for item in menuitem.get_submenu().get_children():
-                if item.get_child() and item.get_child().get_text() == label:
+                if item.get_child() and str(item.get_child().get_text()) == str(label):
                     return item, menuitem
 
         if '_' in label:
@@ -563,7 +563,7 @@ class MainView(BaseView):
         if pan_app.settings.general['maximized']:
             self.main_window.maximize()
         self.main_window.show()
-        from gobject import threads_init
+        from gi.repository.GObject import threads_init
         threads_init()
 
         # Uncomment this line to measure startup time until the window shows.

--- a/virtaal/views/mainview.py
+++ b/virtaal/views/mainview.py
@@ -375,8 +375,8 @@ class MainView(BaseView):
             filename = get_unicode(data.get_data().split(b"\r\n")[0], 'utf-8')
             if filename.startswith("file://"):
                 # This is a URI, so we handle encoded characters like spaces:
-                import urllib
-                filename = urllib.unquote(filename)
+                from six.moves.urllib_parse import unquote
+                filename = unquote(filename)
                 #TODO: only bother if the extension is supported?
                 self.controller.open_file(filename)
 

--- a/virtaal/views/mainview.py
+++ b/virtaal/views/mainview.py
@@ -360,10 +360,10 @@ class MainView(BaseView):
 
     def _setup_dnd(self):
         """configures drag and drop"""
-        targets = Gtk.TargetList().add_uri_targets(0)
         # Konqueror needs Gdk.DragAction.MOVE
-        self.main_window.drag_dest_set(Gtk.DestDefaults.ALL, targets, Gdk.DragAction.COPY | Gdk.DragAction.MOVE)
-        self.main_window.connect("drag_data_received", self._on_drag_data_received)
+        self.main_window.drag_dest_set(Gtk.DestDefaults.ALL, None, Gdk.DragAction.COPY | Gdk.DragAction.MOVE)
+        self.main_window.drag_dest_add_uri_targets()
+        self.main_window.connect("drag-data-received", self._on_drag_data_received)
 
     def _on_drag_data_received(self, w, context, x, y, data, info, time):
         if sys.platform == 'darwin' or Gtk.targets_include_uri(context.list_targets()):

--- a/virtaal/views/markup.py
+++ b/virtaal/views/markup.py
@@ -25,7 +25,6 @@ from diff_match_patch import diff_match_patch
 
 from virtaal.views.theme import current_theme
 
-
 # We want to draw unexpected spaces specially so that users can spot them
 # easily without having to resort to showing all spaces weirdly
 _fancy_spaces_re = re.compile(r"""(?m)  #Multiline expression
@@ -90,7 +89,7 @@ def markuptext(text, fancyspaces=True, markupescapes=True, diff_text=u""):
     return text
 
 def escape(text):
-    """This is to escape text for use with gtk.TextView"""
+    """This is to escape text for use with Gtk.TextView"""
     if not text:
         return ""
     text = text.replace("\n", u'¶\n')
@@ -99,7 +98,7 @@ def escape(text):
     return text
 
 def unescape(text):
-    """This is to unescape text for use with gtk.TextView"""
+    """This is to unescape text for use with Gtk.TextView"""
     if not text:
         return ""
     text = text.replace("\t", "")

--- a/virtaal/views/modeview.py
+++ b/virtaal/views/modeview.py
@@ -18,12 +18,11 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-import gobject
-import gtk
-
-from virtaal.common import GObjectWrapper
+from gi.repository import GObject
+from gi.repository import Gtk
 
 from baseview import BaseView
+from virtaal.common import GObjectWrapper
 
 
 class ModeView(GObjectWrapper, BaseView):
@@ -34,7 +33,7 @@ class ModeView(GObjectWrapper, BaseView):
 
     __gtype_name__ = 'ModeView'
     __gsignals__ = {
-        "mode-selected":  (gobject.SIGNAL_RUN_FIRST, gobject.TYPE_NONE, (gobject.TYPE_STRING,)),
+        "mode-selected": (GObject.SignalFlags.RUN_FIRST, None, (GObject.TYPE_STRING,)),
     }
 
     # INITIALIZERS #
@@ -48,15 +47,15 @@ class ModeView(GObjectWrapper, BaseView):
     def _build_gui(self):
         # Get the mode container from the main controller
         # We need the *same* GtkBuilder instance as used by the MainView, because we need
-        # the gtk.Table as already added to the main window. Loading the GtkBuilder file again
-        # would create a new main window with a different gtk.Table.
+        # the Gtk.Table as already added to the main window. Loading the GtkBuilder file again
+        # would create a new main window with a different Gtk.Table.
         gui = self.controller.main_controller.view.gui # FIXME: Is this acceptable?
         self.mode_box = gui.get_object('mode_box')
 
-        self.cmb_modes = gtk.combo_box_new_text()
+        self.cmb_modes = Gtk.ComboBoxText()
         self.cmb_modes.connect('changed', self._on_cmbmode_change)
 
-        self.lbl_mode = gtk.Label()
+        self.lbl_mode = Gtk.Label()
         #l10n: This refers to the 'mode' that determines how Virtaal moves
         #between units.
         self.lbl_mode.set_markup_with_mnemonic(_('N_avigation:'))

--- a/virtaal/views/modeview.py
+++ b/virtaal/views/modeview.py
@@ -17,12 +17,13 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import, print_function, unicode_literals
 
 from gi.repository import GObject
 from gi.repository import Gtk
 
-from baseview import BaseView
 from virtaal.common import GObjectWrapper
+from .baseview import BaseView
 
 
 class ModeView(GObjectWrapper, BaseView):

--- a/virtaal/views/placeablesguiinfo.py
+++ b/virtaal/views/placeablesguiinfo.py
@@ -416,8 +416,8 @@ def update_style(widget):
     _style = widget.get_style_context()
     fg = _style.get_color(Gtk.StateType.NORMAL)
     bg = _style.get_background_color(Gtk.StateType.NORMAL)
-    StringElemGUI.fg = fg.to_string()
-    StringElemGUI.bg = bg.to_string()
+    StringElemGUI.fg = fg
+    StringElemGUI.bg = bg
     PhGUI.fg = theme.current_theme['markup_warning_fg']
     PhGUI.bg = theme.current_theme['ph_placeable_bg']
     UrlGUI.fg = theme.current_theme['url_fg']

--- a/virtaal/views/placeablesguiinfo.py
+++ b/virtaal/views/placeablesguiinfo.py
@@ -19,7 +19,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-import Gtk.gdk
 from gi.repository import Gtk
 from gi.repository import Pango
 from translate.storage.placeables import base, StringElem, general, xliff
@@ -404,8 +403,9 @@ class UnknownXMLGUI(StringElemGUI):
             lbl.set_size_request(-1, int(h/1.2))
 
 def update_style(widget):
-    fg = widget.style.fg[Gtk.StateType.NORMAL]
-    bg = widget.style.base[Gtk.StateType.NORMAL]
+    _style = widget.get_style_context()
+    fg = _style.get_color(Gtk.StateType.NORMAL)
+    bg = _style.get_background_color(Gtk.StateType.NORMAL)
     StringElemGUI.fg = fg.to_string()
     StringElemGUI.bg = bg.to_string()
     PhGUI.fg = theme.current_theme['markup_warning_fg']

--- a/virtaal/views/placeablesguiinfo.py
+++ b/virtaal/views/placeablesguiinfo.py
@@ -19,7 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-from gi.repository import Gtk
+from gi.repository import Gtk, Gdk
 from gi.repository import Pango
 from translate.storage.placeables import base, StringElem, general, xliff
 

--- a/virtaal/views/placeablesguiinfo.py
+++ b/virtaal/views/placeablesguiinfo.py
@@ -28,7 +28,7 @@ from virtaal.views.rendering import get_role_font_description, make_pango_layout
 
 
 def _count_anchors(buffer, itr):
-    anchor_text = buffer.get_slice(buffer.get_start_iter(), itr)
+    anchor_text = buffer.get_slice(buffer.get_start_iter(), itr, include_hidden_chars=True)
     #XXX: This is a utf-8 bytestring, not unicode! Converting to Unicode
     # just to look for 0xFFFC is a waste.
     return anchor_text.count('\xef\xbf\xbc')

--- a/virtaal/views/placeablesguiinfo.py
+++ b/virtaal/views/placeablesguiinfo.py
@@ -26,12 +26,16 @@ from translate.storage.placeables import base, StringElem, general, xliff
 from virtaal.views import theme
 from virtaal.views.rendering import get_role_font_description, make_pango_layout
 
+from six import PY2
+
 
 def _count_anchors(buffer, itr):
     anchor_text = buffer.get_slice(buffer.get_start_iter(), itr, include_hidden_chars=True)
-    #XXX: This is a utf-8 bytestring, not unicode! Converting to Unicode
-    # just to look for 0xFFFC is a waste.
-    return anchor_text.count('\xef\xbf\xbc')
+    if PY2:
+        #XXX: On Python 2 this is a utf-8 bytestring, not unicode! Converting to
+        # Unicode just to look for 0xFFFC is a waste.
+        return anchor_text.count('\xef\xbf\xbc')
+    return anchor_text.count('\ufffc')
 
 
 class StringElemGUI(object):

--- a/virtaal/views/placeablesguiinfo.py
+++ b/virtaal/views/placeablesguiinfo.py
@@ -416,8 +416,8 @@ def update_style(widget):
     _style = widget.get_style_context()
     fg = _style.get_color(Gtk.StateType.NORMAL)
     bg = _style.get_background_color(Gtk.StateType.NORMAL)
-    StringElemGUI.fg = fg
-    StringElemGUI.bg = bg
+    StringElemGUI.fg = theme.rgba_to_str(fg)
+    StringElemGUI.bg = theme.rgba_to_str(bg)
     PhGUI.fg = theme.current_theme['markup_warning_fg']
     PhGUI.bg = theme.current_theme['ph_placeable_bg']
     UrlGUI.fg = theme.current_theme['url_fg']

--- a/virtaal/views/placeablesguiinfo.py
+++ b/virtaal/views/placeablesguiinfo.py
@@ -73,10 +73,16 @@ class StringElemGUI(object):
     def create_tags(self):
         tag = Gtk.TextTag()
         if self.fg:
-            tag.props.foreground = self.fg
+            if isinstance(self.fg, str):
+                tag.props.foreground = self.fg
+            else:
+                tag.props.foreground_rgba = self.fg
 
         if self.bg:
-            tag.props.background = self.bg
+            if isinstance(self.bg, str):
+                tag.props.background = self.bg
+            else:
+                tag.props.background_rgba = self.bg
 
         return [(tag, None, None)]
 

--- a/virtaal/views/placeablesguiinfo.py
+++ b/virtaal/views/placeablesguiinfo.py
@@ -19,13 +19,13 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-import gtk
-import gtk.gdk
-import pango
+import Gtk.gdk
+from gi.repository import Gtk
+from gi.repository import Pango
 from translate.storage.placeables import base, StringElem, general, xliff
 
-from virtaal.views.rendering import get_role_font_description, make_pango_layout
 from virtaal.views import theme
+from virtaal.views.rendering import get_role_font_description, make_pango_layout
 
 
 def _count_anchors(buffer, itr):
@@ -68,7 +68,7 @@ class StringElemGUI(object):
 
     # METHODS #
     def create_tags(self):
-        tag = gtk.TextTag()
+        tag = Gtk.TextTag()
         if self.fg:
             tag.props.foreground = self.fg
 
@@ -292,7 +292,7 @@ class BxGUI(StringElemGUI):
     bg = '#E6E6FA'
 
     def create_repr_widgets(self):
-        self.widgets.append(gtk.Label('(('))
+        self.widgets.append(Gtk.Label(label='(('))
 
         for lbl in self.widgets:
             font_desc = get_role_font_description(self.textbox.role)
@@ -306,7 +306,7 @@ class ExGUI(StringElemGUI):
     bg = '#E6E6FA'
 
     def create_repr_widgets(self):
-        self.widgets.append(gtk.Label('))'))
+        self.widgets.append(Gtk.Label(label='))'))
 
         for lbl in self.widgets:
             font_desc = get_role_font_description(self.textbox.role)
@@ -321,8 +321,8 @@ class NewlineGUI(StringElemGUI):
     fg = theme.current_theme['subtle_fg']
 
     def create_repr_widgets(self):
-        lbl = gtk.Label(u'¶')
-        lbl.modify_fg(gtk.STATE_NORMAL, gtk.gdk.color_parse(self.fg)) # foreground is light grey
+        lbl = Gtk.Label(label=u'¶')
+        lbl.modify_fg(Gtk.StateType.NORMAL, Gdk.color_parse(self.fg))  # foreground is light grey
         font_desc = get_role_font_description(self.textbox.role)
         lbl.modify_font(font_desc)
         self.textbox.get_pango_context().set_font_description(font_desc)
@@ -334,10 +334,10 @@ class UrlGUI(StringElemGUI):
     fg = theme.current_theme['url_fg']
 
     def create_tags(self):
-        tag = gtk.TextTag()
+        tag = Gtk.TextTag()
         tag.props.foreground = self.fg
         tag.props.background = self.bg
-        tag.props.underline = pango.UNDERLINE_SINGLE
+        tag.props.underline = Pango.Underline.SINGLE
         return [(tag, None, None)]
 
 
@@ -345,8 +345,8 @@ class GPlaceableGUI(StringElemGUI):
     bg = '#ffd27f'
 
     def create_repr_widgets(self):
-        self.widgets.append(gtk.Label('<'))
-        self.widgets.append(gtk.Label('>'))
+        self.widgets.append(Gtk.Label(label='<'))
+        self.widgets.append(Gtk.Label(label='>'))
         if self.elem.id:
             self.widgets[0].set_text('<%s|' % (self.elem.id))
 
@@ -362,7 +362,7 @@ class XPlaceableGUI(StringElemGUI):
     bg = '#ff7fef'
 
     def create_repr_widgets(self):
-        lbl = gtk.Label('[]')
+        lbl = Gtk.Label(label='[]')
         self.widgets.append(lbl)
         if self.elem.id:
             lbl.set_text('[%s]' % (self.elem.id))
@@ -378,8 +378,8 @@ class UnknownXMLGUI(StringElemGUI):
     bg = '#add8e6'
 
     def create_repr_widgets(self):
-        self.widgets.append(gtk.Label('{'))
-        self.widgets.append(gtk.Label('}'))
+        self.widgets.append(Gtk.Label(label='{'))
+        self.widgets.append(Gtk.Label(label='}'))
 
         info = ''
         if self.elem.xml_node.tag:
@@ -404,8 +404,8 @@ class UnknownXMLGUI(StringElemGUI):
             lbl.set_size_request(-1, int(h/1.2))
 
 def update_style(widget):
-    fg = widget.style.fg[gtk.STATE_NORMAL]
-    bg = widget.style.base[gtk.STATE_NORMAL]
+    fg = widget.style.fg[Gtk.StateType.NORMAL]
+    bg = widget.style.base[Gtk.StateType.NORMAL]
     StringElemGUI.fg = fg.to_string()
     StringElemGUI.bg = bg.to_string()
     PhGUI.fg = theme.current_theme['markup_warning_fg']

--- a/virtaal/views/prefsview.py
+++ b/virtaal/views/prefsview.py
@@ -18,15 +18,14 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-import gtk
-import gtk.gdk
-import pango
+import Gtk.gdk
+from gi.repository import Gtk
+from gi.repository import Pango
 from gobject import SIGNAL_RUN_FIRST
 
+from baseview import BaseView
 from virtaal.common import GObjectWrapper, pan_app
 from virtaal.views.widgets.selectview import SelectView
-
-from baseview import BaseView
 
 
 class PreferencesView(BaseView, GObjectWrapper):
@@ -90,7 +89,7 @@ class PreferencesView(BaseView, GObjectWrapper):
         self._widgets['scrwnd_plugins'].show_all()
 
     def _setup_key_bindings(self):
-        gtk.accel_map_add_entry("<Virtaal>/Edit/Preferences", gtk.keysyms.p, gtk.gdk.CONTROL_MASK)
+        Gtk.AccelMap.add_entry("<Virtaal>/Edit/Preferences", Gdk.KEY_p, Gdk.ModifierType.CONTROL_MASK)
 
     def _setup_menu_item(self):
         mainview = self.controller.main_controller.view
@@ -99,7 +98,7 @@ class PreferencesView(BaseView, GObjectWrapper):
 
         accel_group = menu_edit.get_accel_group()
         if accel_group is None:
-            accel_group = gtk.AccelGroup()
+            accel_group = Gtk.AccelGroup()
             menu_edit.set_accel_group(accel_group)
             mainview.add_accel_group(accel_group)
 
@@ -115,8 +114,8 @@ class PreferencesView(BaseView, GObjectWrapper):
     def _set_font_data(self, value):
         if not isinstance(value, dict) or not 'source' in value or not 'target' in value:
             raise ValueError('Value must be a dictionary')
-        sourcefont = pango.FontDescription(value['source'])
-        targetfont = pango.FontDescription(value['target'])
+        sourcefont = Pango.FontDescription(value['source'])
+        targetfont = Pango.FontDescription(value['target'])
         self._widgets['fbtn_source'].set_font_name(value['source'])
         self._widgets['fbtn_target'].set_font_name(value['target'])
     font_data = property(_get_font_data, _set_font_data)

--- a/virtaal/views/prefsview.py
+++ b/virtaal/views/prefsview.py
@@ -17,14 +17,15 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import, print_function, unicode_literals
 
 from gi.repository import Gtk, Gdk
 from gi.repository import Pango
 from gi.repository.GObject import SIGNAL_RUN_FIRST
 
-from baseview import BaseView
 from virtaal.common import GObjectWrapper, pan_app
 from virtaal.views.widgets.selectview import SelectView
+from .baseview import BaseView
 
 
 class PreferencesView(BaseView, GObjectWrapper):

--- a/virtaal/views/prefsview.py
+++ b/virtaal/views/prefsview.py
@@ -18,10 +18,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-import Gtk.gdk
-from gi.repository import Gtk
+from gi.repository import Gtk, Gdk
 from gi.repository import Pango
-from gobject import SIGNAL_RUN_FIRST
+from gi.repository.GObject import SIGNAL_RUN_FIRST
 
 from baseview import BaseView
 from virtaal.common import GObjectWrapper, pan_app

--- a/virtaal/views/propertiesview.py
+++ b/virtaal/views/propertiesview.py
@@ -103,7 +103,7 @@ class PropertiesView(BaseView, GObjectWrapper):
         self._get_widgets()
 
     def _setup_key_bindings(self):
-        import Gtk.gdk
+        from gi.repository import Gdk
         Gtk.AccelMap.add_entry("<Virtaal>/File/Properties", Gdk.KEY_Return, Gdk.ModifierType.MOD1_MASK)
 
     def _setup_menu_item(self):

--- a/virtaal/views/propertiesview.py
+++ b/virtaal/views/propertiesview.py
@@ -41,12 +41,12 @@ def _statistics(stats):
     state_dict = statsdb.extended_state_strings
 
     # just to check that the code didn't get out of sync somewhere:
-    if not set(descriptions.iterkeys()) == set(state_dict.itervalues()):
+    if not set(descriptions.keys()) == set(state_dict.values()):
         logging.warning("statsdb.state_dict doesn't correspond to descriptions here")
 
     statistics = []
     # We want to build them up from untranslated -> reviewed
-    for state in sorted(state_dict.iterkeys()):
+    for state in sorted(state_dict.keys()):
         key = state_dict[state]
         if not key in stats:
             continue

--- a/virtaal/views/propertiesview.py
+++ b/virtaal/views/propertiesview.py
@@ -19,11 +19,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-import gtk
-
-from virtaal.common import GObjectWrapper
+from gi.repository import Gtk
 
 from baseview import BaseView
+from virtaal.common import GObjectWrapper
 
 
 def _statistics(stats):
@@ -104,8 +103,8 @@ class PropertiesView(BaseView, GObjectWrapper):
         self._get_widgets()
 
     def _setup_key_bindings(self):
-        import gtk.gdk
-        gtk.accel_map_add_entry("<Virtaal>/File/Properties", gtk.keysyms.Return, gtk.gdk.MOD1_MASK)
+        import Gtk.gdk
+        Gtk.AccelMap.add_entry("<Virtaal>/File/Properties", Gdk.KEY_Return, Gdk.ModifierType.MOD1_MASK)
 
     def _setup_menu_item(self):
         mainview = self.controller.main_controller.view
@@ -114,7 +113,7 @@ class PropertiesView(BaseView, GObjectWrapper):
 
         accel_group = menu_file.get_accel_group()
         if not accel_group:
-            accel_group = gtk.AccelGroup()
+            accel_group = Gtk.AccelGroup()
             menu_file.set_accel_group(accel_group)
             mainview.add_accel_group(accel_group)
 
@@ -150,42 +149,42 @@ class PropertiesView(BaseView, GObjectWrapper):
         total_strings = 0
         for (description, strings, words) in statistics:
             # Add two identical labels for the word/string descriptions
-            lbl_desc = gtk.Label(description)
+            lbl_desc = Gtk.Label(label=description)
             lbl_desc.set_alignment(1.0, 0.5) # Right aligned
             lbl_desc.show()
-            vbox_word_labels.pack_start(lbl_desc)
+            vbox_word_labels.pack_start(lbl_desc, True, True, 0)
 
-            lbl_desc = gtk.Label(description)
+            lbl_desc = Gtk.Label(label=description)
             lbl_desc.set_alignment(1.0, 0.5) # Right aligned
             lbl_desc.show()
-            vbox_string_labels.pack_start(lbl_desc)
+            vbox_string_labels.pack_start(lbl_desc, True, True, 0)
 
             # Now for the numbers
             total_words += words
-            lbl_stats = gtk.Label(str(words))
+            lbl_stats = Gtk.Label(label=str(words))
             lbl_stats.set_alignment(1.0, 0.5)
             lbl_stats.show()
-            vbox_word_stats.pack_start(lbl_stats)
+            vbox_word_stats.pack_start(lbl_stats, True, True, 0)
 
             total_strings += strings
-            lbl_stats = gtk.Label(str(strings))
+            lbl_stats = Gtk.Label(label=str(strings))
             lbl_stats.set_alignment(1.0, 0.5)
             lbl_stats.show()
-            vbox_string_stats.pack_start(lbl_stats)
+            vbox_string_stats.pack_start(lbl_stats, True, True, 0)
 
         # Now we do the percentages:
         for (description, strings, words) in statistics:
             percentage = _nice_percentage(words, total_words)
-            lbl_perc = gtk.Label(percentage)
+            lbl_perc = Gtk.Label(label=percentage)
             lbl_perc.set_alignment(0.0, 0.5)
             lbl_perc.show()
-            vbox_word_perc.pack_start(lbl_perc)
+            vbox_word_perc.pack_start(lbl_perc, True, True, 0)
 
             percentage = _nice_percentage(strings, total_strings)
-            lbl_perc = gtk.Label(percentage)
+            lbl_perc = Gtk.Label(label=percentage)
             lbl_perc.set_alignment(0.0, 0.5)
             lbl_perc.show()
-            vbox_string_perc.pack_start(lbl_perc)
+            vbox_string_perc.pack_start(lbl_perc, True, True, 0)
 
 
         #l10n: The total number of words. You can not use %Id at this stage. If unsure, just copy the original.

--- a/virtaal/views/propertiesview.py
+++ b/virtaal/views/propertiesview.py
@@ -18,11 +18,12 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import, print_function, unicode_literals
 
 from gi.repository import Gtk
 
-from baseview import BaseView
 from virtaal.common import GObjectWrapper
+from .baseview import BaseView
 
 
 def _statistics(stats):

--- a/virtaal/views/recent.py
+++ b/virtaal/views/recent.py
@@ -18,12 +18,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
+from gi.repository import Gtk
 from translate.storage import factory
 
-import gtk
-
-
-rf = gtk.RecentFilter()
+rf = Gtk.RecentFilter()
 for name, extensions, mimetypes in factory.supported_files():
     if extensions:
         for extension in extensions:
@@ -38,14 +36,14 @@ for name, extensions, mimetypes in factory.supported_files():
 for app in ("virtaal", "poedit", "kbabel", "lokalize", "gtranslator"):
     rf.add_application(app)
 
-rm = gtk.recent_manager_get_default()
+rm = Gtk.RecentManager.get_default()
 
-rc = gtk.RecentChooserMenu()
+rc = Gtk.RecentChooserMenu()
 # For now we don't handle non-local files yet
 rc.set_local_only(True)
 rc.set_show_not_found(False)
 rc.set_show_numbers(True)
 rc.set_show_tips(True)
-rc.set_sort_type(gtk.RECENT_SORT_MRU)
+rc.set_sort_type(Gtk.RecentSortType.MRU)
 rc.add_filter(rf)
 rc.set_limit(15)

--- a/virtaal/views/rendering.py
+++ b/virtaal/views/rendering.py
@@ -18,17 +18,17 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-import pango
+from gi.repository import Pango
 
 from virtaal.common import pan_app
 
 _font_descriptions = {}
 
 def get_font_description(code):
-    """Provide a pango.FontDescription and keep it for reuse."""
+    """Provide a Pango.FontDescription and keep it for reuse."""
     global _font_descriptions
     if not code in _font_descriptions:
-        _font_descriptions[code] = pango.FontDescription(code)
+        _font_descriptions[code] = Pango.FontDescription(code)
     return _font_descriptions[code]
 
 def get_source_font_description():
@@ -44,9 +44,9 @@ def get_role_font_description(role):
         return get_target_font_description()
 
 def make_pango_layout(widget, text, width):
-    pango_layout = pango.Layout(widget.get_pango_context())
-    pango_layout.set_width(width * pango.SCALE)
-    pango_layout.set_wrap(pango.WRAP_WORD_CHAR)
+    pango_layout = Pango.Layout(widget.get_pango_context())
+    pango_layout.set_width(width * Pango.SCALE)
+    pango_layout.set_wrap(Pango.WrapMode.WORD_CHAR)
     pango_layout.set_text(text or u"")
     return pango_layout
 
@@ -54,8 +54,8 @@ def make_pango_layout(widget, text, width):
 _languages = {}
 
 def get_language(code):
-    """Provide a pango.Language and keep it for reuse."""
+    """Provide a Pango.Language and keep it for reuse."""
     global _languages
     if not code in _languages:
-        _languages[code] = pango.Language(code)
+        _languages[code] = Pango.Language(code)
     return _languages[code]

--- a/virtaal/views/rendering.py
+++ b/virtaal/views/rendering.py
@@ -57,5 +57,5 @@ def get_language(code):
     """Provide a Pango.Language and keep it for reuse."""
     global _languages
     if not code in _languages:
-        _languages[code] = Pango.Language(code)
+        _languages[code] = Pango.Language.from_string(code)
     return _languages[code]

--- a/virtaal/views/storeview.py
+++ b/virtaal/views/storeview.py
@@ -51,6 +51,7 @@ class StoreView(BaseView):
             # have its style set
             self._on_style_set(main_window, None)
         main_window.connect('style-set', self._on_style_set)
+        main_window.connect('style-updated', self._on_style_set)
 
     def _init_treeview(self):
         self._treeview = StoreTreeView(self)
@@ -160,7 +161,7 @@ class StoreView(BaseView):
                 title=_("Preview failed"), message=str(exc)
             )
 
-    def _on_style_set(self, widget, prev_style):
+    def _on_style_set(self, widget, prev_style=None):
         # The following color change is to reduce the flickering seen when
         # changing units. It's not the perfect cure, but helps a lot.
         # https://github.com/translate/virtaal/issues/1412

--- a/virtaal/views/storeview.py
+++ b/virtaal/views/storeview.py
@@ -18,7 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-import gtk
+from gi.repository import Gtk
 
 from baseview import BaseView
 from widgets.storetreeview import StoreTreeView
@@ -55,12 +55,15 @@ class StoreView(BaseView):
         self._treeview = StoreTreeView(self)
 
     def _add_accelerator_bindings(self):
-        gtk.accel_map_add_entry("<Virtaal>/Navigation/Up", gtk.accelerator_parse("Up")[0], gtk.gdk.CONTROL_MASK)
-        gtk.accel_map_add_entry("<Virtaal>/Navigation/Down", gtk.accelerator_parse("Down")[0], gtk.gdk.CONTROL_MASK)
-        gtk.accel_map_add_entry("<Virtaal>/Navigation/PgUp", gtk.accelerator_parse("Page_Up")[0], gtk.gdk.CONTROL_MASK)
-        gtk.accel_map_add_entry("<Virtaal>/Navigation/PgDown", gtk.accelerator_parse("Page_Down")[0], gtk.gdk.CONTROL_MASK)
+        Gtk.AccelMap.add_entry("<Virtaal>/Navigation/Up", Gtk.accelerator_parse("Up")[0], Gdk.ModifierType.CONTROL_MASK)
+        Gtk.AccelMap.add_entry("<Virtaal>/Navigation/Down", Gtk.accelerator_parse("Down")[0],
+                               Gdk.ModifierType.CONTROL_MASK)
+        Gtk.AccelMap.add_entry("<Virtaal>/Navigation/PgUp", Gtk.accelerator_parse("Page_Up")[0],
+                               Gdk.ModifierType.CONTROL_MASK)
+        Gtk.AccelMap.add_entry("<Virtaal>/Navigation/PgDown", Gtk.accelerator_parse("Page_Down")[0],
+                               Gdk.ModifierType.CONTROL_MASK)
 
-        self.accel_group = gtk.AccelGroup()
+        self.accel_group = Gtk.AccelGroup()
         self.accel_group.connect_by_path("<Virtaal>/Navigation/Up", self._treeview._move_up)
         self.accel_group.connect_by_path("<Virtaal>/Navigation/Down", self._treeview._move_down)
         self.accel_group.connect_by_path("<Virtaal>/Navigation/PgUp", self._treeview._move_pgup)
@@ -160,4 +163,4 @@ class StoreView(BaseView):
         # The following color change is to reduce the flickering seen when
         # changing units. It's not the perfect cure, but helps a lot.
         # https://github.com/translate/virtaal/issues/1412
-        self._treeview.modify_base(gtk.STATE_ACTIVE, widget.style.bg[gtk.STATE_NORMAL])
+        self._treeview.modify_base(Gtk.StateType.ACTIVE, widget.style.bg[Gtk.StateType.NORMAL])

--- a/virtaal/views/storeview.py
+++ b/virtaal/views/storeview.py
@@ -18,7 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-from gi.repository import Gtk
+from gi.repository import Gtk, Gdk
 
 from baseview import BaseView
 from widgets.storetreeview import StoreTreeView
@@ -116,7 +116,7 @@ class StoreView(BaseView):
         if child and child is not self._treeview:
             self.parent_widget.remove(child)
             child.destroy()
-        if not self._treeview.parent:
+        if not self._treeview.get_parent():
             self.parent_widget.add(self._treeview)
         self.parent_widget.show_all()
         if not self.controller.get_store():
@@ -163,4 +163,5 @@ class StoreView(BaseView):
         # The following color change is to reduce the flickering seen when
         # changing units. It's not the perfect cure, but helps a lot.
         # https://github.com/translate/virtaal/issues/1412
-        self._treeview.modify_base(Gtk.StateType.ACTIVE, widget.style.bg[Gtk.StateType.NORMAL])
+        self._treeview.override_color(Gtk.StateFlags.ACTIVE,
+                                      widget.get_style_context().get_background_color(Gtk.StateType.NORMAL))

--- a/virtaal/views/storeview.py
+++ b/virtaal/views/storeview.py
@@ -163,5 +163,5 @@ class StoreView(BaseView):
         # The following color change is to reduce the flickering seen when
         # changing units. It's not the perfect cure, but helps a lot.
         # https://github.com/translate/virtaal/issues/1412
-        self._treeview.override_color(Gtk.StateFlags.ACTIVE,
-                                      widget.get_style_context().get_background_color(Gtk.StateType.NORMAL))
+        self._treeview.override_background_color(Gtk.StateFlags.NORMAL,
+                                                 widget.get_style_context().get_background_color(Gtk.StateType.NORMAL))

--- a/virtaal/views/storeview.py
+++ b/virtaal/views/storeview.py
@@ -17,11 +17,12 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import, print_function, unicode_literals
 
 from gi.repository import Gtk, Gdk
 
-from baseview import BaseView
-from widgets.storetreeview import StoreTreeView
+from .baseview import BaseView
+from .widgets.storetreeview import StoreTreeView
 
 
 # XXX: ASSUMPTION: The model to display is self.controller.store
@@ -136,7 +137,7 @@ class StoreView(BaseView):
         # TODO: Get file name from user.
         try:
             self.controller.export_project_file(filename=None)
-        except Exception, exc:
+        except Exception as exc:
             self.controller.main_controller.view.show_error_dialog(
                 title=_("Export failed"), message=str(exc)
             )
@@ -145,7 +146,7 @@ class StoreView(BaseView):
         # TODO: Get file name from user.
         try:
             self.controller.export_project_file(filename=None, openafter=True)
-        except Exception, exc:
+        except Exception as exc:
             self.controller.main_controller.view.show_error_dialog(
                 title=_("Export failed"), message=str(exc)
             )
@@ -154,7 +155,7 @@ class StoreView(BaseView):
         # TODO: Get file name from user.
         try:
             self.controller.export_project_file(filename=None, openafter=True, readonly=True)
-        except Exception, exc:
+        except Exception as exc:
             self.controller.main_controller.view.show_error_dialog(
                 title=_("Preview failed"), message=str(exc)
             )

--- a/virtaal/views/theme.py
+++ b/virtaal/views/theme.py
@@ -18,6 +18,12 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
+
+"""This module contains some theme dependent colors.
+
+The colors are kept as strings so that the can easily be interpolated into
+pango markup. A different solution is likely to be better in the long run."""
+
 from gi.repository import Gtk, Gdk
 
 INVERSE = False

--- a/virtaal/views/theme.py
+++ b/virtaal/views/theme.py
@@ -35,6 +35,13 @@ theme or not, can inspect this to know.
 """
 
 
+def rgba_to_str(c: Gdk.RGBA):
+    s = ["#"]
+    for f in c.to_color().to_floats():
+        s.append("%x" % int(f*255))
+    return "".join(s)
+
+
 def str_to_rgba(s):
     rgba = Gdk.RGBA()
     rgba.parse(s)
@@ -117,6 +124,9 @@ def update_style(widget):
         set_inverse()
     else:
         set_default()
+
+    fg = rgba_to_str(fg)
+    bg = rgba_to_str(bg)
 
     # On some themes (notably Windows XP with classic style), diff_delete_bg is
     # almost identical to the background colour used. So we use something from

--- a/virtaal/views/theme.py
+++ b/virtaal/views/theme.py
@@ -131,15 +131,14 @@ def update_style(widget):
     # On some themes (notably Windows XP with classic style), diff_delete_bg is
     # almost identical to the background colour used. So we use something from
     # the gtk theme that is supposed to be different, but not much.
-    if not has_reasonable_contrast(_style.get_background_color(_state),
-                                   Gdk.color_parse(current_theme['diff_delete_bg'])):
+    if not has_reasonable_contrast(bg, current_theme['diff_delete_bg']):
         if INVERSE:
-            new_diff_delete_bg = _style.dark[Gtk.StateType.NORMAL]
+            new_diff_delete_bg = "#000"
         else:
-            new_diff_delete_bg = _style.light[Gtk.StateType.NORMAL]
+            new_diff_delete_bg = "#fff"
         # we only want to change if it will actually result in something readable:
-        if has_good_contrast(_style.text[Gtk.StateType.NORMAL], new_diff_delete_bg):
-            current_theme['diff_delete_bg'] = new_diff_delete_bg.to_string()
+        if has_good_contrast(fg, new_diff_delete_bg):
+            current_theme['diff_delete_bg'] = new_diff_delete_bg
 
 
 # these are based on an (old?) Web Content Accessibility Guidelines of the w3c

--- a/virtaal/views/theme.py
+++ b/virtaal/views/theme.py
@@ -18,7 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-import gtk
+from gi.repository import Gtk
 
 INVERSE = False
 """Whether we are currently in an inverse type of theme (lite text on dark
@@ -97,8 +97,8 @@ def is_inverse(fg, bg):
 
 def update_style(widget):
     _style = widget.style
-    fg = _style.fg[gtk.STATE_NORMAL]
-    bg = _style.base[gtk.STATE_NORMAL]
+    fg = _style.fg[Gtk.StateType.NORMAL]
+    bg = _style.base[Gtk.StateType.NORMAL]
     if is_inverse(fg, bg):
         set_inverse()
     else:
@@ -107,13 +107,13 @@ def update_style(widget):
     # On some themes (notably Windows XP with classic style), diff_delete_bg is
     # almost identical to the background colour used. So we use something from
     # the gtk theme that is supposed to be different, but not much.
-    if not has_reasonable_contrast(_style.bg[gtk.STATE_NORMAL], gtk.gdk.color_parse(current_theme['diff_delete_bg'])):
+    if not has_reasonable_contrast(_style.bg[Gtk.StateType.NORMAL], Gdk.color_parse(current_theme['diff_delete_bg'])):
         if INVERSE:
-            new_diff_delete_bg =  _style.dark[gtk.STATE_NORMAL]
+            new_diff_delete_bg = _style.dark[Gtk.StateType.NORMAL]
         else:
-            new_diff_delete_bg =  _style.light[gtk.STATE_NORMAL]
+            new_diff_delete_bg = _style.light[Gtk.StateType.NORMAL]
         # we only want to change if it will actually result in something readable:
-        if has_good_contrast(_style.text[gtk.STATE_NORMAL], new_diff_delete_bg):
+        if has_good_contrast(_style.text[Gtk.StateType.NORMAL], new_diff_delete_bg):
             current_theme['diff_delete_bg'] = new_diff_delete_bg.to_string()
 
 

--- a/virtaal/views/theme.py
+++ b/virtaal/views/theme.py
@@ -18,7 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-from gi.repository import Gtk
+from gi.repository import Gtk, Gdk
 
 INVERSE = False
 """Whether we are currently in an inverse type of theme (lite text on dark
@@ -96,9 +96,10 @@ def is_inverse(fg, bg):
         return False
 
 def update_style(widget):
-    _style = widget.style
-    fg = _style.fg[Gtk.StateType.NORMAL]
-    bg = _style.base[Gtk.StateType.NORMAL]
+    _style = widget.get_style_context()
+    _state = _style.get_state()
+    fg = _style.get_color(_state)
+    bg = _style.get_background_color(_state)
     if is_inverse(fg, bg):
         set_inverse()
     else:
@@ -107,7 +108,8 @@ def update_style(widget):
     # On some themes (notably Windows XP with classic style), diff_delete_bg is
     # almost identical to the background colour used. So we use something from
     # the gtk theme that is supposed to be different, but not much.
-    if not has_reasonable_contrast(_style.bg[Gtk.StateType.NORMAL], Gdk.color_parse(current_theme['diff_delete_bg'])):
+    if not has_reasonable_contrast(_style.get_background_color(_state),
+                                   Gdk.color_parse(current_theme['diff_delete_bg'])):
         if INVERSE:
             new_diff_delete_bg = _style.dark[Gtk.StateType.NORMAL]
         else:

--- a/virtaal/views/theme.py
+++ b/virtaal/views/theme.py
@@ -34,6 +34,13 @@ Other code wanting to alter their behaviour on whether we run in an inverse
 theme or not, can inspect this to know.
 """
 
+
+def str_to_rgba(s):
+    rgba = Gdk.RGBA()
+    rgba.parse(s)
+    return rgba
+
+
 _default_theme = {
     # Generic styling for a URL
     'url_fg': '#0000ff',
@@ -131,9 +138,10 @@ def update_style(widget):
 #      http://www.w3.org/TR/WCAG20/Overview.html
 
 def _luminance(c):
-    r = pow(c.red/65535.0, 2.2)
-    g = pow(c.green/65535.0, 2.2)
-    b = pow(c.blue/65535.0, 2.2)
+    c = str_to_rgba(c)
+    r = pow(c.red, 2.2)
+    g = pow(c.green, 2.2)
+    b = pow(c.blue, 2.2)
     return 0.2126 * r + 0.7152 * g + 0.0722 * b
 
 def _luminance_contrast_ratio(c1, c2):

--- a/virtaal/views/theme.py
+++ b/virtaal/views/theme.py
@@ -50,7 +50,7 @@ def str_to_rgba(s):
 
 _default_theme = {
     # Generic styling for a URL
-    'url_fg': '#0000ff',
+    'url_fg': '#0000ff',   # Adwaita: #1b6acb
     'subtle_fg': 'darkgrey',
     # Colours for the selected placeable (not affected by its type)
     'selected_placeable_fg': '#000000',
@@ -74,7 +74,7 @@ _default_theme = {
 }
 
 _inverse_theme = {
-    'url_fg': '#aaaaff',
+    'url_fg': '#70aaff',  # Adwaita: #3584e4
     'subtle_fg': 'grey',
     'selected_placeable_fg': '#ffffff',
     'selected_placeable_bg': '#007010',
@@ -139,6 +139,10 @@ def update_style(widget):
         # we only want to change if it will actually result in something readable:
         if has_good_contrast(fg, new_diff_delete_bg):
             current_theme['diff_delete_bg'] = new_diff_delete_bg
+
+    url_fg = rgba_to_str(_style.get_color(Gtk.StateFlags.LINK))
+    if has_good_contrast(bg, url_fg):
+        current_theme["url_fg"] = url_fg
 
 
 # these are based on an (old?) Web Content Accessibility Guidelines of the w3c

--- a/virtaal/views/theme.py
+++ b/virtaal/views/theme.py
@@ -97,7 +97,7 @@ def is_inverse(fg, bg):
 
 def update_style(widget):
     _style = widget.get_style_context()
-    _state = _style.get_state()
+    _state = Gtk.StateType.NORMAL
     fg = _style.get_color(_state)
     bg = _style.get_background_color(_state)
     if is_inverse(fg, bg):

--- a/virtaal/views/unitview.py
+++ b/virtaal/views/unitview.py
@@ -138,7 +138,7 @@ class UnitView(Gtk.EventBox, GObjectWrapper, Gtk.CellEditable, BaseView):
         def on_prev(*args):
             self.targets[self.focused_target_n].move_elem_selection(-1)
         def on_transfer(*args):
-            ev = Gdk.Event(Gdk.KEY_PRESS)
+            ev = Gdk.Event(Gdk.EventType.KEY_PRESS)
             ev.state = Gdk.ModifierType.MOD1_MASK
             ev.keyval = Gdk.KEY_Down
             ev.window = self.targets[self.focused_target_n].get_window(Gtk.TextWindowType.WIDGET)

--- a/virtaal/views/unitview.py
+++ b/virtaal/views/unitview.py
@@ -21,7 +21,7 @@
 import logging
 import re
 
-from gi.repository import Gtk, GObject, Gdk
+from gi.repository import Gtk, Gdk
 from gi.repository.GObject import idle_add, PARAM_READWRITE, SIGNAL_RUN_FIRST, TYPE_PYOBJECT
 from translate.lang import factory
 
@@ -63,7 +63,7 @@ class UnitView(Gtk.EventBox, GObjectWrapper, Gtk.CellEditable, BaseView):
 
     # INITIALIZERS #
     def __init__(self, controller):
-        GObject.GObject.__init__(self)
+        Gtk.EventBox.__init__(self)
         GObjectWrapper.__init__(self)
 
         self.controller = controller

--- a/virtaal/views/unitview.py
+++ b/virtaal/views/unitview.py
@@ -428,7 +428,7 @@ class UnitView(Gtk.EventBox, GObjectWrapper, Gtk.CellEditable, BaseView):
             return False
 
         for i in range(len(self.targets), self.MAX_TARGETS):
-            target = self._create_textbox(u'', editable=True, role='target', scroll_policy=Gtk.PolicyType.AUTOMATIC)
+            target = self._create_textbox(u'', editable=True, role='target')
             textbox = target.get_child()
             textbox.modify_font(rendering.get_target_font_description())
             textbox.selector_textboxes = self.sources
@@ -446,7 +446,7 @@ class UnitView(Gtk.EventBox, GObjectWrapper, Gtk.CellEditable, BaseView):
 
         self.emit('targets-created', self.targets)
 
-    def _create_textbox(self, text=u'', editable=True, role=None, scroll_policy=Gtk.PolicyType.AUTOMATIC):
+    def _create_textbox(self, text=u'', editable=True, role=None, scroll_policy=Gtk.PolicyType.EXTERNAL):
         textbox = TextBox(self.controller.main_controller, role=role)
         textbox.set_editable(editable)
         textbox.set_wrap_mode(Gtk.WrapMode.WORD_CHAR)

--- a/virtaal/views/unitview.py
+++ b/virtaal/views/unitview.py
@@ -17,19 +17,21 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import, print_function, unicode_literals
 
 import logging
 import re
 
 from gi.repository import Gtk, Gdk
 from gi.repository.GObject import idle_add, PARAM_READWRITE, SIGNAL_RUN_FIRST, TYPE_PYOBJECT
+from six import text_type as unicode
 from translate.lang import factory
 
-import rendering
-from baseview import BaseView
 from virtaal.common import GObjectWrapper
-from widgets.listnav import ListNavigator
-from widgets.textbox import TextBox
+from . import rendering
+from .baseview import BaseView
+from .widgets.listnav import ListNavigator
+from .widgets.textbox import TextBox
 
 
 class UnitView(Gtk.EventBox, GObjectWrapper, Gtk.CellEditable, BaseView):

--- a/virtaal/views/unitview.py
+++ b/virtaal/views/unitview.py
@@ -140,11 +140,8 @@ class UnitView(Gtk.EventBox, GObjectWrapper, Gtk.CellEditable, BaseView):
         def on_prev(*args):
             self.targets[self.focused_target_n].move_elem_selection(-1)
         def on_transfer(*args):
-            ev = Gdk.Event(Gdk.EventType.KEY_PRESS)
-            ev.state = Gdk.ModifierType.MOD1_MASK
-            ev.keyval = Gdk.KEY_Down
-            ev.window = self.targets[self.focused_target_n].get_window(Gtk.TextWindowType.WIDGET)
-            ev.put()
+            focused = get_focused(self.targets)
+            self.copy_original(focused)
         mnu_next.connect('activate', on_next)
         mnu_prev.connect('activate', on_prev)
         mnu_transfer.connect('activate', on_transfer)
@@ -405,7 +402,8 @@ class UnitView(Gtk.EventBox, GObjectWrapper, Gtk.CellEditable, BaseView):
                         listnav.move_state(-1)
                     # textbox is the last text view in this unit, so we need to move on
                     # to the next one.
-                    textbox.parent.parent.emit('key-press-event', event)
+                    self._on_key_press_event(None, event)
+
                 return True
 
             # Alt-Down

--- a/virtaal/views/unitview.py
+++ b/virtaal/views/unitview.py
@@ -18,21 +18,21 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-import gtk
 import logging
 import re
+
+from gi.repository import Gtk
 from gobject import idle_add, PARAM_READWRITE, SIGNAL_RUN_FIRST, TYPE_PYOBJECT
 from translate.lang import factory
 
-from virtaal.common import GObjectWrapper
-
 import rendering
 from baseview import BaseView
-from widgets.textbox import TextBox
+from virtaal.common import GObjectWrapper
 from widgets.listnav import ListNavigator
+from widgets.textbox import TextBox
 
 
-class UnitView(gtk.EventBox, GObjectWrapper, gtk.CellEditable, BaseView):
+class UnitView(Gtk.EventBox, GObjectWrapper, Gtk.CellEditable, BaseView):
     """View for translation units and its actions. It should not be used at
     all when no current unit is being edited. """
 
@@ -63,7 +63,7 @@ class UnitView(gtk.EventBox, GObjectWrapper, gtk.CellEditable, BaseView):
 
     # INITIALIZERS #
     def __init__(self, controller):
-        gtk.EventBox.__init__(self)
+        GObject.GObject.__init__(self)
         GObjectWrapper.__init__(self)
 
         self.controller = controller
@@ -76,7 +76,7 @@ class UnitView(gtk.EventBox, GObjectWrapper, gtk.CellEditable, BaseView):
         self.connect('key-press-event', self._on_key_press_event)
         # We automatically inherrit the tooltip from the Treeview, so we have
         # to show our own custom one to not have a tooltip obscuring things
-        invisible_tooltip = gtk.Window(gtk.WINDOW_POPUP)
+        invisible_tooltip = Gtk.Window(Gtk.WindowType.POPUP)
         invisible_tooltip.resize(1,1)
         invisible_tooltip.set_opacity(0)
         self.set_tooltip_window(invisible_tooltip)
@@ -101,7 +101,7 @@ class UnitView(gtk.EventBox, GObjectWrapper, gtk.CellEditable, BaseView):
                     return textview
             return None
 
-        clipboard = gtk.Clipboard(selection=gtk.gdk.SELECTION_CLIPBOARD)
+        clipboard = Gtk.Clipboard(selection=Gdk.SELECTION_CLIPBOARD)
         def on_cut(menuitem):
             focused = get_focused(self.targets)
             if focused is not None:
@@ -138,22 +138,22 @@ class UnitView(gtk.EventBox, GObjectWrapper, gtk.CellEditable, BaseView):
         def on_prev(*args):
             self.targets[self.focused_target_n].move_elem_selection(-1)
         def on_transfer(*args):
-            ev = gtk.gdk.Event(gtk.gdk.KEY_PRESS)
-            ev.state = gtk.gdk.MOD1_MASK
-            ev.keyval = gtk.keysyms.Down
-            ev.window = self.targets[self.focused_target_n].get_window(gtk.TEXT_WINDOW_WIDGET)
+            ev = Gdk.Event(Gdk.KEY_PRESS)
+            ev.state = Gdk.ModifierType.MOD1_MASK
+            ev.keyval = Gdk.KEY_Down
+            ev.window = self.targets[self.focused_target_n].get_window(Gtk.TextWindowType.WIDGET)
             ev.put()
         mnu_next.connect('activate', on_next)
         mnu_prev.connect('activate', on_prev)
         mnu_transfer.connect('activate', on_transfer)
 
-        gtk.accel_map_add_entry("<Virtaal>/Edit/Next Placeable", gtk.keysyms.Right, gtk.gdk.MOD1_MASK)
-        gtk.accel_map_add_entry("<Virtaal>/Edit/Prev Placeable", gtk.keysyms.Left, gtk.gdk.MOD1_MASK)
-        gtk.accel_map_add_entry("<Virtaal>/Edit/Transfer", gtk.keysyms.Down, gtk.gdk.MOD1_MASK)
+        Gtk.AccelMap.add_entry("<Virtaal>/Edit/Next Placeable", Gdk.KEY_Right, Gdk.ModifierType.MOD1_MASK)
+        Gtk.AccelMap.add_entry("<Virtaal>/Edit/Prev Placeable", Gdk.KEY_Left, Gdk.ModifierType.MOD1_MASK)
+        Gtk.AccelMap.add_entry("<Virtaal>/Edit/Transfer", Gdk.KEY_Down, Gdk.ModifierType.MOD1_MASK)
 
         accel_group = menu_edit.get_accel_group()
         if not accel_group:
-            accel_group = gtk.AccelGroup()
+            accel_group = Gtk.AccelGroup()
 
         self.controller.main_controller.view.add_accel_group(accel_group)
         menu_edit.set_accel_group(accel_group)
@@ -247,7 +247,7 @@ class UnitView(gtk.EventBox, GObjectWrapper, gtk.CellEditable, BaseView):
         return False
 
     def do_start_editing(self, *_args):
-        """C{gtk.CellEditable.start_editing()}"""
+        """C{Gtk.CellEditable.start_editing()}"""
         self.focus_text_view(self.targets[0])
 
     def do_editing_done(self, *_args):
@@ -265,7 +265,7 @@ class UnitView(gtk.EventBox, GObjectWrapper, gtk.CellEditable, BaseView):
         self.emit('target-focused', self._focused_target_n)
 
     def load_unit(self, unit):
-        """Load a GUI (C{gtk.CellEditable}) for the given unit."""
+        """Load a GUI (C{Gtk.CellEditable}) for the given unit."""
         assert unit
         if unit is None:
             logging.error("UnitView can't load a None unit")
@@ -343,12 +343,12 @@ class UnitView(gtk.EventBox, GObjectWrapper, gtk.CellEditable, BaseView):
 
     def _update_editor_gui(self):
         """Build the default editor with the following components:
-            - A C{gtk.TextView} for each source
-            - A C{gtk.TextView} for each target
+            - A C{Gtk.TextView} for each source
+            - A C{Gtk.TextView} for each target
             - A C{ListNavigator} for the unit states
-            - A C{gtk.Label} for programmer notes
-            - A C{gtk.Label} for translator notes
-            - A C{gtk.Label} for context info"""
+            - A C{Gtk.Label} for programmer notes
+            - A C{Gtk.Label} for translator notes
+            - A C{Gtk.Label} for context info"""
         # We assume a unit exists, otherwise none of this makes sense:
         self._layout_update_notes('programmer')
         self._layout_update_sources()
@@ -371,12 +371,12 @@ class UnitView(gtk.EventBox, GObjectWrapper, gtk.CellEditable, BaseView):
             source = self._create_textbox(u'', editable=False, role='source')
             textbox = source.get_child()
             textbox.modify_font(rendering.get_source_font_description())
-            self._widgets['vbox_sources'].pack_start(source)
+            self._widgets['vbox_sources'].pack_start(source, True, True, 0)
             self.sources.append(textbox)
 
             # The following fixes a very weird crash (bug #810)
             def ignore_tab(txtbx, event, eventname):
-                if event.keyval in (gtk.keysyms.Tab, gtk.keysyms.ISO_Left_Tab):
+                if event.keyval in (Gdk.KEY_Tab, Gdk.KEY_ISO_Left_Tab):
                     self.focused_target_n = 0
                     return True
             textbox.connect('key-pressed', ignore_tab)
@@ -428,7 +428,7 @@ class UnitView(gtk.EventBox, GObjectWrapper, gtk.CellEditable, BaseView):
             return False
 
         for i in range(len(self.targets), self.MAX_TARGETS):
-            target = self._create_textbox(u'', editable=True, role='target', scroll_policy=gtk.POLICY_AUTOMATIC)
+            target = self._create_textbox(u'', editable=True, role='target', scroll_policy=Gtk.PolicyType.AUTOMATIC)
             textbox = target.get_child()
             textbox.modify_font(rendering.get_target_font_description())
             textbox.selector_textboxes = self.sources
@@ -438,7 +438,7 @@ class UnitView(gtk.EventBox, GObjectWrapper, gtk.CellEditable, BaseView):
             textbox.connect('text-deleted', self._on_target_delete_range, i)
             textbox.connect('changed', self._on_target_changed, i)
 
-            self._widgets['vbox_targets'].pack_start(target)
+            self._widgets['vbox_targets'].pack_start(target, True, True, 0)
             self.targets.append(textbox)
 
         for target, next_target in zip(self.targets, self.targets[1:] + [None]):
@@ -446,27 +446,27 @@ class UnitView(gtk.EventBox, GObjectWrapper, gtk.CellEditable, BaseView):
 
         self.emit('targets-created', self.targets)
 
-    def _create_textbox(self, text=u'', editable=True, role=None, scroll_policy=gtk.POLICY_AUTOMATIC):
+    def _create_textbox(self, text=u'', editable=True, role=None, scroll_policy=Gtk.PolicyType.AUTOMATIC):
         textbox = TextBox(self.controller.main_controller, role=role)
         textbox.set_editable(editable)
-        textbox.set_wrap_mode(gtk.WRAP_WORD_CHAR)
-        textbox.set_border_window_size(gtk.TEXT_WINDOW_TOP, 1)
+        textbox.set_wrap_mode(Gtk.WrapMode.WORD_CHAR)
+        textbox.set_border_window_size(Gtk.TextWindowType.TOP, 1)
         textbox.set_left_margin(2)
         textbox.set_right_margin(2)
         textbox.set_text(text or u'')
         textbox.connect('focus-in-event', self._on_textbox_focused)
         textbox.connect('focus-out-event', self._on_textbox_unfocused)
 
-        scrollwnd = gtk.ScrolledWindow()
-        scrollwnd.set_policy(gtk.POLICY_NEVER, scroll_policy)
-        scrollwnd.set_shadow_type(gtk.SHADOW_IN)
+        scrollwnd = Gtk.ScrolledWindow()
+        scrollwnd.set_policy(Gtk.PolicyType.NEVER, scroll_policy)
+        scrollwnd.set_shadow_type(Gtk.ShadowType.IN)
         scrollwnd.add(textbox)
 
         return scrollwnd
 
     def _create_workflow_liststore(self):
         workflow = self.controller.current_unit._workflow
-        lst = gtk.ListStore(str, object)
+        lst = Gtk.ListStore(str, object)
         if not workflow:
             return lst
         for state in workflow.states:
@@ -475,12 +475,12 @@ class UnitView(gtk.EventBox, GObjectWrapper, gtk.CellEditable, BaseView):
 
     def _layout_update_notes(self, origin):
         if origin not in self._widgets['notes']:
-            label = gtk.Label()
+            label = Gtk.Label()
             label.set_line_wrap(True)
-            label.set_justify(gtk.JUSTIFY_FILL)
+            label.set_justify(Gtk.Justification.FILL)
             label.set_property('selectable', True)
 
-            self._widgets['vbox_middle'].pack_start(label)
+            self._widgets['vbox_middle'].pack_start(label, True, True, 0)
             if origin == 'programmer':
                 self._widgets['vbox_middle'].reorder_child(label, 0)
             elif origin == 'translator':
@@ -546,11 +546,11 @@ class UnitView(gtk.EventBox, GObjectWrapper, gtk.CellEditable, BaseView):
 
     def _layout_update_context_info(self):
         if not self._widgets['context_info']:
-            label = gtk.Label()
+            label = Gtk.Label()
             label.set_line_wrap(True)
-            label.set_justify(gtk.JUSTIFY_FILL)
+            label.set_justify(Gtk.Justification.FILL)
             label.set_property('selectable', True)
-            self._widgets['vbox_middle'].pack_start(label)
+            self._widgets['vbox_middle'].pack_start(label, True, True, 0)
             self._widgets['vbox_middle'].reorder_child(label, 2)
             self._widgets['context_info'] = label
 
@@ -648,7 +648,7 @@ class UnitView(gtk.EventBox, GObjectWrapper, gtk.CellEditable, BaseView):
         self.modified()
 
     def _on_key_press_event(self, _widget, event, *_args):
-        if event.keyval == gtk.keysyms.Return or event.keyval == gtk.keysyms.KP_Enter:
+        if event.keyval == Gdk.KEY_Return or event.keyval == Gdk.KEY_KP_Enter:
             self.must_advance = True
             # Clear selected elements
             self.editing_done()

--- a/virtaal/views/unitview.py
+++ b/virtaal/views/unitview.py
@@ -525,9 +525,9 @@ class UnitView(Gtk.EventBox, GObjectWrapper, Gtk.CellEditable, BaseView):
                 # The above condition should *never* be False
                 textbox = self.sources[0]
                 textbox.set_text(u'')
-                textbox.parent.show()
+                textbox.get_parent().show()
             for i in range(1, num_source_widgets):
-                self.sources[i].parent.hide_all()
+                self.sources[i].get_parent().hide_all()
             return
 
         num_unit_sources = 1
@@ -577,9 +577,9 @@ class UnitView(Gtk.EventBox, GObjectWrapper, Gtk.CellEditable, BaseView):
                 # The above condition should *never* be False
                 textbox = self.targets[0]
                 textbox.set_text(u'')
-                textbox.parent.show_all()
+                textbox.get_parent().show_all()
             for i in range(1, num_target_widgets):
-                self.targets[i].parent.hide_all()
+                self.targets[i].get_parent().hide_all()
             return
 
         num_unit_targets = 1

--- a/virtaal/views/unitview.py
+++ b/virtaal/views/unitview.py
@@ -616,7 +616,7 @@ class UnitView(Gtk.EventBox, GObjectWrapper, Gtk.CellEditable, BaseView):
                 _("Move one step forward in the workflow (Ctrl+Enter)")
             )
             statenav.connect('selection-changed', self._on_state_changed)
-            self._widgets['vbox_right'].pack_end(statenav, False, False, 0)
+            self._widgets['vbox_right'].pack_end(statenav, False, True, 0)
             self._widgets['state'] = statenav
 
         state_names = self.controller.get_unit_state_names()

--- a/virtaal/views/util.py
+++ b/virtaal/views/util.py
@@ -18,8 +18,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-import gobject
-import gtk
+from gi.repository import GObject
+from gi.repository import Gtk
 
 __all__ = ['pulse']
 
@@ -37,7 +37,7 @@ def pulse_step(widget, steptime, colordiff, stopcolor, component):
     if len(colordiff) < 3:
         raise ValueError('colordiff does not have all colour deltas')
 
-    col = getattr(widget.style, component)[gtk.STATE_NORMAL]
+    col = getattr(widget.style, component)[Gtk.StateType.NORMAL]
     modify_func = getattr(widget, 'modify_%s' % (component))
 
     # Check if col's values have not overshot stopcolor, taking into
@@ -48,12 +48,12 @@ def pulse_step(widget, steptime, colordiff, stopcolor, component):
             (colordiff[COL_GREEN] == 0 or (colordiff[COL_GREEN] > 0 and col.green+colordiff[COL_GREEN] >= stopcolor[COL_GREEN]) or (colordiff[COL_GREEN] < 0 and col.green+colordiff[COL_GREEN] <= stopcolor[COL_GREEN])) and \
             (colordiff[COL_BLUE] == 0 or (colordiff[COL_BLUE]  > 0 and col.blue+colordiff[COL_BLUE] >= stopcolor[COL_BLUE]) or (colordiff[COL_BLUE] < 0 and col.blue+colordiff[COL_BLUE] <= stopcolor[COL_BLUE])):
         # Pulse overshot, restore stopcolor and end the fade
-        col = gtk.gdk.Color(
+        col = Gdk.Color(
             red=stopcolor[COL_RED],
             green=stopcolor[COL_GREEN],
             blue=stopcolor[COL_BLUE]
         )
-        modify_func(gtk.STATE_NORMAL, col)
+        modify_func(Gtk.StateType.NORMAL, col)
         #logging.debug(
         #    'Pulse complete (%d, %d, %d) > (%d, %d, %d)' %
         #    (col.red, col.green, col.blue, stopcolor[COL_RED], stopcolor[COL_GREEN], stopcolor[COL_BLUE])
@@ -68,22 +68,22 @@ def pulse_step(widget, steptime, colordiff, stopcolor, component):
             col.green == stopcolor[COL_GREEN] and \
             col.blue  == stopcolor[COL_BLUE]:
         # Pulse complete
-        modify_func(gtk.STATE_NORMAL, col)
+        modify_func(Gtk.StateType.NORMAL, col)
         return
 
-    modify_func(gtk.STATE_NORMAL, col)
-    gobject.timeout_add(steptime, pulse_step, widget, steptime, colordiff, stopcolor, component)
+    modify_func(Gtk.StateType.NORMAL, col)
+    GObject.timeout_add(steptime, pulse_step, widget, steptime, colordiff, stopcolor, component)
 
 def pulse(widget, color, fadetime=5000, steptime=10, component='bg'):
     """Fade the background colour of the current widget from the given colour
         back to its original background colour.
-        @type  widget: gtk.Widget
+        @type  widget: Gtk.Widget
         @param widget: The widget to pulse.
         @param color: Tuple of RGB-values.
         @param fadetime: The total duration (in ms) of the fade.
         @param steptime: The number of steps that the fade should be divided
             into."""
-    if not isinstance(widget, gtk.Widget):
+    if not isinstance(widget, Gtk.Widget):
         raise ValueError('widget is not a GTK widget')
 
     if not component in ('base', 'bg', 'fg'):
@@ -91,7 +91,7 @@ def pulse(widget, color, fadetime=5000, steptime=10, component='bg'):
 
     modify_func = getattr(widget, 'modify_%s' % (component))
 
-    col = getattr(widget.style, component)[gtk.STATE_NORMAL]
+    col = getattr(widget.style, component)[Gtk.StateType.NORMAL]
     nsteps = fadetime/steptime
     colordiff = (
         (col.red   - color[COL_RED])   / nsteps,
@@ -103,10 +103,10 @@ def pulse(widget, color, fadetime=5000, steptime=10, component='bg'):
     #    'Before fade: [widget %s][steptime %d][colordiff %s][stopcolor %s]' %
     #    (widget, steptime, colordiff, stopcolor)
     #)
-    pulsecol = gtk.gdk.Color(
+    pulsecol = Gdk.Color(
         red=color[COL_RED],
         green=color[COL_GREEN],
         blue=color[COL_BLUE]
     )
-    modify_func(gtk.STATE_NORMAL, pulsecol)
-    gobject.timeout_add(steptime, pulse_step, widget, steptime, colordiff, stopcolor, component)
+    modify_func(Gtk.StateType.NORMAL, pulsecol)
+    GObject.timeout_add(steptime, pulse_step, widget, steptime, colordiff, stopcolor, component)

--- a/virtaal/views/welcomescreenview.py
+++ b/virtaal/views/welcomescreenview.py
@@ -18,13 +18,14 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import, print_function, unicode_literals
 
 from gi.repository import Gtk
 from gi.repository.GObject import idle_add
 
-from baseview import BaseView
 from virtaal.common.pan_app import get_abs_data_filename, ui_language
 from virtaal.views.widgets.welcomescreen import WelcomeScreen
+from .baseview import BaseView
 
 
 class WelcomeScreenView(BaseView):

--- a/virtaal/views/welcomescreenview.py
+++ b/virtaal/views/welcomescreenview.py
@@ -19,13 +19,12 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-import gtk
+from gi.repository import Gtk
 from gobject import idle_add
 
+from baseview import BaseView
 from virtaal.common.pan_app import get_abs_data_filename, ui_language
 from virtaal.views.widgets.welcomescreen import WelcomeScreen
-
-from baseview import BaseView
 
 
 class WelcomeScreenView(BaseView):
@@ -42,14 +41,14 @@ class WelcomeScreenView(BaseView):
         self.parent_widget = self.controller.main_controller.view.gui.get_object('vbox_main')
 
         self.set_banner()
-        self.widget.set_policy(gtk.POLICY_NEVER, gtk.POLICY_AUTOMATIC)
+        self.widget.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
         self.widget.connect('button-clicked', self._on_button_clicked)
 
     def set_banner(self):
         if ui_language == "ar":
             self.widget.set_banner_image(get_abs_data_filename(['virtaal', 'welcome_screen_banner_ar.png']))
             return
-        if self.widget.get_direction() == gtk.TEXT_DIR_RTL:
+        if self.widget.get_direction() == Gtk.TextDirection.RTL:
             self.widget.set_banner_image(get_abs_data_filename(['virtaal', 'welcome_screen_banner_rtl.png']))
         else:
             self.widget.set_banner_image(get_abs_data_filename(['virtaal', 'welcome_screen_banner.png']))
@@ -108,11 +107,11 @@ class WelcomeScreenView(BaseView):
 
         iconfile = get_abs_data_filename(['icons', 'hicolor', '24x24', 'mimetypes', 'x-translation.png'])
         for i in range(len(items)):
-            buttons[i].child.get_children()[0].set_from_file(iconfile)
+            buttons[i].get_child().get_children()[0].set_from_file(iconfile)
             name = items[i]['name']
             name = name.replace('&', '&amp;')
             name = name.replace('<', '&lt;')
-            buttons[i].child.get_children()[1].set_markup(markup % {'name': name})
+            buttons[i].get_child().get_children()[1].set_markup(markup % {'name': name})
             buttons[i].set_tooltip_text(items[i]['uri'])
             buttons[i].props.visible = True
         for i in range(len(items), 5):

--- a/virtaal/views/welcomescreenview.py
+++ b/virtaal/views/welcomescreenview.py
@@ -20,7 +20,7 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 from gi.repository import Gtk
-from gobject import idle_add
+from gi.repository.GObject import idle_add
 
 from baseview import BaseView
 from virtaal.common.pan_app import get_abs_data_filename, ui_language
@@ -57,11 +57,11 @@ class WelcomeScreenView(BaseView):
     # METHODS #
     def hide(self):
         self.widget.hide()
-        if self.widget.parent is self.parent_widget:
+        if self.widget.get_parent() is self.parent_widget:
             self.parent_widget.remove(self.widget)
 
     def show(self):
-        if not self.widget.parent:
+        if not self.widget.get_parent():
             self.parent_widget.add(self.widget)
         else:
             self.widget.reparent(self.parent_widget)
@@ -72,10 +72,10 @@ class WelcomeScreenView(BaseView):
 
         def calculate_width():
             txt = self.widget.widgets['txt_features']
-            expander = txt.parent.parent
+            expander = txt.get_parent().get_parent()
 
             screenwidth = self.widget.get_allocation().width
-            col1 = self.widget.widgets['buttons']['open'].parent
+            col1 = self.widget.widgets['buttons']['open'].get_parent()
             width_col1 = col1.get_allocation().width
             if width_col1 > 0.7 * screenwidth:
                 width_col1 = int(0.7 * screenwidth)

--- a/virtaal/views/widgets/aboutdialog.py
+++ b/virtaal/views/widgets/aboutdialog.py
@@ -18,16 +18,16 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-import gtk
+from gi.repository import Gtk
 
 from virtaal import __version__
 from virtaal.common import pan_app
 from virtaal.support import openmailto
 
 
-class AboutDialog(gtk.AboutDialog):
+class AboutDialog(Gtk.AboutDialog):
     def __init__(self, parent):
-        gtk.AboutDialog.__init__(self)
+        GObject.GObject.__init__(self)
         self._register_uri_handlers()
         self.set_name("Virtaal")
         self.set_version(__version__.ver)
@@ -72,7 +72,7 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.""")
         # l10n: Rather than translating, fill in the names of the translators
         self.set_translator_credits(_("translator-credits"))
         self.set_icon(parent.get_icon())
-        self.set_logo(gtk.gdk.pixbuf_new_from_file(pan_app.get_abs_data_filename(["virtaal", "virtaal_logo.png"])))
+        self.set_logo(GdkPixbuf.Pixbuf.new_from_file(pan_app.get_abs_data_filename(["virtaal", "virtaal_logo.png"])))
         self.set_artists([
                 "Heather Bailey",
                 ])
@@ -92,5 +92,5 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.""")
 
         Use open and mailto from virtaal.support.openmailto
         """
-        gtk.about_dialog_set_url_hook(self.on_url, "url")
-        gtk.about_dialog_set_email_hook(self.on_url, "mail")
+        Gtk.about_dialog_set_url_hook(self.on_url, "url")
+        Gtk.about_dialog_set_email_hook(self.on_url, "mail")

--- a/virtaal/views/widgets/aboutdialog.py
+++ b/virtaal/views/widgets/aboutdialog.py
@@ -18,7 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-from gi.repository import Gtk
+from gi.repository import Gtk, GObject, GdkPixbuf
 
 from virtaal import __version__
 from virtaal.common import pan_app
@@ -92,5 +92,3 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.""")
 
         Use open and mailto from virtaal.support.openmailto
         """
-        Gtk.about_dialog_set_url_hook(self.on_url, "url")
-        Gtk.about_dialog_set_email_hook(self.on_url, "mail")

--- a/virtaal/views/widgets/aboutdialog.py
+++ b/virtaal/views/widgets/aboutdialog.py
@@ -18,7 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-from gi.repository import Gtk, GObject, GdkPixbuf
+from gi.repository import Gtk, GdkPixbuf
 
 from virtaal import __version__
 from virtaal.common import pan_app
@@ -27,7 +27,7 @@ from virtaal.support import openmailto
 
 class AboutDialog(Gtk.AboutDialog):
     def __init__(self, parent):
-        GObject.GObject.__init__(self)
+        super(AboutDialog, self).__init__()
         self._register_uri_handlers()
         self.set_name("Virtaal")
         self.set_version(__version__.ver)

--- a/virtaal/views/widgets/cellrendererwidget.py
+++ b/virtaal/views/widgets/cellrendererwidget.py
@@ -93,7 +93,7 @@ class CellRendererWidget(Gtk.CellRenderer):
         return self.XPAD, self.YPAD, width, height
 
     def do_render(self, window, widget, bg_area, cell_area, flags):
-        #print '%s>> on_render(flags=%s)' % (self.strfunc(self.widget), flagstr(flags))
+        # print '%s>> on_render(flags=%s)' % (self.strfunc(self.widget), flagstr(flags))
         if flags & Gtk.CellRendererState.SELECTED:
             self.props.mode = Gtk.CellRendererMode.EDITABLE
             # FIXME: this will crash program
@@ -105,16 +105,13 @@ class CellRendererWidget(Gtk.CellRenderer):
         layout = self.create_pango_layout(self.strfunc(self.widget), widget, w)
         layout_w, layout_h = layout.get_pixel_size()
         y = cell_area.y + yo + (h-layout_h)/2
-        Gtk.paint_layout(
-            style=widget.get_style(),
+        Gtk.render_layout(
+            context=widget.get_style_context(),
             cr=window,
-            state_type=Gtk.StateType.NORMAL,
-            use_text=True,
-            widget=widget,
-            detail='',
             x=x,
             y=y,
-            layout=layout)
+            layout=layout
+        )
 
     def do_start_editing(self, event, tree_view, path, bg_area, cell_area, flags):
         #print '%s>> on_start_editing(flags=%s, event=%s)' % (self.strfunc(self.widget), flagstr(flags), event)
@@ -172,6 +169,7 @@ class CellWidget(Gtk.HBox, Gtk.CellEditable):
     # INITIALIZERS #
     def __init__(self, *widgets):
         super(CellWidget, self).__init__()
+        Gtk.CellEditable.__init__(self)
         for w in widgets:
             if w.get_parent() is not None:
                 w.get_parent().remove(w)

--- a/virtaal/views/widgets/cellrendererwidget.py
+++ b/virtaal/views/widgets/cellrendererwidget.py
@@ -18,8 +18,11 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
+import gi
 
-from gi.repository import Gtk, GObject
+gi.require_version('Gtk', '3.0')
+
+from gi.repository import Gtk
 from gi.repository import Pango
 from gi.repository.GObject import idle_add, PARAM_READWRITE, SIGNAL_RUN_FIRST, TYPE_PYOBJECT
 
@@ -27,10 +30,10 @@ from gi.repository.GObject import idle_add, PARAM_READWRITE, SIGNAL_RUN_FIRST, T
 def flagstr(flags):
     """Create a string-representation for the given flags structure."""
     fset = []
-    for f in dir(gtk):
+    for f in dir(Gtk):
         if not f.startswith('CELL_RENDERER_'):
             continue
-        if flags & getattr(gtk, f):
+        if flags & getattr(Gtk, f):
             fset.append(f)
     return '|'.join(fset)
 
@@ -47,7 +50,7 @@ class CellRendererWidget(Gtk.CellRenderer):
 
     # INITIALIZERS #
     def __init__(self, strfunc, default_width=-1):
-        GObject.GObject.__init__(self)
+        super(CellRendererWidget, self).__init__()
 
         self.default_width = default_width
         self._editing = False
@@ -93,7 +96,8 @@ class CellRendererWidget(Gtk.CellRenderer):
         #print '%s>> on_render(flags=%s)' % (self.strfunc(self.widget), flagstr(flags))
         if flags & Gtk.CellRendererState.SELECTED:
             self.props.mode = Gtk.CellRendererMode.EDITABLE
-            self._start_editing(widget) # FIXME: This is obviously a hack, but what more do you want?
+            # FIXME: this will crash program
+            # self._start_editing(widget) # FIXME: This is obviously a hack, but what more do you want?
             return True
         self.props.mode = Gtk.CellRendererMode.INERT
         xo, yo, w, h = self.get_size(widget, cell_area)
@@ -189,7 +193,7 @@ if __name__ == "__main__":
     class Tree(Gtk.TreeView):
         def __init__(self):
             self.store = Gtk.ListStore(str, TYPE_PYOBJECT, bool)
-            GObject.GObject.__init__(self)
+            super(Tree, self).__init__()
             self.set_model(self.store)
             self.set_headers_visible(True)
 

--- a/virtaal/views/widgets/cellrendererwidget.py
+++ b/virtaal/views/widgets/cellrendererwidget.py
@@ -98,8 +98,9 @@ class CellRendererWidget(Gtk.CellRenderer):
             self.props.mode = Gtk.CellRendererMode.EDITABLE
             # FIXME: this will crash program
             # self._start_editing(widget) # FIXME: This is obviously a hack, but what more do you want?
-            return True
-        self.props.mode = Gtk.CellRendererMode.INERT
+            # return True
+        else:
+            self.props.mode = Gtk.CellRendererMode.INERT
         xo, yo, w, h = self.get_size(widget, cell_area)
         x = cell_area.x + xo
         layout = self.create_pango_layout(self.strfunc(self.widget), widget, w)

--- a/virtaal/views/widgets/cellrendererwidget.py
+++ b/virtaal/views/widgets/cellrendererwidget.py
@@ -24,7 +24,9 @@ gi.require_version('Gtk', '3.0')
 
 from gi.repository import Gtk
 from gi.repository import Pango
-from gi.repository.GObject import idle_add, PARAM_READWRITE, SIGNAL_RUN_FIRST, TYPE_PYOBJECT
+from gi.repository.GObject import ParamFlags, SignalFlags, TYPE_PYOBJECT
+PARAM_READWRITE = ParamFlags.READWRITE
+SIGNAL_RUN_FIRST = SignalFlags.RUN_FIRST
 
 
 def flagstr(flags):
@@ -186,7 +188,7 @@ if __name__ == "__main__":
         def insert(self, name):
             iter = self.store.append()
             hb = Gtk.HBox()
-            hb.pack_start(Gtk.Button(name, True, True, 0), False, True, 0)
+            hb.pack_start(Gtk.Button.new_with_label(name), False, True, 0)
             lbl = Gtk.Label(label=(name + ' ') * 20)
             lbl.set_line_wrap(True)
             hb.pack_start(lbl, False, True, 0)

--- a/virtaal/views/widgets/cellrendererwidget.py
+++ b/virtaal/views/widgets/cellrendererwidget.py
@@ -170,7 +170,6 @@ class CellWidget(Gtk.HBox, Gtk.CellEditable):
     # INITIALIZERS #
     def __init__(self, *widgets):
         super(CellWidget, self).__init__()
-        Gtk.CellEditable.__init__(self)
         for w in widgets:
             if w.get_parent() is not None:
                 w.get_parent().remove(w)

--- a/virtaal/views/widgets/cellrendererwidget.py
+++ b/virtaal/views/widgets/cellrendererwidget.py
@@ -19,9 +19,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-from gi.repository import Gtk
+from gi.repository import Gtk, GObject
 from gi.repository import Pango
-from gobject import idle_add, PARAM_READWRITE, SIGNAL_RUN_FIRST, TYPE_PYOBJECT
+from gi.repository.GObject import idle_add, PARAM_READWRITE, SIGNAL_RUN_FIRST, TYPE_PYOBJECT
 
 
 def flagstr(flags):
@@ -35,7 +35,7 @@ def flagstr(flags):
     return '|'.join(fset)
 
 
-class CellRendererWidget(Gtk.GenericCellRenderer):
+class CellRendererWidget(Gtk.CellRenderer):
     __gtype_name__ = 'CellRendererWidget'
     __gproperties__ = {
         'widget': (TYPE_PYOBJECT, 'Widget', 'The column containing the widget to render', PARAM_READWRITE),

--- a/virtaal/views/widgets/cellrendererwidget.py
+++ b/virtaal/views/widgets/cellrendererwidget.py
@@ -101,11 +101,14 @@ class CellRendererWidget(Gtk.CellRenderer):
             # return True
         else:
             self.props.mode = Gtk.CellRendererMode.INERT
-        xo, yo, w, h = self.get_size(widget, cell_area)
-        x = cell_area.x + xo
+
+        x = cell_area.x + self.XPAD
+        y = cell_area.y + self.YPAD
+        w = cell_area.width - 2 * self.XPAD
+        h = cell_area.height - 2 * self.YPAD
         layout = self.create_pango_layout(self.strfunc(self.widget), widget, w)
         layout_w, layout_h = layout.get_pixel_size()
-        y = cell_area.y + yo + (h-layout_h)/2
+        y = y + (h-layout_h)/2
         Gtk.render_layout(
             context=widget.get_style_context(),
             cr=window,

--- a/virtaal/views/widgets/cellrendererwidget.py
+++ b/virtaal/views/widgets/cellrendererwidget.py
@@ -44,7 +44,7 @@ class CellRendererWidget(Gtk.CellRenderer):
         'widget': (TYPE_PYOBJECT, 'Widget', 'The column containing the widget to render', PARAM_READWRITE),
     }
 
-    XPAD = 0
+    XPAD = 2
     YPAD = 2
 
 

--- a/virtaal/views/widgets/label_expander.py
+++ b/virtaal/views/widgets/label_expander.py
@@ -18,32 +18,32 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-import gtk
-import gtk.gdk
-import gobject
-import pango
+import Gtk.gdk
+from gi.repository import GObject
+from gi.repository import Gtk
 
 from virtaal.views import markup
 
-class LabelExpander(gtk.EventBox):
+
+class LabelExpander(Gtk.EventBox):
     __gproperties__ = {
-        "expanded": (gobject.TYPE_BOOLEAN,
+        "expanded": (GObject.TYPE_BOOLEAN,
                      "expanded",
                      "A boolean indicating whether this widget has been expanded to show its contained widget",
                      False,
-                     gobject.PARAM_READWRITE),
+                     GObject.PARAM_READWRITE),
     }
 
     def __init__(self, widget, get_text, expanded=False):
         super(LabelExpander, self).__init__()
 
-        label_text = gtk.Label()
+        label_text = Gtk.Label()
         label_text.set_single_line_mode(False)
         label_text.set_line_wrap(True)
-        label_text.set_justify(gtk.JUSTIFY_FILL)
+        label_text.set_justify(Gtk.Justification.FILL)
         label_text.set_use_markup(True)
 
-        self.label = gtk.EventBox()
+        self.label = Gtk.EventBox()
         self.label.add(label_text)
 
         self.widget = widget
@@ -60,18 +60,19 @@ class LabelExpander(gtk.EventBox):
         setattr(self, prop.name, value)
 
     def _get_expanded(self):
-        return self.child == self.widget
+        return self.get_child() == self.widget
 
     def _set_expanded(self, value):
-        if self.child != None:
-            self.remove(self.child)
+        if self.get_child() != None:
+            self.remove(self.get_child())
 
         if value:
             self.add(self.widget)
         else:
             self.add(self.label)
-            self.label.child.set_markup(markup.markuptext(self.get_text(), fancyspaces=False, markupescapes=False))
+            self.label.get_child().set_markup(
+                markup.markuptext(self.get_text(), fancyspaces=False, markupescapes=False))
 
-        self.child.show()
+        self.get_child().show()
 
     expanded = property(_get_expanded, _set_expanded)

--- a/virtaal/views/widgets/langadddialog.py
+++ b/virtaal/views/widgets/langadddialog.py
@@ -18,10 +18,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-import gobject
-import gtk
+from gi.repository import Gtk
 
-from virtaal.common import pan_app
 from virtaal.views.baseview import BaseView
 
 
@@ -41,7 +39,7 @@ class LanguageAddDialog(object):
         )
 
         self._get_widgets()
-        if isinstance(parent, gtk.Widget):
+        if isinstance(parent, Gtk.Widget):
             self.dialog.set_transient_for(parent)
             self.dialog.set_icon(parent.get_toplevel().get_icon())
 
@@ -90,7 +88,7 @@ class LanguageAddDialog(object):
     def run(self, clear=True):
         if clear:
             self.clear()
-        response = self.dialog.run() == gtk.RESPONSE_OK
+        response = self.dialog.run() == Gtk.ResponseType.OK
         self.dialog.hide()
         return response
 

--- a/virtaal/views/widgets/langselectdialog.py
+++ b/virtaal/views/widgets/langselectdialog.py
@@ -18,11 +18,11 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-import gobject
-import gtk
 import locale
 
-from virtaal.common import pan_app
+from gi.repository import GObject
+from gi.repository import Gtk
+
 from virtaal.views.baseview import BaseView
 
 
@@ -45,7 +45,7 @@ class LanguageSelectDialog(object):
         self._init_treeviews()
         self.update_languages(languages)
 
-        if isinstance(parent, gtk.Widget):
+        if isinstance(parent, Gtk.Widget):
             self.dialog.set_transient_for(parent)
             self.dialog.set_icon(parent.get_toplevel().get_icon())
 
@@ -58,12 +58,12 @@ class LanguageSelectDialog(object):
 
         self.dialog = self.gui.get_object('LanguageSelector')
 
-        self.btn_ok.connect('clicked', lambda *args: self.dialog.response(gtk.RESPONSE_OK))
-        self.btn_cancel.connect('clicked', lambda *args: self.dialog.response(gtk.RESPONSE_CANCEL))
+        self.btn_ok.connect('clicked', lambda *args: self.dialog.response(Gtk.ResponseType.OK))
+        self.btn_cancel.connect('clicked', lambda *args: self.dialog.response(Gtk.ResponseType.CANCEL))
 
     def _init_treeviews(self):
-        self.lst_langs_src = gtk.ListStore(gobject.TYPE_STRING, gobject.TYPE_STRING)
-        self.lst_langs_tgt = gtk.ListStore(gobject.TYPE_STRING, gobject.TYPE_STRING)
+        self.lst_langs_src = Gtk.ListStore(GObject.TYPE_STRING, GObject.TYPE_STRING)
+        self.lst_langs_tgt = Gtk.ListStore(GObject.TYPE_STRING, GObject.TYPE_STRING)
         self.tvw_sourcelang.set_model(self.lst_langs_src)
         self.tvw_targetlang.set_model(self.lst_langs_tgt)
 
@@ -75,31 +75,31 @@ class LanguageSelectDialog(object):
         self.tvw_sourcelang.set_search_equal_func(searchfunc)
         self.tvw_targetlang.set_search_equal_func(searchfunc)
 
-        cell = gtk.CellRendererText()
-        col = gtk.TreeViewColumn(_('Language'))
-        col.pack_start(cell)
+        cell = Gtk.CellRendererText()
+        col = Gtk.TreeViewColumn(_('Language'))
+        col.pack_start(cell, True, True, 0)
         col.add_attribute(cell, 'text', 0)
         col.set_sort_column_id(0)
         self.tvw_sourcelang.append_column(col)
 
-        cell = gtk.CellRendererText()
-        col = gtk.TreeViewColumn(_('Language'))
-        col.pack_start(cell)
+        cell = Gtk.CellRendererText()
+        col = Gtk.TreeViewColumn(_('Language'))
+        col.pack_start(cell, True, True, 0)
         col.add_attribute(cell, 'text', 0)
         col.set_sort_column_id(0)
         self.tvw_targetlang.append_column(col)
 
-        cell = gtk.CellRendererText()
+        cell = Gtk.CellRendererText()
         #l10n: This is the column heading for the language code
-        col = gtk.TreeViewColumn(_('Code'))
-        col.pack_start(cell)
+        col = Gtk.TreeViewColumn(_('Code'))
+        col.pack_start(cell, True, True, 0)
         col.add_attribute(cell, 'text', 1)
         col.set_sort_column_id(1)
         self.tvw_sourcelang.append_column(col)
 
-        cell = gtk.CellRendererText()
-        col = gtk.TreeViewColumn(_('Code'))
-        col.pack_start(cell)
+        cell = Gtk.CellRendererText()
+        col = Gtk.TreeViewColumn(_('Code'))
+        col.pack_start(cell, True, True, 0)
         col.add_attribute(cell, 'text', 1)
         col.set_sort_column_id(1)
         self.tvw_targetlang.append_column(col)
@@ -139,7 +139,7 @@ class LanguageSelectDialog(object):
         self._select_lang(self.tvw_targetlang, tgtlang)
 
         self.tvw_targetlang.grab_focus()
-        response = self.dialog.run() == gtk.RESPONSE_OK
+        response = self.dialog.run() == Gtk.ResponseType.OK
         self.dialog.hide()
         return response
 

--- a/virtaal/views/widgets/langselectdialog.py
+++ b/virtaal/views/widgets/langselectdialog.py
@@ -77,14 +77,14 @@ class LanguageSelectDialog(object):
 
         cell = Gtk.CellRendererText()
         col = Gtk.TreeViewColumn(_('Language'))
-        col.pack_start(cell, True, True, 0)
+        col.pack_start(cell, True)
         col.add_attribute(cell, 'text', 0)
         col.set_sort_column_id(0)
         self.tvw_sourcelang.append_column(col)
 
         cell = Gtk.CellRendererText()
         col = Gtk.TreeViewColumn(_('Language'))
-        col.pack_start(cell, True, True, 0)
+        col.pack_start(cell, True)
         col.add_attribute(cell, 'text', 0)
         col.set_sort_column_id(0)
         self.tvw_targetlang.append_column(col)
@@ -92,14 +92,14 @@ class LanguageSelectDialog(object):
         cell = Gtk.CellRendererText()
         #l10n: This is the column heading for the language code
         col = Gtk.TreeViewColumn(_('Code'))
-        col.pack_start(cell, True, True, 0)
+        col.pack_start(cell, True)
         col.add_attribute(cell, 'text', 1)
         col.set_sort_column_id(1)
         self.tvw_sourcelang.append_column(col)
 
         cell = Gtk.CellRendererText()
         col = Gtk.TreeViewColumn(_('Code'))
-        col.pack_start(cell, True, True, 0)
+        col.pack_start(cell, True)
         col.add_attribute(cell, 'text', 1)
         col.set_sort_column_id(1)
         self.tvw_targetlang.append_column(col)

--- a/virtaal/views/widgets/listnav.py
+++ b/virtaal/views/widgets/listnav.py
@@ -26,7 +26,7 @@ options.
 
 import logging
 
-from gi.repository import Gtk, GObject
+from gi.repository import Gtk, GObject, Gdk
 
 from popupwidgetbutton import PopupWidgetButton
 
@@ -222,9 +222,10 @@ if __name__ == '__main__':
     listnav = ListNavigator()
 
     hb = Gtk.HBox()
-    hb.pack_start(listnav, expand=False, fill=False)
+    hb.pack_start(listnav, False, False, 0)
+
     vb = Gtk.VBox()
-    vb.pack_start(hb, expand=False, fill=False)
+    vb.pack_start(hb, False, False, 0)
 
     wnd = Gtk.Window()
     wnd.set_title('List Navigator Test')
@@ -246,7 +247,7 @@ if __name__ == '__main__':
 
         lst = Gtk.ListStore(str, object)
         for i in range(10):
-            lst.append([i, Item(i)])
+            lst.append([str(i), Item(i)])
         return lst
     listnav.set_model(create_test_model())
 

--- a/virtaal/views/widgets/listnav.py
+++ b/virtaal/views/widgets/listnav.py
@@ -25,17 +25,16 @@ options.
 """
 
 import logging
-import gobject, gtk
 
 from popupwidgetbutton import PopupWidgetButton
 
 
-class ListNavigator(gtk.HBox):
+class ListNavigator(Gtk.HBox):
     __gtype_name__ = 'ListNavigator'
     __gsignals__ = {
-        'back-clicked':      (gobject.SIGNAL_RUN_FIRST, None, ()),
-        'forward-clicked':   (gobject.SIGNAL_RUN_FIRST, None, ()),
-        'selection-changed': (gobject.SIGNAL_RUN_FIRST, None, (object,))
+        'back-clicked': (GObject.SignalFlags.RUN_FIRST, None, ()),
+        'forward-clicked': (GObject.SignalFlags.RUN_FIRST, None, ()),
+        'selection-changed': (GObject.SignalFlags.RUN_FIRST, None, (object,))
     }
 
     COL_DISPLAY, COL_VALUE = range(2)
@@ -46,11 +45,11 @@ class ListNavigator(gtk.HBox):
         self._init_widgets()
 
     def _init_treeview(self):
-        tvw = gtk.TreeView()
-        tvw.append_column(gtk.TreeViewColumn(
-            "State", gtk.CellRendererText(), text=self.COL_DISPLAY
+        tvw = Gtk.TreeView()
+        tvw.append_column(Gtk.TreeViewColumn(
+            "State", Gtk.CellRendererText(), text=self.COL_DISPLAY
         ))
-        lst = gtk.ListStore(str, object)
+        lst = Gtk.ListStore(str, object)
         tvw.set_model(lst)
         tvw.set_headers_visible(False)
         tvw.get_selection().connect('changed', self._on_selection_changed)
@@ -59,14 +58,14 @@ class ListNavigator(gtk.HBox):
 
     def _init_widgets(self):
         # Create widgets
-        self.btn_back = gtk.Button()
-        self.btn_forward = gtk.Button()
-        self.btn_back.add(gtk.Arrow(gtk.ARROW_LEFT, gtk.SHADOW_NONE))
-        self.btn_forward.add(gtk.Arrow(gtk.ARROW_RIGHT, gtk.SHADOW_NONE))
+        self.btn_back = Gtk.Button()
+        self.btn_forward = Gtk.Button()
+        self.btn_back.add(Gtk.Arrow(Gtk.ArrowType.LEFT, Gtk.ShadowType.NONE))
+        self.btn_forward.add(Gtk.Arrow(Gtk.ArrowType.RIGHT, Gtk.ShadowType.NONE))
 
         self.tvw_items, self.lst_items = self._init_treeview()
-        frame = gtk.Frame()
-        #frame.set_shadow_type(gtk.SHADOW_ETCHED_IN)
+        frame = Gtk.Frame()
+        # frame.set_shadow_type(Gtk.ShadowType.ETCHED_IN)
         frame.add(self.tvw_items)
 
         self.btn_popup = PopupWidgetButton(frame, label='(uninitialised)')
@@ -107,15 +106,15 @@ class ListNavigator(gtk.HBox):
         self.tvw_items.set_cursor(i)
 
     def set_model(self, model, unselectable=None, select_first=True, select_name=None):
-        """Set the model for the C{gtk.TreeView} in the pop-up window.
+        """Set the model for the C{Gtk.TreeView} in the pop-up window.
             @type  select_first: bool
             @param select_first: Whether or not the first row should be selected
             @type  select_name: str
             @param select_name: The row with this display value is selected.
                 This overrides C{select_first}."""
-        if model.get_column_type(self.COL_DISPLAY) != gobject.TYPE_STRING:
+        if model.get_column_type(self.COL_DISPLAY) != GObject.TYPE_STRING:
             raise ValueError('Column %d does not contain "string" values' % (self.COL_DISPLAY))
-        if model.get_column_type(self.COL_VALUE) != gobject.TYPE_PYOBJECT:
+        if model.get_column_type(self.COL_VALUE) != GObject.TYPE_PYOBJECT:
             raise ValueError('Column %d does not contain "object" values' % (self.COL_VALUE))
 
         # we're just initialising, so we don't want listeners to think something really changed
@@ -174,15 +173,16 @@ class ListNavigator(gtk.HBox):
 
         # See virtaal.views.widgets.textbox.TextBox._on_key_pressed for an
         # explanation fo the filter below.
-        filtered_state = event.state & (gtk.gdk.CONTROL_MASK | gtk.gdk.MOD1_MASK | gtk.gdk.MOD4_MASK | gtk.gdk.SHIFT_MASK)
+        filtered_state = event.get_state() & (
+                    Gdk.ModifierType.CONTROL_MASK | Gdk.ModifierType.MOD1_MASK | Gdk.ModifierType.MOD4_MASK | Gdk.ModifierType.SHIFT_MASK)
         keyval = event.keyval
 
         if filtered_state == 0:
             # No modifying keys (like Ctrl and Alt) are pressed
-            if keyval == gtk.keysyms.Up and self.btn_popup.is_popup_visible:
+            if keyval == Gdk.KEY_Up and self.btn_popup.is_popup_visible:
                 self.move_state(-1)
                 return True
-            elif keyval == gtk.keysyms.Down and self.btn_popup.is_popup_visible:
+            elif keyval == Gdk.KEY_Down and self.btn_popup.is_popup_visible:
                 self.move_state(1)
                 return True
 
@@ -216,19 +216,19 @@ class ListNavigator(gtk.HBox):
 
 if __name__ == '__main__':
     # XXX: Uncomment below to test RTL
-    #gtk.widget_set_default_direction(gtk.TEXT_DIR_RTL)
+    #Gtk.widget_set_default_direction(Gtk.TextDirection.RTL)
     listnav = ListNavigator()
 
-    hb = gtk.HBox()
+    hb = Gtk.HBox()
     hb.pack_start(listnav, expand=False, fill=False)
-    vb = gtk.VBox()
+    vb = Gtk.VBox()
     vb.pack_start(hb, expand=False, fill=False)
 
-    wnd = gtk.Window()
+    wnd = Gtk.Window()
     wnd.set_title('List Navigator Test')
     wnd.set_size_request(400, 300)
     wnd.add(vb)
-    wnd.connect('destroy', lambda *args: gtk.main_quit())
+    wnd.connect('destroy', lambda *args: Gtk.main_quit())
     listnav.set_parent_window(wnd)
 
     def on_selection_changed(sender, selected):
@@ -242,11 +242,11 @@ if __name__ == '__main__':
             def __str__(self):
                 return '<Item i=%s>' % (self.i)
 
-        lst = gtk.ListStore(str, object)
+        lst = Gtk.ListStore(str, object)
         for i in range(10):
             lst.append([i, Item(i)])
         return lst
     listnav.set_model(create_test_model())
 
     wnd.show_all()
-    gtk.main()
+    Gtk.main()

--- a/virtaal/views/widgets/listnav.py
+++ b/virtaal/views/widgets/listnav.py
@@ -26,6 +26,8 @@ options.
 
 import logging
 
+from gi.repository import Gtk, GObject
+
 from popupwidgetbutton import PopupWidgetButton
 
 
@@ -77,9 +79,9 @@ class ListNavigator(Gtk.HBox):
         self.btn_popup.connect('key-press-event', self._on_popup_key_press_event)
 
         # Add widgets to containers
-        self.pack_start(self.btn_back,    expand=False, fill=False)
-        self.pack_start(self.btn_popup,   expand=True,  fill=True)
-        self.pack_start(self.btn_forward, expand=False, fill=False)
+        self.pack_start(self.btn_back, False, False, 0)
+        self.pack_start(self.btn_popup, True, True, 0)
+        self.pack_start(self.btn_forward, False, False, 0)
 
     def set_tooltips_text(self, backward, default, forward):
         """Set tooltips for the widgets."""

--- a/virtaal/views/widgets/listnav.py
+++ b/virtaal/views/widgets/listnav.py
@@ -23,12 +23,13 @@ ListNavigator: A composite widget for navigating in a list of "states" by using
 "previous" and "next" buttons as well as a pop-up list containing all available
 options.
 """
+from __future__ import absolute_import, print_function, unicode_literals
 
 import logging
 
 from gi.repository import Gtk, GObject, Gdk
 
-from popupwidgetbutton import PopupWidgetButton
+from .popupwidgetbutton import PopupWidgetButton
 
 
 class ListNavigator(Gtk.HBox):

--- a/virtaal/views/widgets/popupmenubutton.py
+++ b/virtaal/views/widgets/popupmenubutton.py
@@ -18,7 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-import gtk
+from gi.repository import Gtk
 
 # Positioning constants below:
 # POS_CENTER_BELOW: Centers the pop-up window below the button (default).
@@ -44,16 +44,17 @@ _rtl_pos_map = {
         POS_NW_SW: POS_NE_SE,
 }
 
-class PopupMenuButton(gtk.ToggleButton):
+
+class PopupMenuButton(Gtk.ToggleButton):
     """A toggle button that displays a pop-up menu when clicked."""
 
     # INITIALIZERS #
     def __init__(self, label=None, menu_pos=POS_SW_NW):
-        gtk.ToggleButton.__init__(self, label=label)
-        self.set_relief(gtk.RELIEF_NONE)
-        self.set_menu(gtk.Menu())
+        GObject.GObject.__init__(self, label=label)
+        self.set_relief(Gtk.ReliefStyle.NONE)
+        self.set_menu(Gtk.Menu())
 
-        if self.get_direction() == gtk.TEXT_DIR_LTR:
+        if self.get_direction() == Gtk.TextDirection.LTR:
             self.menu_pos = menu_pos
         else:
             self.menu_pos = _rtl_pos_map.get(menu_pos, POS_SE_NE)

--- a/virtaal/views/widgets/popupmenubutton.py
+++ b/virtaal/views/widgets/popupmenubutton.py
@@ -18,7 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-from gi.repository import Gtk, GObject
+from gi.repository import Gdk, Gtk, GObject
 
 from six import string_types as unicode
 
@@ -116,7 +116,29 @@ class PopupMenuButton(Gtk.ToggleButton):
         return True
 
     def popup(self):
-        self.menu.popup(None, None, self._calculate_popup_pos, None, 0, 0)
+        # default is POS_SW_NW
+        menu_anchor = Gdk.Gravity.SOUTH_WEST
+        widget_anchor = Gdk.Gravity.NORTH_WEST
+        if self.menu_pos == POS_NW_SW:
+            menu_anchor = Gdk.Gravity.NORTH_WEST
+            widget_anchor = Gdk.Gravity.SOUTH_WEST
+        elif self.menu_pos == POS_NE_SE:
+            menu_anchor = Gdk.Gravity.NORTH_EAST
+            widget_anchor = Gdk.Gravity.SOUTH_EAST
+        elif self.menu_pos == POS_SE_NE:
+            menu_anchor = Gdk.Gravity.SOUTH_EAST
+            widget_anchor = Gdk.Gravity.NORTH_EAST
+        elif self.menu_pos == POS_NW_NE:
+            menu_anchor = Gdk.Gravity.NORTH_WEST
+            widget_anchor = Gdk.Gravity.NORTH_EAST
+        elif self.menu_pos == POS_CENTER_BELOW:
+            menu_anchor = Gdk.Gravity.NORTH
+            widget_anchor = Gdk.Gravity.SOUTH
+        elif self.menu_pos == POS_CENTER_ABOVE:
+            menu_anchor = Gdk.Gravity.SOUTH
+            widget_anchor = Gdk.Gravity.NORTH
+
+        self.menu.popup_at_widget(self, widget_anchor, menu_anchor, None)
 
 
     # EVENT HANDLERS #

--- a/virtaal/views/widgets/popupmenubutton.py
+++ b/virtaal/views/widgets/popupmenubutton.py
@@ -18,7 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-from gi.repository import Gtk
+from gi.repository import Gtk, GObject
 
 # Positioning constants below:
 # POS_CENTER_BELOW: Centers the pop-up window below the button (default).

--- a/virtaal/views/widgets/popupmenubutton.py
+++ b/virtaal/views/widgets/popupmenubutton.py
@@ -36,8 +36,6 @@ from six import string_types as unicode
 # POS_SE_NE: Positions the pop-up window so that its South East (bottom right)
 #            corner is on the North East corner of the button. RTL of POS_SW_NW
 POS_CENTER_BELOW, POS_CENTER_ABOVE, POS_NW_SW, POS_NE_SE, POS_NW_NE, POS_SW_NW, POS_SE_NE = range(7)
-# XXX: Add position symbols above as needed and implementation in
-#      _update_popup_geometry()
 
 _rtl_pos_map = {
         POS_CENTER_BELOW: POS_CENTER_BELOW,
@@ -79,37 +77,6 @@ class PopupMenuButton(Gtk.ToggleButton):
 
 
     # METHODS #
-    def _calculate_popup_pos(self, menu, *args):
-        menu_width, menu_height = 0, 0
-        menu_alloc = menu.get_allocation()
-        if menu_alloc.height > 1:
-            menu_height = menu_alloc.height
-            menu_width = menu_alloc.width
-        else:
-            menu_width, menu_height = menu.size_request()
-
-        btn_window_xy = self.get_window().get_origin()
-        btn_alloc = self.get_allocation()
-
-        # Default values are POS_SW_NW
-        x = btn_window_xy[0] + btn_alloc.x
-        y = btn_window_xy[1] + btn_alloc.y - menu_height
-        if self.menu_pos == POS_NW_SW:
-            y = btn_window_xy[1] + btn_alloc.y + btn_alloc.height
-        elif self.menu_pos == POS_NE_SE:
-            x -= (menu_width - btn_alloc.width)
-            y = btn_window_xy[1] + btn_alloc.y + btn_alloc.height
-        elif self.menu_pos == POS_SE_NE:
-            x -= (menu_width - btn_alloc.width)
-        elif self.menu_pos == POS_NW_NE:
-            x += btn_alloc.width
-            y = btn_window_xy[1] + btn_alloc.y
-        elif self.menu_pos == POS_CENTER_BELOW:
-            x -= (menu_width - btn_alloc.width) / 2
-        elif self.menu_pos == POS_CENTER_ABOVE:
-            x -= (menu_width - btn_alloc.width) / 2
-            y = btn_window_xy[1] - menu_height
-        return (x, y, True)
 
     def popdown(self):
         self.menu.popdown()

--- a/virtaal/views/widgets/popupmenubutton.py
+++ b/virtaal/views/widgets/popupmenubutton.py
@@ -20,6 +20,8 @@
 
 from gi.repository import Gtk, GObject
 
+from six import string_types as unicode
+
 # Positioning constants below:
 # POS_CENTER_BELOW: Centers the pop-up window below the button (default).
 # POS_CENTER_ABOVE: Centers the pop-up window above the button.

--- a/virtaal/views/widgets/popupmenubutton.py
+++ b/virtaal/views/widgets/popupmenubutton.py
@@ -77,7 +77,7 @@ class PopupMenuButton(Gtk.ToggleButton):
 
 
     # METHODS #
-    def _calculate_popup_pos(self, menu):
+    def _calculate_popup_pos(self, menu, *args):
         menu_width, menu_height = 0, 0
         menu_alloc = menu.get_allocation()
         if menu_alloc.height > 1:
@@ -86,7 +86,7 @@ class PopupMenuButton(Gtk.ToggleButton):
         else:
             menu_width, menu_height = menu.size_request()
 
-        btn_window_xy = self.window.get_origin()
+        btn_window_xy = self.get_window().get_origin()
         btn_alloc = self.get_allocation()
 
         # Default values are POS_SW_NW
@@ -114,7 +114,7 @@ class PopupMenuButton(Gtk.ToggleButton):
         return True
 
     def popup(self):
-        self.menu.popup(None, None, self._calculate_popup_pos, 0, 0)
+        self.menu.popup(None, None, self._calculate_popup_pos, None, 0, 0)
 
 
     # EVENT HANDLERS #

--- a/virtaal/views/widgets/popupwidgetbutton.py
+++ b/virtaal/views/widgets/popupwidgetbutton.py
@@ -19,11 +19,11 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 """
-PopupWidgetButton: Extends a C{gtk.ToggleButton} to show a given widget in a
+PopupWidgetButton: Extends a C{Gtk.ToggleButton} to show a given widget in a
 pop-up window.
 """
 
-import gtk
+from gi.repository import Gtk
 from gobject import SIGNAL_RUN_FIRST
 
 # XXX: Kudo's to Toms Bauģis <toms.baugis at gmail.com> who wrote the
@@ -55,8 +55,9 @@ _rtl_pos_map = {
         POS_NW_SW: POS_NE_SE,
 }
 
-class PopupWidgetButton(gtk.ToggleButton):
-    """Extends a C{gtk.ToggleButton} to show a given widget in a pop-up window."""
+
+class PopupWidgetButton(Gtk.ToggleButton):
+    """Extends a C{Gtk.ToggleButton} to show a given widget in a pop-up window."""
     __gtype_name__ = 'PopupWidgetButton'
     __gsignals__ = {
         'shown':  (SIGNAL_RUN_FIRST, None, ()),
@@ -73,7 +74,7 @@ class PopupWidgetButton(gtk.ToggleButton):
         self.connect('key-press-event', self._on_key_press_event)
         self.connect('toggled', self._on_toggled)
 
-        if self.get_direction() == gtk.TEXT_DIR_LTR:
+        if self.get_direction() == Gtk.TextDirection.LTR:
             self.popup_pos = popup_pos
         else:
             self.popup_pos = _rtl_pos_map.get(popup_pos, POS_NE_SE)
@@ -81,7 +82,7 @@ class PopupWidgetButton(gtk.ToggleButton):
         self._update_popup_geometry_func = None
 
         # Create pop-up window
-        self.popup = gtk.Window(type=gtk.WINDOW_POPUP)
+        self.popup = Gtk.Window(type=Gtk.WindowType.POPUP)
         self.popup.set_size_request(0,0)
         self.popup.add(widget)
         self.popup.show_all()
@@ -172,7 +173,7 @@ class PopupWidgetButton(gtk.ToggleButton):
         self.hide_popup()
 
     def _on_key_press_event(self, window, event):
-        if event.keyval == gtk.keysyms.Escape and self.popup.props.visible:
+        if event.keyval == Gdk.KEY_Escape and self.popup.props.visible:
             self.hide_popup()
             return True
         return False
@@ -188,13 +189,13 @@ class PopupWidgetButton(gtk.ToggleButton):
 
 
 if __name__ == '__main__':
-    btn = PopupWidgetButton(label='TestMe', widget=gtk.Button('Click me'))
+    btn = PopupWidgetButton(label='TestMe', widget=Gtk.Button('Click me'))
 
-    hb = gtk.HBox()
-    hb.pack_start(gtk.Button('Left'),  expand=False, fill=False)
+    hb = Gtk.HBox()
+    hb.pack_start(Gtk.Button('Left', True, True, 0), expand=False, fill=False)
     hb.pack_start(btn,                 expand=False, fill=False)
-    hb.pack_start(gtk.Button('Right'), expand=False, fill=False)
-    vb = gtk.VBox()
+    hb.pack_start(Gtk.Button('Right', True, True, 0), expand=False, fill=False)
+    vb = Gtk.VBox()
     vb.pack_start(hb, expand=False, fill=False)
 
     from gtk import Window
@@ -202,6 +203,6 @@ if __name__ == '__main__':
     wnd.set_size_request(400, 300)
     wnd.set_title('Pop-up Window Button Test')
     wnd.add(vb)
-    wnd.connect('destroy', lambda *args: gtk.main_quit())
+    wnd.connect('destroy', lambda *args: Gtk.main_quit())
     wnd.show_all()
-    gtk.main()
+    Gtk.main()

--- a/virtaal/views/widgets/popupwidgetbutton.py
+++ b/virtaal/views/widgets/popupwidgetbutton.py
@@ -102,25 +102,25 @@ class PopupWidgetButton(Gtk.ToggleButton):
     # METHODS #
     def calculate_popup_xy(self, popup_alloc, btn_alloc, btn_window_xy):
         # Default values are POS_NW_SW
-        x = btn_window_xy[0] + btn_alloc.x
-        y = btn_window_xy[1] + btn_alloc.y + btn_alloc.height
-        width, height = self.popup.get_child_requisition()
+        x = btn_window_xy.x + btn_alloc.x
+        y = btn_window_xy.y + btn_alloc.y + btn_alloc.height
+        # width, height = self.popup.get_child_requisition()
 
         if self.popup_pos == POS_NE_SE:
             x -= (popup_alloc.width - btn_alloc.width)
         elif self.popup_pos == POS_NW_NE:
             x += btn_alloc.width
-            y = btn_window_xy[1] + btn_alloc.y
+            y = btn_window_xy.y + btn_alloc.y
         elif self.popup_pos == POS_SE_NE:
-            x -= (popup_alloc.width - btn_alloc.width)
-            y = btn_window_xy[1] - popup_alloc.height
+            x -= popup_alloc.width
+            y -= btn_alloc.height
         elif self.popup_pos == POS_SW_NW:
-            y = btn_window_xy[1] - popup_alloc.height
+            y = btn_window_xy.y - popup_alloc.height
         elif self.popup_pos == POS_CENTER_BELOW:
             x -= (popup_alloc.width - btn_alloc.width) / 2
         elif self.popup_pos == POS_CENTER_ABOVE:
             x -= (popup_alloc.width - btn_alloc.width) / 2
-            y = btn_window_xy[1] - popup_alloc.height
+            y = btn_window_xy.y - popup_alloc.height
 
         return x, y
 
@@ -146,11 +146,13 @@ class PopupWidgetButton(Gtk.ToggleButton):
 
     def _update_popup_geometry(self):
         self.popup.set_size_request(-1, -1)
-        width, height = self.popup.get_child_requisition()
+        requisition = self.popup.get_child_requisition()
+        width = requisition.width
+        height = requisition.height
 
         x, y = -1, -1
         popup_alloc = self.popup.get_allocation()
-        btn_window_xy = self.window.get_origin()
+        btn_window_xy = self.get_window().get_origin()
         btn_alloc = self.get_allocation()
 
         if callable(self._update_popup_geometry_func):
@@ -164,8 +166,7 @@ class PopupWidgetButton(Gtk.ToggleButton):
 
         popup_alloc.width, popup_alloc.height = width, height
         x, y = self.calculate_popup_xy(popup_alloc, btn_alloc, btn_window_xy)
-
-        self.popup.window.get_toplevel().move_resize(x, y, width, height)
+        self.popup.get_window().get_toplevel().move_resize(x, y, width, height)
 
 
     # EVENT HANDLERS #

--- a/virtaal/views/widgets/popupwidgetbutton.py
+++ b/virtaal/views/widgets/popupwidgetbutton.py
@@ -24,7 +24,7 @@ pop-up window.
 """
 
 from gi.repository import Gtk
-from gobject import SIGNAL_RUN_FIRST
+from gi.repository.GObject import SIGNAL_RUN_FIRST
 
 # XXX: Kudo's to Toms Bauģis <toms.baugis at gmail.com> who wrote the
 #      ActivityEntry widget for the hamster-applet project. A lot of this
@@ -88,7 +88,7 @@ class PopupWidgetButton(Gtk.ToggleButton):
         self.popup.show_all()
         self.popup.hide()
 
-        self.connect('expose-event', self._on_expose)
+        self.connect('draw', self._on_expose)
 
 
     # ACCESSORS #

--- a/virtaal/views/widgets/popupwidgetbutton.py
+++ b/virtaal/views/widgets/popupwidgetbutton.py
@@ -23,6 +23,7 @@ PopupWidgetButton: Extends a C{Gtk.ToggleButton} to show a given widget in a
 pop-up window.
 """
 
+from gi.repository import Gdk
 from gi.repository import Gtk
 from gi.repository.GObject import SIGNAL_RUN_FIRST
 

--- a/virtaal/views/widgets/popupwidgetbutton.py
+++ b/virtaal/views/widgets/popupwidgetbutton.py
@@ -113,8 +113,8 @@ class PopupWidgetButton(Gtk.ToggleButton):
             x += btn_alloc.width
             y = btn_window_xy.y + btn_alloc.y
         elif self.popup_pos == POS_SE_NE:
-            x -= popup_alloc.width
-            y -= btn_alloc.height
+            x -= (popup_alloc.width - btn_alloc.width)
+            y = btn_window_xy.y - popup_alloc.height
         elif self.popup_pos == POS_SW_NW:
             y = btn_window_xy.y - popup_alloc.height
         elif self.popup_pos == POS_CENTER_BELOW:

--- a/virtaal/views/widgets/selectdialog.py
+++ b/virtaal/views/widgets/selectdialog.py
@@ -17,12 +17,13 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import, print_function, unicode_literals
 
 from gi.repository import Gtk
 from gi.repository.GObject import SIGNAL_RUN_FIRST, TYPE_PYOBJECT
 
-from selectview import SelectView
 from virtaal.common import GObjectWrapper
+from .selectview import SelectView
 
 
 class SelectDialog(GObjectWrapper):

--- a/virtaal/views/widgets/selectdialog.py
+++ b/virtaal/views/widgets/selectdialog.py
@@ -19,7 +19,7 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 from gi.repository import Gtk
-from gobject import SIGNAL_RUN_FIRST, TYPE_PYOBJECT
+from gi.repository.GObject import SIGNAL_RUN_FIRST, TYPE_PYOBJECT
 
 from selectview import SelectView
 from virtaal.common import GObjectWrapper

--- a/virtaal/views/widgets/selectdialog.py
+++ b/virtaal/views/widgets/selectdialog.py
@@ -18,12 +18,11 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-import gtk
+from gi.repository import Gtk
 from gobject import SIGNAL_RUN_FIRST, TYPE_PYOBJECT
 
-from virtaal.common import GObjectWrapper
-
 from selectview import SelectView
+from virtaal.common import GObjectWrapper
 
 
 class SelectDialog(GObjectWrapper):
@@ -60,19 +59,19 @@ class SelectDialog(GObjectWrapper):
         self.sview.connect('item-selected', self._on_item_selected)
 
     def _create_gui(self, title, message, parent):
-        self.dialog = gtk.Dialog()
+        self.dialog = Gtk.Dialog()
         self.dialog.set_modal(True)
-        if isinstance(parent, gtk.Widget):
+        if isinstance(parent, Gtk.Widget):
             self.set_transient_for(parent)
         self.dialog.set_title(title is not None and title or 'Select items')
-        self.message = gtk.Label(message is not None and message or '')
-        self.dialog.child.pack_start(self.message, expand=False, fill=False, padding=10)
+        self.message = Gtk.Label(label=message is not None and message or '')
+        self.dialog.get_child().pack_start(self.message, expand=False, fill=False, padding=10)
 
-        scrolled_window = gtk.ScrolledWindow()
-        scrolled_window.set_policy(gtk.POLICY_AUTOMATIC, gtk.POLICY_AUTOMATIC)
+        scrolled_window = Gtk.ScrolledWindow()
+        scrolled_window.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
         scrolled_window.add(self.sview)
-        self.dialog.child.pack_end(scrolled_window, expand=True, fill=True)
-        self.dialog.add_buttons(gtk.STOCK_CLOSE, gtk.RESPONSE_CLOSE)
+        self.dialog.get_child().pack_end(scrolled_window, expand=True, fill=True)
+        self.dialog.add_buttons(Gtk.STOCK_CLOSE, Gtk.ResponseType.CLOSE)
 
 
     # METHODS #
@@ -93,7 +92,7 @@ class SelectDialog(GObjectWrapper):
     def run(self, items=None, parent=None):
         if items is not None:
             self.sview.set_model(items)
-        if isinstance(parent, gtk.Widget):
+        if isinstance(parent, Gtk.Widget):
             self.dialog.reparent(parent)
         self.dialog.show_all()
         self.response = self.dialog.run()

--- a/virtaal/views/widgets/selectdialog.py
+++ b/virtaal/views/widgets/selectdialog.py
@@ -71,7 +71,7 @@ class SelectDialog(GObjectWrapper):
         scrolled_window = Gtk.ScrolledWindow()
         scrolled_window.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
         scrolled_window.add(self.sview)
-        self.dialog.get_child().pack_end(scrolled_window, expand=True, fill=True)
+        self.dialog.get_child().pack_end(scrolled_window, True, True, 0)
         self.dialog.add_buttons(Gtk.STOCK_CLOSE, Gtk.ResponseType.CLOSE)
 
 

--- a/virtaal/views/widgets/selectview.py
+++ b/virtaal/views/widgets/selectview.py
@@ -105,6 +105,7 @@ class SelectView(Gtk.TreeView, GObjectWrapper):
             lbl.set_text(name)
             lbl.set_use_markup(self.bold_name)
             lbl.set_property('xpad', 2)
+            lbl.set_margin_top(2)
             vbox.pack_start(lbl, True, True, 0)
             vbox.lbl_name = lbl
 
@@ -116,6 +117,7 @@ class SelectView(Gtk.TreeView, GObjectWrapper):
             lbl.set_text(item['desc'])
             lbl.set_use_markup(False)
             lbl.set_property('xpad', 2)
+            lbl.set_margin_bottom(2)
             if self.get_direction() == Gtk.TextDirection.LTR:
                 # in RTL this code causes the label to be left aligned in the
                 # column for some reason

--- a/virtaal/views/widgets/selectview.py
+++ b/virtaal/views/widgets/selectview.py
@@ -20,7 +20,7 @@
 
 import locale
 
-from gi.repository import Gtk, GObject
+from gi.repository import Gtk
 from gi.repository.GObject import SIGNAL_RUN_FIRST, TYPE_PYOBJECT
 
 from virtaal.common import GObjectWrapper
@@ -53,7 +53,7 @@ class SelectView(Gtk.TreeView, GObjectWrapper):
 
     # INITIALIZERS #
     def __init__(self, items=None, bold_name=True):
-        GObject.GObject.__init__(self)
+        Gtk.TreeView.__init__(self)
         GObjectWrapper.__init__(self)
 
         self.bold_name = bold_name

--- a/virtaal/views/widgets/selectview.py
+++ b/virtaal/views/widgets/selectview.py
@@ -18,8 +18,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-import gtk
 import locale
+
+from gi.repository import Gtk
 from gobject import SIGNAL_RUN_FIRST, TYPE_PYOBJECT
 
 from virtaal.common import GObjectWrapper
@@ -35,7 +36,7 @@ COL_ENABLED, COL_NAME, COL_DESC, COL_DATA, COL_WIDGET = range(5)
 DEFAULT_WIDTH = 450
 
 
-class SelectView(gtk.TreeView, GObjectWrapper):
+class SelectView(Gtk.TreeView, GObjectWrapper):
     """
     A tree view that enables the user to select items from a list.
     """
@@ -48,17 +49,17 @@ class SelectView(gtk.TreeView, GObjectWrapper):
     }
 
     CONTENT_VBOX = 'vb_content'
-    """The name of the C{gtk.VBox} containing the selection items."""
+    """The name of the C{Gtk.VBox} containing the selection items."""
 
     # INITIALIZERS #
     def __init__(self, items=None, bold_name=True):
-        gtk.TreeView.__init__(self)
+        GObject.GObject.__init__(self)
         GObjectWrapper.__init__(self)
 
         self.bold_name = bold_name
         self.selected_item = None
         if not items:
-            items = gtk.ListStore(bool, str, str, TYPE_PYOBJECT, TYPE_PYOBJECT)
+            items = Gtk.ListStore(bool, str, str, TYPE_PYOBJECT, TYPE_PYOBJECT)
         self.set_model(items)
 
         self._add_columns()
@@ -66,9 +67,9 @@ class SelectView(gtk.TreeView, GObjectWrapper):
         self._connect_events()
 
     def _add_columns(self):
-        cell = gtk.CellRendererToggle()
+        cell = Gtk.CellRendererToggle()
         cell.connect('toggled', self._on_item_toggled)
-        self.select_col = gtk.TreeViewColumn(_('Enabled'), cell, active=COL_ENABLED)
+        self.select_col = Gtk.TreeViewColumn(_('Enabled'), cell, active=COL_ENABLED)
         self.append_column(self.select_col)
 
         width = self.get_allocation().width
@@ -76,7 +77,7 @@ class SelectView(gtk.TreeView, GObjectWrapper):
             width = DEFAULT_WIDTH
 
         cell = CellRendererWidget(strfunc=self._get_widget_string, default_width=width)
-        self.namedesc_col = gtk.TreeViewColumn(_('Name'), cell, widget=4)
+        self.namedesc_col = Gtk.TreeViewColumn(_('Name'), cell, widget=4)
         self.append_column(self.namedesc_col)
 
     def _connect_events(self):
@@ -88,45 +89,45 @@ class SelectView(gtk.TreeView, GObjectWrapper):
 
     # METHODS #
     def _create_widget_for_item(self, item):
-        hbox = gtk.HBox()
-        vbox = gtk.VBox()
+        hbox = Gtk.HBox()
+        vbox = Gtk.VBox()
         vbox.min_height = 60
 
         vbox.lbl_name = None
         if 'name' in item and item['name']:
             name = (self.bold_name and '<b>%s</b>' or '%s') % (item['name'])
-            lbl = gtk.Label()
+            lbl = Gtk.Label()
             lbl.set_alignment(0, 0)
             lbl.set_text(name)
             lbl.set_use_markup(self.bold_name)
             lbl.set_property('xpad', 1)
-            vbox.pack_start(lbl)
+            vbox.pack_start(lbl, True, True, 0)
             vbox.lbl_name = lbl
 
         vbox.lbl_desc = None
         if 'desc' in item and item['desc']:
-            lbl = gtk.Label()
+            lbl = Gtk.Label()
             lbl.set_alignment(0, 0)
             lbl.set_line_wrap(True)
             lbl.set_text(item['desc'])
             lbl.set_use_markup(False)
             lbl.set_property('xpad', 1)
-            if self.get_direction() == gtk.TEXT_DIR_LTR:
+            if self.get_direction() == Gtk.TextDirection.LTR:
                 # in RTL this code causes the label to be left aligned in the
                 # column for some reason
                 lbl.set_size_request(DEFAULT_WIDTH, -1)
-            vbox.pack_start(lbl)
+            vbox.pack_start(lbl, True, True, 0)
             vbox.lbl_desc = lbl
-        hbox.pack_start(vbox)
+        hbox.pack_start(vbox, True, True, 0)
 
         #TODO: ideally we need an accesskey, but it is not currently working
         if 'config' in item and callable(item['config']):
-            btnconf = gtk.Button(_('Configure...'))
+            btnconf = Gtk.Button(_('Configure...'))
             def clicked(button, event):
                 item['config'](self.get_toplevel())
             btnconf.connect('button-release-event', clicked)
             btnconf.config_func = item['config']
-            hbox.pack_start(btnconf, expand=False)
+            hbox.pack_start(btnconf, False, True, 0)
 
         return hbox
 
@@ -199,10 +200,10 @@ class SelectView(gtk.TreeView, GObjectWrapper):
             self.selected_item = None
 
     def set_model(self, items):
-        if isinstance(items, gtk.ListStore):
+        if isinstance(items, Gtk.ListStore):
             self._model = items
         else:
-            self._model = gtk.ListStore(bool, str, str, TYPE_PYOBJECT, TYPE_PYOBJECT)
+            self._model = Gtk.ListStore(bool, str, str, TYPE_PYOBJECT, TYPE_PYOBJECT)
             items.sort(cmp=locale.strcoll, key=lambda x: x.get('name', ''))
             for row in items:
                 self._model.append([
@@ -213,7 +214,7 @@ class SelectView(gtk.TreeView, GObjectWrapper):
                     self._create_widget_for_item(row)
                 ])
 
-        gtk.TreeView.set_model(self, self._model)
+        Gtk.TreeView.set_model(self, self._model)
 
 
     # EVENT HANDLERS #
@@ -232,6 +233,6 @@ class SelectView(gtk.TreeView, GObjectWrapper):
 
     def _on_selection_change(self, selection):
         model, iter = selection.get_selected()
-        if isinstance(model, gtk.TreeIter) and model is self._model and self._model.iter_is_valid(iter):
+        if isinstance(model, Gtk.TreeIter) and model is self._model and self._model.iter_is_valid(iter):
             self.selected_item = self.get_item(iter)
             self.emit('item-selected', self.selected_item)

--- a/virtaal/views/widgets/selectview.py
+++ b/virtaal/views/widgets/selectview.py
@@ -74,7 +74,11 @@ class SelectView(Gtk.TreeView, GObjectWrapper):
         if width <= 1:
             width = DEFAULT_WIDTH
 
-        cell = CellRendererWidget(strfunc=self._get_widget_string, default_width=width)
+        cell = CellRendererWidget(
+            strfunc=self._get_widget_string,
+            default_width=width,
+            widget_func=self._create_widget_for_item,
+        )
         self.namedesc_col = Gtk.TreeViewColumn(_('Name'), cell, widget=4)
         self.append_column(self.namedesc_col)
 

--- a/virtaal/views/widgets/selectview.py
+++ b/virtaal/views/widgets/selectview.py
@@ -98,7 +98,7 @@ class SelectView(Gtk.TreeView, GObjectWrapper):
             lbl.set_alignment(0, 0)
             lbl.set_text(name)
             lbl.set_use_markup(self.bold_name)
-            lbl.set_property('xpad', 1)
+            lbl.set_property('xpad', 2)
             vbox.pack_start(lbl, True, True, 0)
             vbox.lbl_name = lbl
 
@@ -109,7 +109,7 @@ class SelectView(Gtk.TreeView, GObjectWrapper):
             lbl.set_line_wrap(True)
             lbl.set_text(item['desc'])
             lbl.set_use_markup(False)
-            lbl.set_property('xpad', 1)
+            lbl.set_property('xpad', 2)
             if self.get_direction() == Gtk.TextDirection.LTR:
                 # in RTL this code causes the label to be left aligned in the
                 # column for some reason

--- a/virtaal/views/widgets/selectview.py
+++ b/virtaal/views/widgets/selectview.py
@@ -20,8 +20,8 @@
 
 import locale
 
-from gi.repository import Gtk
-from gobject import SIGNAL_RUN_FIRST, TYPE_PYOBJECT
+from gi.repository import Gtk, GObject
+from gi.repository.GObject import SIGNAL_RUN_FIRST, TYPE_PYOBJECT
 
 from virtaal.common import GObjectWrapper
 from virtaal.views.widgets.cellrendererwidget import CellRendererWidget

--- a/virtaal/views/widgets/selectview.py
+++ b/virtaal/views/widgets/selectview.py
@@ -18,6 +18,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
+from locale import strxfrm
+
 from gi.repository import Gtk
 from gi.repository.GObject import SIGNAL_RUN_FIRST, TYPE_PYOBJECT
 
@@ -212,7 +214,7 @@ class SelectView(Gtk.TreeView, GObjectWrapper):
         else:
             self._model = Gtk.ListStore(bool, str, str, TYPE_PYOBJECT, TYPE_PYOBJECT)
             items = list(items)
-            items.sort(key=lambda x: x.get('name', ''))
+            items.sort(key=lambda x: strxfrm(x.get('name', '')))
             for row in items:
                 self._model.append([
                     row.get('enabled', False),

--- a/virtaal/views/widgets/selectview.py
+++ b/virtaal/views/widgets/selectview.py
@@ -87,6 +87,8 @@ class SelectView(Gtk.TreeView, GObjectWrapper):
 
     def _set_defaults(self):
         self.set_rules_hint(True)
+        self.props.activate_on_single_click = True
+        self.props.enable_search = False
 
 
     # METHODS #
@@ -236,6 +238,11 @@ class SelectView(Gtk.TreeView, GObjectWrapper):
 
     def _on_selection_change(self, selection):
         model, iter = selection.get_selected()
-        if isinstance(model, Gtk.TreeIter) and model is self._model and self._model.iter_is_valid(iter):
+        if iter and self._model.iter_is_valid(iter):
             self.selected_item = self.get_item(iter)
+            path = model.get_path(iter)
+            self.set_cursor(path, self.namedesc_col, start_editing=True)
             self.emit('item-selected', self.selected_item)
+
+    def do_row_activated(self, path, column):
+        self.set_cursor(path, self.namedesc_col, start_editing=True)

--- a/virtaal/views/widgets/selectview.py
+++ b/virtaal/views/widgets/selectview.py
@@ -18,8 +18,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-import locale
-
 from gi.repository import Gtk
 from gi.repository.GObject import SIGNAL_RUN_FIRST, TYPE_PYOBJECT
 
@@ -205,7 +203,7 @@ class SelectView(Gtk.TreeView, GObjectWrapper):
         else:
             self._model = Gtk.ListStore(bool, str, str, TYPE_PYOBJECT, TYPE_PYOBJECT)
             items = list(items)
-            items.sort(cmp=locale.strcoll, key=lambda x: x.get('name', ''))
+            items.sort(key=lambda x: x.get('name', ''))
             for row in items:
                 self._model.append([
                     row.get('enabled', False),

--- a/virtaal/views/widgets/selectview.py
+++ b/virtaal/views/widgets/selectview.py
@@ -204,6 +204,7 @@ class SelectView(Gtk.TreeView, GObjectWrapper):
             self._model = items
         else:
             self._model = Gtk.ListStore(bool, str, str, TYPE_PYOBJECT, TYPE_PYOBJECT)
+            items = list(items)
             items.sort(cmp=locale.strcoll, key=lambda x: x.get('name', ''))
             for row in items:
                 self._model.append([
@@ -214,7 +215,7 @@ class SelectView(Gtk.TreeView, GObjectWrapper):
                     self._create_widget_for_item(row)
                 ])
 
-        Gtk.TreeView.set_model(self, self._model)
+        super(SelectView, self).set_model(self._model)
 
 
     # EVENT HANDLERS #

--- a/virtaal/views/widgets/selectview.py
+++ b/virtaal/views/widgets/selectview.py
@@ -79,7 +79,7 @@ class SelectView(Gtk.TreeView, GObjectWrapper):
             default_width=width,
             widget_func=self._create_widget_for_item,
         )
-        self.namedesc_col = Gtk.TreeViewColumn(_('Name'), cell, widget=4)
+        self.namedesc_col = Gtk.TreeViewColumn(_('Name'), cell, widget=COL_WIDGET)
         self.append_column(self.namedesc_col)
 
     def _connect_events(self):
@@ -173,6 +173,7 @@ class SelectView(Gtk.TreeView, GObjectWrapper):
                 widget = widget.get_children()[1]
                 config = widget.config_func
         except IndexError:
+            # no button at .get_children()[1]
             pass
 
         item = {

--- a/virtaal/views/widgets/storecellrenderer.py
+++ b/virtaal/views/widgets/storecellrenderer.py
@@ -270,7 +270,6 @@ class StoreCellRenderer(Gtk.CellRenderer):
         if widget.get_direction() == Gtk.TextDirection.RTL:
             self.source_layout.set_alignment(Pango.Alignment.RIGHT)
             self.target_layout.set_alignment(Pango.Alignment.RIGHT)
-            self.target_layout.set_auto_dir(False)
         _layout_width, source_height = self.source_layout.get_pixel_size()
         _layout_width, target_height = self.target_layout.get_pixel_size()
         return max(source_height, target_height) + self.ROW_PADDING

--- a/virtaal/views/widgets/storecellrenderer.py
+++ b/virtaal/views/widgets/storecellrenderer.py
@@ -303,7 +303,7 @@ class StoreCellRenderer(Gtk.CellRenderer):
 
     # EVENT HANDLERS #
     def _on_editor_done(self, editor):
-        self.emit("editing-done", editor.get_data("path"), editor.must_advance, editor.is_modified())
+        self.emit("editing-done", editor.get_path(), editor.must_advance, editor.is_modified())
         return True
 
     def _on_modified(self, widget):

--- a/virtaal/views/widgets/storecellrenderer.py
+++ b/virtaal/views/widgets/storecellrenderer.py
@@ -44,12 +44,16 @@ def gtk_container_compute_optimal_height(widget, width):
     if not widget.props.visible:
         return
     for child in widget.get_children():
+        if not child.props.visible:
+            continue
         compute_optimal_height(child, width)
 
 
-@compute_optimal_height.when_type(Gtk.Table)
+@compute_optimal_height.when_type(Gtk.Grid)
 def gtk_table_compute_optimal_height(widget, width):
     for child in widget.get_children():
+        if child.props.name != "vbox_middle":
+            continue
         # width / 2 because we use half of the available width
         compute_optimal_height(child, width / 2)
 
@@ -175,7 +179,7 @@ class StoreCellRenderer(Gtk.CellRenderer):
             editor.set_size_request(width, -1)
             editor.show()
             # fixme: this will make vbox_editor width too large
-            # compute_optimal_height(editor, width)
+            compute_optimal_height(editor, width)
             parent_height = widget.get_allocation().height
             if parent_height < -1:
                 parent_height = widget.size_request()[1]

--- a/virtaal/views/widgets/storecellrenderer.py
+++ b/virtaal/views/widgets/storecellrenderer.py
@@ -174,7 +174,8 @@ class StoreCellRenderer(Gtk.CellRenderer):
             editor = self.view.get_unit_celleditor(self.unit)
             editor.set_size_request(width, -1)
             editor.show()
-            compute_optimal_height(editor, width)
+            # fixme: this will make vbox_editor width too large
+            # compute_optimal_height(editor, width)
             parent_height = widget.get_allocation().height
             if parent_height < -1:
                 parent_height = widget.size_request()[1]

--- a/virtaal/views/widgets/storecellrenderer.py
+++ b/virtaal/views/widgets/storecellrenderer.py
@@ -60,7 +60,7 @@ def gtk_textview_compute_optimal_height(widget, width):
         return
     buf = widget.get_buffer()
     # For border calculations, see gtktextview.c:gtk_text_view_size_request in the GTK source
-    border = 2 * widget.border_width - 2 * widget.parent.border_width
+    border = 2 * widget.get_border_width() - 2 * widget.get_parent().get_border_width()
     if widget.style_get_property("interior-focus"):
         border += 2 * widget.style_get_property("focus-line-width")
 
@@ -82,10 +82,10 @@ def gtk_textview_compute_optimal_height(widget, width):
         # directly after the file is opened. For now we try to guess a more
         # useful default than 0. This should look much better than 0, at least.
         h = 28
-    parent = widget.parent
+    parent = widget.get_parent()
     if isinstance(parent, Gtk.ScrolledWindow) and parent.get_shadow_type() != Gtk.ShadowType.NONE:
-        border += 2 * parent.rc_get_style().ythickness
-    widget.parent.set_size_request(-1, h + border)
+        border += 2 * parent.get_style().ythickness
+    widget.get_parent().set_size_request(-1, h + border)
 
 
 @compute_optimal_height.when_type(Gtk.Label)
@@ -97,7 +97,7 @@ def gtk_label_compute_optimal_height(widget, width):
         widget.set_size_request(width, h)
 
 
-class StoreCellRenderer(Gtk.GenericCellRenderer):
+class StoreCellRenderer(Gtk.CellRenderer):
     """
     Cell renderer for a unit based on the C{UnitRenderer} class from Virtaal's
     pre-MVC days.
@@ -180,7 +180,9 @@ class StoreCellRenderer(Gtk.GenericCellRenderer):
                 parent_height = widget.size_request()[1]
             if parent_height > 0:
                 self.check_editor_height(editor, width, parent_height)
-            _width, height = editor.size_request()
+            size_request = editor.size_request()
+            _width = size_request.width
+            height = size_request.height
             height += self.ROW_PADDING
         else:
             height = self.compute_cell_height(widget, width)
@@ -255,7 +257,8 @@ class StoreCellRenderer(Gtk.GenericCellRenderer):
         notesheight = 0
 
         for note in editor._widgets['notes'].values():
-            notesheight += note.size_request()[1]
+            size_request = note.size_request()
+            notesheight += size_request.height
 
         maxheight = parentheight - notesheight
 
@@ -270,7 +273,7 @@ class StoreCellRenderer(Gtk.GenericCellRenderer):
         max_tb_height = maxheight / len(visible_textboxes)
 
         for textbox in visible_textboxes:
-            if textbox.props.visible and textbox.parent.size_request()[1] > max_tb_height:
+            if textbox.props.visible and textbox.get_parent().size_request().height > max_tb_height:
                 textbox.parent.set_size_request(-1, max_tb_height)
                 #logging.debug('%s.set_size_request(-1, %d)' % (textbox.parent, max_tb_height))
 

--- a/virtaal/views/widgets/storecellrenderer.py
+++ b/virtaal/views/widgets/storecellrenderer.py
@@ -200,7 +200,7 @@ class StoreCellRenderer(Gtk.CellRenderer):
             self._editor_modified_id = editor.connect("modified", self._on_modified)
         return editor
 
-    def on_render(self, window, widget, _background_area, cell_area, _expose_area, _flags):
+    def do_render(self, window, widget, _background_area, cell_area, _flags):
         if self.editable:
             return True
         x_offset, y_offset, width, _height = self.do_get_size(widget, cell_area)
@@ -212,10 +212,28 @@ class StoreCellRenderer(Gtk.CellRenderer):
             target_x += width/2
         else:
             source_x += (width/2) + 10
-        widget.get_style().paint_layout(window, Gtk.StateType.NORMAL, False,
-                                        cell_area, widget, '', source_x, y, self.source_layout)
-        widget.get_style().paint_layout(window, Gtk.StateType.NORMAL, False,
-                                        cell_area, widget, '', target_x, y, self.target_layout)
+        Gtk.paint_layout(
+            style=widget.get_style(),
+            cr=window,
+            state_type=Gtk.StateType.NORMAL,
+            use_text=False,
+            widget=widget,
+            detail='',
+            x=source_x,
+            y=y,
+            layout=self.source_layout
+        )
+        Gtk.paint_layout(
+            style=widget.get_style(),
+            cr=window,
+            state_type=Gtk.StateType.NORMAL,
+            use_text=False,
+            widget=widget,
+            detail='',
+            x=target_x,
+            y=y,
+            layout=self.target_layout
+        )
 
 
     # METHODS #

--- a/virtaal/views/widgets/storecellrenderer.py
+++ b/virtaal/views/widgets/storecellrenderer.py
@@ -18,10 +18,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-import gtk
-import gobject
-import pango
-
+from gi.repository import GObject
+from gi.repository import Gtk
+from gi.repository import Pango
 from translate.lang import factory
 
 from virtaal.common import pan_app
@@ -34,24 +33,28 @@ from virtaal.views.theme import current_theme
 def compute_optimal_height(widget, width):
     raise NotImplementedError()
 
-@compute_optimal_height.when_type(gtk.Widget)
+
+@compute_optimal_height.when_type(Gtk.Widget)
 def gtk_widget_compute_optimal_height(widget, width):
     pass
 
-@compute_optimal_height.when_type(gtk.Container)
+
+@compute_optimal_height.when_type(Gtk.Container)
 def gtk_container_compute_optimal_height(widget, width):
     if not widget.props.visible:
         return
     for child in widget.get_children():
         compute_optimal_height(child, width)
 
-@compute_optimal_height.when_type(gtk.Table)
+
+@compute_optimal_height.when_type(Gtk.Table)
 def gtk_table_compute_optimal_height(widget, width):
     for child in widget.get_children():
         # width / 2 because we use half of the available width
         compute_optimal_height(child, width / 2)
 
-@compute_optimal_height.when_type(gtk.TextView)
+
+@compute_optimal_height.when_type(Gtk.TextView)
 def gtk_textview_compute_optimal_height(widget, width):
     if not widget.props.visible:
         return
@@ -80,11 +83,12 @@ def gtk_textview_compute_optimal_height(widget, width):
         # useful default than 0. This should look much better than 0, at least.
         h = 28
     parent = widget.parent
-    if isinstance(parent, gtk.ScrolledWindow) and parent.get_shadow_type() != gtk.SHADOW_NONE:
+    if isinstance(parent, Gtk.ScrolledWindow) and parent.get_shadow_type() != Gtk.ShadowType.NONE:
         border += 2 * parent.rc_get_style().ythickness
     widget.parent.set_size_request(-1, h + border)
 
-@compute_optimal_height.when_type(gtk.Label)
+
+@compute_optimal_height.when_type(Gtk.Label)
 def gtk_label_compute_optimal_height(widget, width):
     if widget.get_text().strip() == "":
         widget.set_size_request(width, 0)
@@ -93,7 +97,7 @@ def gtk_label_compute_optimal_height(widget, width):
         widget.set_size_request(width, h)
 
 
-class StoreCellRenderer(gtk.GenericCellRenderer):
+class StoreCellRenderer(Gtk.GenericCellRenderer):
     """
     Cell renderer for a unit based on the C{UnitRenderer} class from Virtaal's
     pre-MVC days.
@@ -106,23 +110,23 @@ class StoreCellRenderer(gtk.GenericCellRenderer):
             object,
             "The unit",
             "The unit that this renderer is currently handling",
-            gobject.PARAM_READWRITE
+            GObject.PARAM_READWRITE
         ),
         "editable": (
             bool,
             "editable",
             "A boolean indicating whether this unit is currently editable",
             False,
-            gobject.PARAM_READWRITE
+            GObject.PARAM_READWRITE
         ),
     }
 
     __gsignals__ = {
         "editing-done": (
-            gobject.SIGNAL_RUN_FIRST, gobject.TYPE_NONE,
-            (gobject.TYPE_STRING, gobject.TYPE_BOOLEAN, gobject.TYPE_BOOLEAN)
+            GObject.SignalFlags.RUN_FIRST, None,
+            (GObject.TYPE_STRING, GObject.TYPE_BOOLEAN, GObject.TYPE_BOOLEAN)
         ),
-        "modified": (gobject.SIGNAL_RUN_FIRST, gobject.TYPE_NONE, ())
+        "modified": (GObject.SignalFlags.RUN_FIRST, None, ())
     }
 
     ROW_PADDING = 10
@@ -130,8 +134,8 @@ class StoreCellRenderer(gtk.GenericCellRenderer):
 
     # INITIALIZERS #
     def __init__(self, view):
-        gtk.GenericCellRenderer.__init__(self)
-        self.set_property('mode', gtk.CELL_RENDERER_MODE_EDITABLE)
+        GObject.GObject.__init__(self)
+        self.set_property('mode', Gtk.CellRendererMode.EDITABLE)
         self.view = view
         self.__unit = None
         self.editable = False
@@ -202,14 +206,14 @@ class StoreCellRenderer(gtk.GenericCellRenderer):
         y = cell_area.y + y_offset
         source_x = x
         target_x = x
-        if widget.get_direction() == gtk.TEXT_DIR_LTR:
+        if widget.get_direction() == Gtk.TextDirection.LTR:
             target_x += width/2
         else:
             source_x += (width/2) + 10
-        widget.get_style().paint_layout(window, gtk.STATE_NORMAL, False,
-                cell_area, widget, '', source_x, y, self.source_layout)
-        widget.get_style().paint_layout(window, gtk.STATE_NORMAL, False,
-                cell_area, widget, '', target_x, y, self.target_layout)
+        widget.get_style().paint_layout(window, Gtk.StateType.NORMAL, False,
+                                        cell_area, widget, '', source_x, y, self.source_layout)
+        widget.get_style().paint_layout(window, Gtk.StateType.NORMAL, False,
+                                        cell_area, widget, '', target_x, y, self.target_layout)
 
 
     # METHODS #
@@ -218,10 +222,10 @@ class StoreCellRenderer(gtk.GenericCellRenderer):
         # We can't use widget.get_pango_context() because we'll end up
         # overwriting the language and font settings if we don't have a
         # new one
-        layout = pango.Layout(widget.create_pango_context())
+        layout = Pango.Layout(widget.create_pango_context())
         layout.set_font_description(font_description)
-        layout.set_wrap(pango.WRAP_WORD_CHAR)
-        layout.set_width(width * pango.SCALE)
+        layout.set_wrap(Pango.WrapMode.WORD_CHAR)
+        layout.set_width(width * Pango.SCALE)
         #XXX - plurals?
         text = text or u""
         layout.set_markup(markup.markuptext(text))
@@ -239,9 +243,9 @@ class StoreCellRenderer(gtk.GenericCellRenderer):
         self.target_layout.get_context().set_language(rendering.get_language(tgtlang))
         # This makes no sense, but has the desired effect to align things correctly for
         # both LTR and RTL languages:
-        if widget.get_direction() == gtk.TEXT_DIR_RTL:
-            self.source_layout.set_alignment(pango.ALIGN_RIGHT)
-            self.target_layout.set_alignment(pango.ALIGN_RIGHT)
+        if widget.get_direction() == Gtk.TextDirection.RTL:
+            self.source_layout.set_alignment(Pango.Alignment.RIGHT)
+            self.target_layout.set_alignment(Pango.Alignment.RIGHT)
             self.target_layout.set_auto_dir(False)
         _layout_width, source_height = self.source_layout.get_pixel_size()
         _layout_width, target_height = self.target_layout.get_pixel_size()

--- a/virtaal/views/widgets/storecellrenderer.py
+++ b/virtaal/views/widgets/storecellrenderer.py
@@ -293,7 +293,7 @@ class StoreCellRenderer(Gtk.CellRenderer):
 
         for textbox in visible_textboxes:
             if textbox.props.visible and textbox.get_parent().size_request().height > max_tb_height:
-                textbox.parent.set_size_request(-1, max_tb_height)
+                textbox.get_parent().set_size_request(-1, max_tb_height)
                 #logging.debug('%s.set_size_request(-1, %d)' % (textbox.parent, max_tb_height))
 
 

--- a/virtaal/views/widgets/storecellrenderer.py
+++ b/virtaal/views/widgets/storecellrenderer.py
@@ -134,7 +134,7 @@ class StoreCellRenderer(Gtk.CellRenderer):
 
     # INITIALIZERS #
     def __init__(self, view):
-        GObject.GObject.__init__(self)
+        super(StoreCellRenderer, self).__init__()
         self.set_property('mode', Gtk.CellRendererMode.EDITABLE)
         self.view = view
         self.__unit = None

--- a/virtaal/views/widgets/storecellrenderer.py
+++ b/virtaal/views/widgets/storecellrenderer.py
@@ -186,7 +186,6 @@ class StoreCellRenderer(Gtk.CellRenderer):
             if parent_height > 0:
                 self.check_editor_height(editor, width, parent_height)
             size_request = editor.size_request()
-            _width = size_request.width
             height = size_request.height
             height += self.ROW_PADDING
         else:

--- a/virtaal/views/widgets/storetreemodel.py
+++ b/virtaal/views/widgets/storetreemodel.py
@@ -20,17 +20,18 @@
 
 from gi.repository import GObject
 from gi.repository import Gtk
+from pygtkcompat.generictreemodel import GenericTreeModel
 
 from virtaal.views import markup
 
 COLUMN_NOTE, COLUMN_UNIT, COLUMN_EDITABLE = 0, 1, 2
 
 
-class StoreTreeModel(Gtk.GenericTreeModel):
+class StoreTreeModel(GenericTreeModel):
     """Custom C{Gtk.TreeModel} adapted from the old C{UnitModel} class."""
 
     def __init__(self, storemodel):
-        GObject.GObject.__init__(self)
+        super(StoreTreeModel, self).__init__()
         self._store = storemodel
         self._store_len = len(storemodel)
         self._current_editable = 0
@@ -112,4 +113,6 @@ class StoreTreeModel(Gtk.GenericTreeModel):
         return self.on_get_path(store_index)
 
     def path_to_store_index(self, path):
+        if path is None:
+            return 0
         return path[0]

--- a/virtaal/views/widgets/storetreemodel.py
+++ b/virtaal/views/widgets/storetreemodel.py
@@ -18,36 +18,36 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-import gtk
-import gobject
+from gi.repository import GObject
+from gi.repository import Gtk
 
 from virtaal.views import markup
 
-
 COLUMN_NOTE, COLUMN_UNIT, COLUMN_EDITABLE = 0, 1, 2
 
-class StoreTreeModel(gtk.GenericTreeModel):
-    """Custom C{gtk.TreeModel} adapted from the old C{UnitModel} class."""
+
+class StoreTreeModel(Gtk.GenericTreeModel):
+    """Custom C{Gtk.TreeModel} adapted from the old C{UnitModel} class."""
 
     def __init__(self, storemodel):
-        gtk.GenericTreeModel.__init__(self)
+        GObject.GObject.__init__(self)
         self._store = storemodel
         self._store_len = len(storemodel)
         self._current_editable = 0
 
     def on_get_flags(self):
-        return gtk.TREE_MODEL_ITERS_PERSIST | gtk.TREE_MODEL_LIST_ONLY
+        return Gtk.TreeModelFlags.ITERS_PERSIST | Gtk.TreeModelFlags.LIST_ONLY
 
     def on_get_n_columns(self):
         return 3
 
     def on_get_column_type(self, index):
         if index == 0:
-            return gobject.TYPE_STRING
+            return GObject.TYPE_STRING
         elif index == 1:
-            return gobject.TYPE_PYOBJECT
+            return GObject.TYPE_PYOBJECT
         elif index == 2:
-            return gobject.TYPE_BOOLEAN
+            return GObject.TYPE_BOOLEAN
 
     def on_get_iter(self, path):
         return path[0]

--- a/virtaal/views/widgets/storetreeview.py
+++ b/virtaal/views/widgets/storetreeview.py
@@ -19,22 +19,23 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-import gtk
-import gobject
 import logging
+
+from gi.repository import GObject
+from gi.repository import Gtk
 
 from storecellrenderer import StoreCellRenderer
 from storetreemodel import COLUMN_NOTE, COLUMN_UNIT, COLUMN_EDITABLE, StoreTreeModel
 
 
-class StoreTreeView(gtk.TreeView):
+class StoreTreeView(Gtk.TreeView):
     """
-    The extended C{gtk.TreeView} we use display our units.
+    The extended C{Gtk.TreeView} we use display our units.
     This class was adapted from the old C{UnitGrid} class.
     """
 
     __gsignals__ = {
-        'modified':(gobject.SIGNAL_RUN_FIRST, gobject.TYPE_NONE, ())
+        'modified': (GObject.SignalFlags.RUN_FIRST, None, ())
     }
 
     # INITIALIZERS #
@@ -43,7 +44,7 @@ class StoreTreeView(gtk.TreeView):
         super(StoreTreeView, self).__init__()
 
         self.set_headers_visible(False)
-        #self.set_direction(gtk.TEXT_DIR_LTR)
+        # self.set_direction(Gtk.TextDirection.LTR)
 
         self.renderer = self._make_renderer()
         self.append_column(self._make_column(self.renderer))
@@ -85,7 +86,7 @@ class StoreTreeView(gtk.TreeView):
         return renderer
 
     def _make_column(self, renderer):
-        column = gtk.TreeViewColumn(None, renderer, unit=COLUMN_UNIT, editable=COLUMN_EDITABLE)
+        column = Gtk.TreeViewColumn(None, renderer, unit=COLUMN_UNIT, editable=COLUMN_EDITABLE)
         column.set_expand(True)
         return column
 
@@ -98,7 +99,7 @@ class StoreTreeView(gtk.TreeView):
             return
         newpath = model.store_index_to_path(index)
         selected = self.get_selection().get_selected()
-        selected_path = isinstance(selected[1], gtk.TreeIter) and model.get_path(selected[1]) or None
+        selected_path = isinstance(selected[1], Gtk.TreeIter) and model.get_path(selected[1]) or None
 
         if selected[1] is None or (selected_path and selected_path != newpath):
             #logging.debug('select_index()->self.set_cursor(path="%s")' % (newpath))
@@ -115,7 +116,7 @@ class StoreTreeView(gtk.TreeView):
                 self.set_cursor(newpath, self.get_columns()[0], start_editing=True)
                 self._waiting_for_row_change -= 1
             self._waiting_for_row_change += 1
-            gobject.idle_add(change_cursor, priority=gobject.PRIORITY_DEFAULT_IDLE)
+            GObject.idle_add(change_cursor, priority=GObject.PRIORITY_DEFAULT_IDLE)
 
     def set_model(self, storemodel):
         if storemodel:
@@ -194,7 +195,8 @@ class StoreTreeView(gtk.TreeView):
         if path != None:
             def do_setcursor():
                 self.set_cursor(path, column, start_editing=True)
-            gobject.idle_add(do_setcursor)
+
+            GObject.idle_add(do_setcursor)
 
         return False
 
@@ -210,7 +212,7 @@ class StoreTreeView(gtk.TreeView):
             self.view.cursor.index = index
 
         # We defer the scrolling until GTK has finished all its current drawing
-        # tasks, hence the gobject.idle_add. If we don't wait, then the TreeView
+        # tasks, hence the GObject.idle_add. If we don't wait, then the TreeView
         # draws the editor widget in the wrong position. Presumably GTK issues
         # a redraw event for the editor widget at a given x-y position and then also
         # issues a TreeView scroll; thus, the editor widget gets drawn at the wrong
@@ -223,7 +225,7 @@ class StoreTreeView(gtk.TreeView):
             self.scroll_to_cell(path, self.get_column(0), True, 0.5, 0.0)
             return False
 
-        gobject.idle_add(do_scroll)
+        GObject.idle_add(do_scroll)
         return True
 
     def _on_key_press(self, _widget, _event, _data=None):

--- a/virtaal/views/widgets/storetreeview.py
+++ b/virtaal/views/widgets/storetreeview.py
@@ -97,7 +97,7 @@ class StoreTreeView(Gtk.TreeView):
         model = self.get_model()
         if not model or not isinstance(model, StoreTreeModel):
             return
-        newpath = model.store_index_to_path(index)
+        newpath = Gtk.TreePath(model.store_index_to_path(index))
         selected = self.get_selection().get_selected()
         selected_path = isinstance(selected[1], Gtk.TreeIter) and model.get_path(selected[1]) or None
 

--- a/virtaal/views/widgets/storetreeview.py
+++ b/virtaal/views/widgets/storetreeview.py
@@ -33,6 +33,7 @@ class StoreTreeView(Gtk.TreeView):
     The extended C{Gtk.TreeView} we use display our units.
     This class was adapted from the old C{UnitGrid} class.
     """
+    __gtype_name__ = 'StoreTreeView'
 
     __gsignals__ = {
         'modified': (GObject.SignalFlags.RUN_FIRST, None, ())

--- a/virtaal/views/widgets/storetreeview.py
+++ b/virtaal/views/widgets/storetreeview.py
@@ -208,7 +208,7 @@ class StoreTreeView(Gtk.TreeView):
             return True
 
         index = model.path_to_store_index(path)
-        if index != self.view.cursor.index:
+        if self.view.cursor and index != self.view.cursor.index:
             self.view.cursor.index = index
 
         # We defer the scrolling until GTK has finished all its current drawing
@@ -222,7 +222,8 @@ class StoreTreeView(Gtk.TreeView):
                 # cursor became invalid since this was added to the idle queue
                 # maybe because the file was closed since then.
                 return False
-            self.scroll_to_cell(path, self.get_column(0), True, 0.5, 0.0)
+            if path:
+                self.scroll_to_cell(path, self.get_column(0), True, 0.5, 0.0)
             return False
 
         GObject.idle_add(do_scroll)

--- a/virtaal/views/widgets/storetreeview.py
+++ b/virtaal/views/widgets/storetreeview.py
@@ -18,14 +18,15 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import, print_function, unicode_literals
 
 import logging
 
 from gi.repository import GObject
 from gi.repository import Gtk
 
-from storecellrenderer import StoreCellRenderer
-from storetreemodel import COLUMN_NOTE, COLUMN_UNIT, COLUMN_EDITABLE, StoreTreeModel
+from .storecellrenderer import StoreCellRenderer
+from .storetreemodel import COLUMN_NOTE, COLUMN_UNIT, COLUMN_EDITABLE, StoreTreeModel
 
 
 class StoreTreeView(Gtk.TreeView):

--- a/virtaal/views/widgets/test_selectdialog.py
+++ b/virtaal/views/widgets/test_selectdialog.py
@@ -18,7 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-from selectdialog import SelectDialog
+from .selectdialog import SelectDialog
 
 
 class TestSelectDialog(object):

--- a/virtaal/views/widgets/test_selectdialog.py
+++ b/virtaal/views/widgets/test_selectdialog.py
@@ -45,7 +45,7 @@ class TestSelectDialog(object):
         self.dialog.run()
 
     def _on_dialog_action(self, dialog, item, action):
-        print '%s: %s' % (action, item)
+        print('%s: %s' % (action, item))
 
 
 if __name__ == '__main__':

--- a/virtaal/views/widgets/test_selectdialog.py
+++ b/virtaal/views/widgets/test_selectdialog.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2009 Zuza Software Foundation
+#
+# This file is part of Virtaal.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+
+from selectdialog import SelectDialog
+
+
+class TestSelectDialog(object):
+    """
+    Test runner for SelectDialog.
+    """
+
+    def __init__(self):
+        self.items = (
+            {'enabled': True,  'name': 'item1', 'desc': 'desc1'},
+            {'enabled': False, 'name': 'item2'                 },
+            {'enabled': True,                   'desc': 'desc3'},
+            {                  'name': 'item4', 'desc': 'desc4'},
+            {'enabled': True,  'name': 'item5', 'desc': ''     },
+            {'enabled': False, 'name': '',      'desc': 'desc6'},
+        )
+        self.dialog = SelectDialog(self.items, title='Test runner', message='Select the items you want:')
+        self.dialog.connect('item-enabled',   self._on_dialog_action, 'Enabled')
+        self.dialog.connect('item-disabled',  self._on_dialog_action, 'Disabled')
+        self.dialog.connect('item-selected',  self._on_dialog_action, 'Selected')
+        self.dialog.connect('selection-done', self._on_dialog_action, 'Selection done')
+
+    def run(self):
+        self.dialog.run()
+
+    def _on_dialog_action(self, dialog, item, action):
+        print '%s: %s' % (action, item)
+
+
+if __name__ == '__main__':
+    runner = TestSelectDialog()
+    runner.run()

--- a/virtaal/views/widgets/test_selectview.py
+++ b/virtaal/views/widgets/test_selectview.py
@@ -22,7 +22,7 @@ import gi
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
 
-from selectview import SelectView
+from .selectview import SelectView
 
 
 class SelectViewTestWindow(Gtk.Window):

--- a/virtaal/views/widgets/test_selectview.py
+++ b/virtaal/views/widgets/test_selectview.py
@@ -48,7 +48,7 @@ class SelectViewTestWindow(Gtk.Window):
 
 
     def _on_item_action(self, sender, item_info, action):
-        print 'Item %s: %s' % (action, item_info)
+        print('Item %s: %s' % (action, item_info))
 
 
 if __name__ == '__main__':

--- a/virtaal/views/widgets/test_selectview.py
+++ b/virtaal/views/widgets/test_selectview.py
@@ -17,7 +17,9 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
+import gi
 
+gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
 
 from selectview import SelectView

--- a/virtaal/views/widgets/test_selectview.py
+++ b/virtaal/views/widgets/test_selectview.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2009 Zuza Software Foundation
+#
+# This file is part of Virtaal.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+
+from gi.repository import Gtk
+
+from selectview import SelectView
+
+
+class SelectViewTestWindow(Gtk.Window):
+    def __init__(self):
+        super(SelectViewTestWindow, self).__init__()
+        self.connect('destroy', lambda *args: Gtk.main_quit())
+        self.add(self.create_selectview())
+
+    def create_selectview(self):
+        self.items = (
+            {'enabled': True,  'name': 'item1', 'desc': 'desc1'},
+            {'enabled': False, 'name': 'item2'                 },
+            {'enabled': True,                   'desc': 'desc3'},
+            {                  'name': 'item4', 'desc': 'desc4'},
+            {'enabled': True,  'name': 'item5', 'desc': ''     },
+            {'enabled': False, 'name': '',      'desc': 'desc6'},
+        )
+        self.selectview = SelectView(self.items)
+        self.selectview.connect('item-enabled', self._on_item_action, 'enabled')
+        self.selectview.connect('item-disabled', self._on_item_action, 'disabled')
+        self.selectview.connect('item-selected', self._on_item_action, 'selected')
+        return self.selectview
+
+
+    def _on_item_action(self, sender, item_info, action):
+        print 'Item %s: %s' % (action, item_info)
+
+
+if __name__ == '__main__':
+    win = SelectViewTestWindow()
+    win.show_all()
+    Gtk.main()

--- a/virtaal/views/widgets/test_textbox.py
+++ b/virtaal/views/widgets/test_textbox.py
@@ -27,7 +27,9 @@ class TextWindow(Gtk.Window):
     def __init__(self, textbox=None):
         super(TextWindow, self).__init__()
         if textbox is None:
-            textbox = TextBox()
+            self.placeables_controller = None
+            self.undo_controller = None
+            textbox = TextBox(self)
 
         self.vbox = Gtk.VBox()
         self.add(self.vbox)

--- a/virtaal/views/widgets/test_textbox.py
+++ b/virtaal/views/widgets/test_textbox.py
@@ -20,7 +20,7 @@
 
 from gi.repository import Gtk
 
-from textbox import TextBox
+from .textbox import TextBox
 
 
 class TextWindow(Gtk.Window):

--- a/virtaal/views/widgets/test_textbox.py
+++ b/virtaal/views/widgets/test_textbox.py
@@ -27,8 +27,6 @@ class TextWindow(Gtk.Window):
     def __init__(self, textbox=None):
         super(TextWindow, self).__init__()
         if textbox is None:
-            self.placeables_controller = None
-            self.undo_controller = None
             textbox = TextBox(self)
 
         self.vbox = Gtk.VBox()
@@ -39,7 +37,6 @@ class TextWindow(Gtk.Window):
 
         self.connect('destroy', lambda *args: Gtk.main_quit())
         self.set_size_request(600, 100)
-
 
 class TestTextBox(object):
     def __init__(self):

--- a/virtaal/views/widgets/test_textbox.py
+++ b/virtaal/views/widgets/test_textbox.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright 2008-2009 Zuza Software Foundation
+# Copyright 2009 Zuza Software Foundation
 #
 # This file is part of Virtaal.
 #
@@ -18,24 +18,34 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-__all__ = ['forall_widgets']
-
 from gi.repository import Gtk
 
-from virtaal.support.simplegeneric import generic
+from textbox import TextBox
 
 
-@generic
-def get_children(widget):
-    return []
+class TextWindow(Gtk.Window):
+    def __init__(self, textbox=None):
+        super(TextWindow, self).__init__()
+        if textbox is None:
+            textbox = TextBox()
+
+        self.vbox = Gtk.VBox()
+        self.add(self.vbox)
+
+        self.textbox = textbox
+        self.vbox.add(textbox)
+
+        self.connect('destroy', lambda *args: Gtk.main_quit())
+        self.set_size_request(600, 100)
 
 
-@get_children.when_type(Gtk.Container)
-def get_children_container(widget):
-    return widget.get_children()
+class TestTextBox(object):
+    def __init__(self):
+        self.window = TextWindow()
 
-def forall_widgets(f, widget):
-    f(widget)
-    for child in get_children(widget):
-        forall_widgets(f, child)
 
+if __name__ == '__main__':
+    window = TextWindow()
+    window.show_all()
+    window.textbox.set_text(u'Ģët <a href="http://www.example.com" alt="Ģët &brand;!">&brandLong;</a>')
+    Gtk.main()

--- a/virtaal/views/widgets/textbox.py
+++ b/virtaal/views/widgets/textbox.py
@@ -18,8 +18,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-from gi.repository import Gtk
-from gobject import SIGNAL_RUN_FIRST, SIGNAL_RUN_LAST
+from gi.repository import Gtk, Gdk
+from gi.repository.GObject import SignalFlags
 from translate.lang import data
 from translate.storage.placeables import StringElem, parse as elem_parse
 
@@ -35,12 +35,12 @@ class TextBox(Gtk.TextView):
 
     __gtype_name__ = 'TextBox'
     __gsignals__ = {
-        'element-selected':      (SIGNAL_RUN_FIRST, None, (object,)),
-        'key-pressed':           (SIGNAL_RUN_LAST,  bool, (object, str)),
-        'refreshed':             (SIGNAL_RUN_FIRST, None, (object,)),
-        'text-deleted':          (SIGNAL_RUN_LAST,  bool, (object, object, int, int, object)),
-        'text-inserted':         (SIGNAL_RUN_LAST,  bool, (object, int, object)),
-        'changed':               (SIGNAL_RUN_LAST, None, ()),
+        'element-selected': (SignalFlags.RUN_FIRST, None, (object,)),
+        'key-pressed': (SignalFlags.RUN_LAST, bool, (object, str)),
+        'refreshed': (SignalFlags.RUN_FIRST, None, (object,)),
+        'text-deleted': (SignalFlags.RUN_LAST, bool, (object, object, int, int, object)),
+        'text-inserted': (SignalFlags.RUN_LAST, bool, (object, int, object)),
+        'changed': (SignalFlags.RUN_LAST, None, ()),
     }
 
     SPECIAL_KEYS = {
@@ -145,7 +145,7 @@ class TextBox(Gtk.TextView):
             start_iter = self.buffer.get_start_iter()
         if end_iter is None:
             end_iter = self.buffer.get_end_iter()
-        return data.forceunicode(self.buffer.get_text(start_iter, end_iter))
+        return data.forceunicode(self.buffer.get_text(start_iter, end_iter, include_hidden_chars=True))
 
     def set_text(self, text, update=False):
         """Set the text rendered in this text box.

--- a/virtaal/views/widgets/textbox.py
+++ b/virtaal/views/widgets/textbox.py
@@ -333,13 +333,14 @@ class TextBox(Gtk.TextView):
         if not hasattr(self, 'selector_color'):
             self.selector_color = Gdk.color_parse(current_theme['selector_textbox'])
         if not hasattr(self, 'nonselector_color'):
-            self.nonselector_color = self.parent.style.bg[Gtk.StateType.NORMAL]
+            self.nonselector_color = self.get_parent().get_style_context().get_color(Gtk.StateType.NORMAL)
 
         for selector in self.selector_textboxes:
             if selector is self.selector_textbox:
-                selector.parent.modify_bg(Gtk.StateType.NORMAL, self.selector_color)
+                selector.get_parent().override_color(Gtk.StateType.NORMAL, Gdk.RGBA(*self.selector_color.to_floats()))
             else:
-                selector.parent.modify_bg(Gtk.StateType.NORMAL, self.nonselector_color)
+                selector.get_parent().override_color(Gtk.StateType.NORMAL,
+                                                     Gdk.RGBA(*self.nonselector_color.to_floats()))
 
     def place_cursor(self, cursor_pos):
         cursor_iter = self.buffer.get_iter_at_offset(cursor_pos)

--- a/virtaal/views/widgets/textbox.py
+++ b/virtaal/views/widgets/textbox.py
@@ -350,7 +350,7 @@ class TextBox(Gtk.TextView):
         self.buffer.place_cursor(cursor_iter)
         # Make sure the cursor is visible to reduce jitters (with backspace at
         # the end of a long unit with scrollbar, for example).
-        self.scroll_to_iter(cursor_iter, 0.0)
+        self.scroll_to_iter(cursor_iter, 0.0, 0, 0, 0)
 
     def refresh(self, preserve_selection=True, update=False):
         """Refresh the text box by setting its text to the current text."""

--- a/virtaal/views/widgets/textbox.py
+++ b/virtaal/views/widgets/textbox.py
@@ -464,7 +464,7 @@ class TextBox(Gtk.TextView):
         if not selection or self.suggestion is None:
             return False
         start_offset = selection[0].get_offset()
-        text = self.buffer.get_text(*selection)
+        text = self.buffer.get_text(*selection, include_hidden_chars=False)
         return self.suggestion['text'] and \
                 self.suggestion['text'] == text and \
                 self.suggestion['offset'] >= 0 and \

--- a/virtaal/views/widgets/textbox.py
+++ b/virtaal/views/widgets/textbox.py
@@ -312,7 +312,7 @@ class TextBox(Gtk.TextView):
         self.refresh(update=True)
 
     def move_elem_selection(self, offset):
-        direction = offset/abs(offset) # Reduce offset to one of -1, 0 or 1
+        direction = int(offset/abs(offset)) # Reduce offset to one of -1, 0 or 1
         st_index = self.selector_textboxes.index(self.selector_textbox)
         st_len = len(self.selector_textboxes)
 

--- a/virtaal/views/widgets/textbox.py
+++ b/virtaal/views/widgets/textbox.py
@@ -26,6 +26,8 @@ from translate.storage.placeables import StringElem, parse as elem_parse
 from virtaal.views import placeablesguiinfo
 from virtaal.views.theme import current_theme
 
+from six import text_type as unicode
+
 
 class TextBox(Gtk.TextView):
     """

--- a/virtaal/views/widgets/textbox.py
+++ b/virtaal/views/widgets/textbox.py
@@ -29,6 +29,25 @@ from virtaal.views.theme import current_theme
 from six import text_type as unicode
 
 
+def colors_equal(a, b):
+    """Compare two colors that could be Gdk.RGBA, Gdk.Color, or str."""
+    if isinstance(a, Gdk.Color):
+        a = a.to_string()
+    if isinstance(a, str):
+        x = Gdk.RGBA()
+        x.parse(a)
+        a = x
+
+    if isinstance(b, Gdk.Color):
+        b = b.to_string()
+    if isinstance(b, str):
+        x = Gdk.RGBA()
+        x.parse(b)
+        b = x
+
+    return a.equal(b)
+
+
 class TextBox(Gtk.TextView):
     """
     A C{Gtk.TextView} extended to work with our nifty L{StringElem} parsed
@@ -233,8 +252,8 @@ class TextBox(Gtk.TextView):
 
                     #logging.debug('  Apply tag at interval (%d, %d) [%s]' % (tag_start, tag_end, self.get_text(*iters)))
                     if not include_subtree or \
-                            elem.gui_info.fg != placeablesguiinfo.StringElemGUI.fg or \
-                            elem.gui_info.bg != placeablesguiinfo.StringElemGUI.bg:
+                            not colors_equal(elem.gui_info.fg, placeablesguiinfo.StringElemGUI.fg) or \
+                            not colors_equal(elem.gui_info.bg, placeablesguiinfo.StringElemGUI.bg):
                         self.buffer.get_tag_table().add(tag)
                         start_iter = self.buffer.get_iter_at_offset(tag_start)
                         end_iter = self.buffer.get_iter_at_offset(tag_end)

--- a/virtaal/views/widgets/textbox.py
+++ b/virtaal/views/widgets/textbox.py
@@ -18,20 +18,18 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-import gtk
+from gi.repository import Gtk
 from gobject import SIGNAL_RUN_FIRST, SIGNAL_RUN_LAST
-
-from translate.storage.placeables import StringElem, parse as elem_parse
-from translate.storage.placeables.terminology import TerminologyPlaceable
 from translate.lang import data
+from translate.storage.placeables import StringElem, parse as elem_parse
 
 from virtaal.views import placeablesguiinfo
 from virtaal.views.theme import current_theme
 
 
-class TextBox(gtk.TextView):
+class TextBox(Gtk.TextView):
     """
-    A C{gtk.TextView} extended to work with our nifty L{StringElem} parsed
+    A C{Gtk.TextView} extended to work with our nifty L{StringElem} parsed
     strings.
     """
 
@@ -46,15 +44,19 @@ class TextBox(gtk.TextView):
     }
 
     SPECIAL_KEYS = {
-        'alt-down':  [(gtk.keysyms.Down,  gtk.gdk.MOD1_MASK)],
-        'alt-left':  [(gtk.keysyms.Left,  gtk.gdk.MOD1_MASK)],
-        'alt-right': [(gtk.keysyms.Right, gtk.gdk.MOD1_MASK)],
-        'enter':     [(gtk.keysyms.Return, 0), (gtk.keysyms.KP_Enter, 0)],
-        'ctrl-enter':[(gtk.keysyms.Return, gtk.gdk.CONTROL_MASK), (gtk.keysyms.KP_Enter, gtk.gdk.CONTROL_MASK)],
-        'ctrl-shift-enter':[(gtk.keysyms.Return, gtk.gdk.CONTROL_MASK | gtk.gdk.SHIFT_MASK), (gtk.keysyms.KP_Enter, gtk.gdk.CONTROL_MASK | gtk.gdk.SHIFT_MASK)],
-        'shift-tab': [(gtk.keysyms.ISO_Left_Tab, gtk.gdk.SHIFT_MASK), (gtk.keysyms.Tab, gtk.gdk.SHIFT_MASK)],
-        'ctrl-tab': [(gtk.keysyms.ISO_Left_Tab, gtk.gdk.CONTROL_MASK), (gtk.keysyms.Tab, gtk.gdk.CONTROL_MASK)],
-        'ctrl-shift-tab': [(gtk.keysyms.ISO_Left_Tab, gtk.gdk.CONTROL_MASK | gtk.gdk.SHIFT_MASK), (gtk.keysyms.Tab, gtk.gdk.CONTROL_MASK | gtk.gdk.SHIFT_MASK)],
+        'alt-down': [(Gdk.KEY_Down, Gdk.ModifierType.MOD1_MASK)],
+        'alt-left': [(Gdk.KEY_Left, Gdk.ModifierType.MOD1_MASK)],
+        'alt-right': [(Gdk.KEY_Right, Gdk.ModifierType.MOD1_MASK)],
+        'enter': [(Gdk.KEY_Return, 0), (Gdk.KEY_KP_Enter, 0)],
+        'ctrl-enter': [(Gdk.KEY_Return, Gdk.ModifierType.CONTROL_MASK),
+                       (Gdk.KEY_KP_Enter, Gdk.ModifierType.CONTROL_MASK)],
+        'ctrl-shift-enter': [(Gdk.KEY_Return, Gdk.ModifierType.CONTROL_MASK | Gdk.ModifierType.SHIFT_MASK),
+                             (Gdk.KEY_KP_Enter, Gdk.ModifierType.CONTROL_MASK | Gdk.ModifierType.SHIFT_MASK)],
+        'shift-tab': [(Gdk.KEY_ISO_Left_Tab, Gdk.ModifierType.SHIFT_MASK), (Gdk.KEY_Tab, Gdk.ModifierType.SHIFT_MASK)],
+        'ctrl-tab': [(Gdk.KEY_ISO_Left_Tab, Gdk.ModifierType.CONTROL_MASK),
+                     (Gdk.KEY_Tab, Gdk.ModifierType.CONTROL_MASK)],
+        'ctrl-shift-tab': [(Gdk.KEY_ISO_Left_Tab, Gdk.ModifierType.CONTROL_MASK | Gdk.ModifierType.SHIFT_MASK),
+                           (Gdk.KEY_Tab, Gdk.ModifierType.CONTROL_MASK | Gdk.ModifierType.SHIFT_MASK)],
     }
     """A table of name-keybinding mappings. The name (key) is passed as the
     second parameter to the 'key-pressed' event."""
@@ -134,7 +136,7 @@ class TextBox(gtk.TextView):
 
     def get_text(self, start_iter=None, end_iter=None):
         """Return the text rendered in this text box.
-            Uses C{gtk.TextBuffer.get_text()}."""
+            Uses C{Gtk.TextBuffer.get_text()}."""
         if isinstance(start_iter, int):
             start_iter = self.buffer.get_iter_at_offset(start_iter)
         if isinstance(end_iter, int):
@@ -147,7 +149,7 @@ class TextBox(gtk.TextView):
 
     def set_text(self, text, update=False):
         """Set the text rendered in this text box.
-            Uses C{gtk.TextBuffer.set_text()}.
+            Uses C{Gtk.TextBuffer.set_text()}.
             @type  text: str|unicode|L{StringElem}
             @param text: The text to render in this text box."""
         if not isinstance(text, StringElem):
@@ -260,8 +262,8 @@ class TextBox(gtk.TextView):
         if selection:
             self.buffer.delete(*selection)
 
-        while gtk.events_pending():
-            gtk.main_iteration()
+        while Gtk.events_pending():
+            Gtk.main_iteration()
 
         cursor_pos = self.buffer.props.cursor_position
         widget = elem.gui_info.get_insert_widget()
@@ -273,7 +275,7 @@ class TextBox(gtk.TextView):
                 # the Gtk guys thought it acceptable to have create_child_anchor() above CHANGE
                 # THE PARAMETER ITER'S VALUE! But only in some cases, while the moon is 73.8% full
                 # and it's after 16:33. Documenting this is obviously also too much to ask.
-                # Nevermind the fact that there isn't simply a gtk.TextBuffer.remove_anchor() method
+                # Nevermind the fact that there isn't simply a Gtk.TextBuffer.remove_anchor() method
                 # or something similar. Why would you want to remove anything from a TextView that
                 # you have added anyway!?
                 # It's crap like this that'll make me ditch Gtk.
@@ -329,15 +331,15 @@ class TextBox(gtk.TextView):
     def __color_selector_textboxes(self, *args):
         """Put a highlighting border around the current selector text box."""
         if not hasattr(self, 'selector_color'):
-            self.selector_color = gtk.gdk.color_parse(current_theme['selector_textbox'])
+            self.selector_color = Gdk.color_parse(current_theme['selector_textbox'])
         if not hasattr(self, 'nonselector_color'):
-            self.nonselector_color = self.parent.style.bg[gtk.STATE_NORMAL]
+            self.nonselector_color = self.parent.style.bg[Gtk.StateType.NORMAL]
 
         for selector in self.selector_textboxes:
             if selector is self.selector_textbox:
-                selector.parent.modify_bg(gtk.STATE_NORMAL, self.selector_color)
+                selector.parent.modify_bg(Gtk.StateType.NORMAL, self.selector_color)
             else:
-                selector.parent.modify_bg(gtk.STATE_NORMAL, self.nonselector_color)
+                selector.parent.modify_bg(Gtk.StateType.NORMAL, self.nonselector_color)
 
     def place_cursor(self, cursor_pos):
         cursor_iter = self.buffer.get_iter_at_offset(cursor_pos)
@@ -734,7 +736,7 @@ class TextBox(gtk.TextView):
         evname = None
 
         if self.suggestion_is_visible():
-            if event.keyval == gtk.keysyms.Tab:
+            if event.keyval == Gdk.KEY_Tab:
                 self.hide_suggestion()
                 self.buffer.insert(
                     self.buffer.get_iter_at_offset(self.suggestion['offset']),
@@ -747,23 +749,24 @@ class TextBox(gtk.TextView):
 
         # Uncomment the following block to get nice textual logging of key presses in the textbox
         #keyname = '<unknown>'
-        #for attr in dir(gtk.keysyms):
-        #    if getattr(gtk.keysyms, attr) == event.keyval:
+        # for attr in dir(Gtk.keysyms):
+        #    if getattr(Gtk.keysyms, attr) == event.keyval:
         #        keyname = attr
         #statenames = []
         #for attr in [a for a in ('MOD1_MASK', 'MOD2_MASK', 'MOD3_MASK', 'MOD4_MASK', 'MOD5_MASK', 'CONTROL_MASK', 'SHIFT_MASK', 'RELEASE_MASK', 'LOCK_MASK', 'SUPER_MASK', 'HYPER_MASK', 'META_MASK')]:
-        #    if event.state & getattr(gtk.gdk, attr):
+        #    if event.get_state() & getattr(Gtk.gdk, attr):
         #        statenames.append(attr)
         #statenames = '|'.join(statenames)
         #logging.debug('Key pressed: %s (%s)' % (keyname, statenames))
-        #logging.debug('state (raw): %x' % (event.state,))
+        #logging.debug('state (raw): %x' % (event.get_state(),))
 
         # Filter out unimportant flags that is present with other keyboard
         # layouts and input methods. The following has been encountered:
         # * MOD2_MASK - Num Lock (bug 926)
         # * LEAVE_NOTIFY_MASK - Arabic keyboard layout (?) (bug 926)
         # * 0x2000000 - IBus input method (bug 1281)
-        filtered_state = event.state & (gtk.gdk.CONTROL_MASK | gtk.gdk.MOD1_MASK | gtk.gdk.MOD4_MASK | gtk.gdk.SHIFT_MASK)
+        filtered_state = event.get_state() & (
+                    Gdk.ModifierType.CONTROL_MASK | Gdk.ModifierType.MOD1_MASK | Gdk.ModifierType.MOD4_MASK | Gdk.ModifierType.SHIFT_MASK)
 
         for name, keyslist in self.SPECIAL_KEYS.items():
             for keyval, state in keyslist:

--- a/virtaal/views/widgets/welcomescreen.py
+++ b/virtaal/views/widgets/welcomescreen.py
@@ -18,8 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-from gi.repository import GObject
-from gi.repository import Gtk
+from gi.repository import GObject, Gtk, Gdk
 
 from virtaal.views.theme import current_theme
 
@@ -119,5 +118,6 @@ class WelcomeScreen(Gtk.ScrolledWindow):
         self.emit('button-clicked', name)
 
     def do_style_set(self, previous_style):
-        self.get_child().modify_bg(Gtk.StateType.NORMAL, self.style.base[Gtk.StateType.NORMAL])
+        self.get_child().override_color(Gtk.StateFlags.NORMAL,
+                                        self.get_style_context().get_color(Gtk.StateFlags.NORMAL))
         self._style_widgets()

--- a/virtaal/views/widgets/welcomescreen.py
+++ b/virtaal/views/widgets/welcomescreen.py
@@ -103,7 +103,11 @@ class WelcomeScreen(Gtk.ScrolledWindow):
 
         def _set_text(features):
             # .get_buffer() is a bit expensive during startup
-            self.widgets['txt_features'].get_buffer().set_text(features)
+            txt_features = self.widgets['txt_features']
+            txt_features.get_buffer().set_text(features)
+            context = txt_features.get_parent().get_style_context()
+            background = context.get_background_color(Gtk.StateType.NORMAL)
+            txt_features.override_background_color(Gtk.StateType.NORMAL, background)
 
         GObject.idle_add(_set_text, features, priority=GObject.PRIORITY_LOW)
 

--- a/virtaal/views/widgets/welcomescreen.py
+++ b/virtaal/views/widgets/welcomescreen.py
@@ -18,36 +18,36 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-import gtk
-import gobject
+from gi.repository import GObject
+from gi.repository import Gtk
 
 from virtaal.views.theme import current_theme
 
 
-class WelcomeScreen(gtk.ScrolledWindow):
+class WelcomeScreen(Gtk.ScrolledWindow):
     """
     The scrolled window that contains the welcome screen container widget.
     """
 
     __gtype_name__ = 'WelcomeScreen'
-    __gsignals__ = { 'button-clicked': (gobject.SIGNAL_RUN_FIRST, None, (str,)) }
+    __gsignals__ = {'button-clicked': (GObject.SignalFlags.RUN_FIRST, None, (str,))}
 
 
     # INITIALISERS #
     def __init__(self, gui):
         """Constructor.
-            @type  gui: C{gtk.Builder}
+            @type  gui: C{Gtk.Builder}
             @param gui: The GtkBuilder XML object to retrieve the welcome screen from."""
         super(WelcomeScreen, self).__init__()
 
         self.gui = gui
 
-        self.set_policy(gtk.POLICY_AUTOMATIC, gtk.POLICY_AUTOMATIC)
+        self.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
 
         win = gui.get_object('WelcomeScreen')
         if not win:
             raise ValueError('Welcome screen not found in GtkBuikder object.')
-        child = win.child
+        child = win.get_child()
         win.remove(child)
         self.add_with_viewport(child)
 
@@ -73,23 +73,23 @@ class WelcomeScreen(gtk.ScrolledWindow):
 
 
     def _style_widgets(self):
-        url_fg_color = gtk.gdk.color_parse(current_theme['url_fg'])
+        url_fg_color = Gdk.color_parse(current_theme['url_fg'])
 
-        for s in [gtk.STATE_ACTIVE, gtk.STATE_NORMAL, gtk.STATE_SELECTED]:
+        for s in [Gtk.StateType.ACTIVE, Gtk.StateType.NORMAL, Gtk.StateType.SELECTED]:
             self.widgets['exp_features'].get_children()[1].modify_fg(s, url_fg_color)
 
-        # Find a gtk.Label as a child of the button...
+        # Find a Gtk.Label as a child of the button...
         for btn in self.widgets['buttons'].values():
             label = None
-            if isinstance(btn.child, gtk.Label):
-                label = btn.child
+            if isinstance(btn.get_child(), Gtk.Label):
+                label = btn.get_child()
             else:
-                for widget in btn.child.get_children():
-                    if isinstance(widget, gtk.Label):
+                for widget in btn.get_child().get_children():
+                    if isinstance(widget, Gtk.Label):
                         label = widget
                         break
             if label:
-                for s in [gtk.STATE_ACTIVE, gtk.STATE_NORMAL, gtk.STATE_SELECTED]:
+                for s in [Gtk.StateType.ACTIVE, Gtk.StateType.NORMAL, Gtk.StateType.SELECTED]:
                     label.modify_fg(s, url_fg_color)
 
     def _init_feature_view(self):
@@ -105,7 +105,8 @@ class WelcomeScreen(gtk.ScrolledWindow):
         def _set_text(features):
             # .get_buffer() is a bit expensive during startup
             self.widgets['txt_features'].get_buffer().set_text(features)
-        gobject.idle_add(_set_text, features, priority=gobject.PRIORITY_LOW)
+
+        GObject.idle_add(_set_text, features, priority=GObject.PRIORITY_LOW)
 
 
     # METHODS #
@@ -118,5 +119,5 @@ class WelcomeScreen(gtk.ScrolledWindow):
         self.emit('button-clicked', name)
 
     def do_style_set(self, previous_style):
-        self.child.modify_bg(gtk.STATE_NORMAL, self.style.base[gtk.STATE_NORMAL])
+        self.get_child().modify_bg(Gtk.StateType.NORMAL, self.style.base[Gtk.StateType.NORMAL])
         self._style_widgets()


### PR DESCRIPTION
## The raw Python 3 + GTK3 port (pioneer era)

First of two PRs (split from #3342, which GitHub's rebase-merge button
couldn't compute cleanly at 144 commits - confirmed a false positive:
a forced local `git rebase` replays all 144 commits with zero
conflicts, byte-identical result, but the button itself stayed red).
Splitting at the branch's own natural seam instead.

This PR is the real, original mechanical port - `pygi-convert.sh`-driven
PyGTK→PyGObject conversion, GTK2→GTK3 widget porting, and the Python
2→3 syntax/API migration - carrying its own original authorship, email,
and date throughout. This isn't just credited in prose; the git history
itself is theirs:

- **licamla** did the original `pygi-convert.sh`/PyGTK→PyGObject pass (13 commits)
- **Friedel Wolff** did the bulk of the real review and correctness work fixing it up (63 commits - bytes/str handling, colour/RGBA plumbing, popup positioning, a segfault fix in `cellrendererwidget.py`, and much more)
- **Stuart Prescott** did the Python 3 syntax pass and stood up the original CI for it (12 commits)
- **Rafael Fontenelle** reviewed/merged a piece of it (1 commit)

Verified all 89 commits shared with `translate/virtaal`'s old `py3`
branch carry byte-identical author name, email, and original date -
only the committer changed (exactly what a clean history reconstruction
does).

### Known incomplete on its own - by design

This PR predates two things it needs to actually run cleanly against
current `main`: PR-0's file renames/removals (`test_selectdialog.py`
etc. → `demo_*.py`, three dead TM plugins), and translate-toolkit's own
API drift since 2020 (`translate.lang.data.tr_lang`/`forceunicode`
removed upstream, `six` no longer vendored). Neither is fixed here -
fixing them means editing code these commits didn't touch, which would
break the "this is really their work, unmodified" property this PR
exists to preserve. **#3342 (retargeted to build on this PR) is what
makes the combined result actually work end to end** - treat this PR
as the historical record, not a standalone deliverable.

Depends on #3341 (merged).
