### PR TITLE
Python 3 + GTK3 port, part 2c: dev hygiene & small fixes

### DIFF
--- a/bin/virtaal
+++ b/bin/virtaal
@@ -85,32 +85,31 @@ def main(argv):
     startup_file = None
 
     if len(argv) > 1:
-        import optparse
-        from optparse import OptionParser, make_option
+        import argparse
 
         from virtaal import __version__
 
-        optparse._ = _
-        usage = _("%prog [options] [translation_file]")
-        option_list = [
-            make_option("-l", "--log",
-                        action="store", type="string", dest="log", metavar=_("LOG"),
-                        help=_("turn on logging, storing the result to the supplied filename.")),
-            make_option("-c", "--config",
-                        action="store", type="string", dest="config", metavar=_("CONFIG"),
-                        help=_("use the configuration file given by the supplied filename.")),
-            make_option("-D", "--debug",
-                        action="store_true", dest="debug", default=False,
-                        help=_("enable debugging features")),
-        ]
+        # No optparse._ = _ equivalent - argparse's own generated chrome
+        # (e.g. "show this help message and exit") isn't translated any
+        # more. Virtaal's own help text below is unaffected.
+        parser = argparse.ArgumentParser()
+        parser.add_argument("-v", "--version", action="version", version=__version__.ver)
+        parser.add_argument("-l", "--log", dest="log", metavar=_("LOG"),
+                             help=_("turn on logging, storing the result to the supplied filename."))
+        parser.add_argument("-c", "--config", dest="config", metavar=_("CONFIG"),
+                             help=_("use the configuration file given by the supplied filename."))
+        parser.add_argument("-D", "--debug", dest="debug", action="store_true", default=False,
+                             help=_("enable debugging features"))
         # Profiling does not make sense in packaged versions.  Set to True to disable profiling.
         if not packaged:
-            option_list.insert(0, make_option("-P", "--profile", action="store",
-                                              type="string", dest="profile",
-                                              metavar=_("PROFILE"),
-                                              #l10n: 'profiling' refers to performance testing
-                                              help=_("perform profiling, storing the result to the supplied filename.")))
-        parser = OptionParser(option_list=option_list, usage=usage, version=__version__.ver)
+            parser.add_argument("-P", "--profile", dest="profile", metavar=_("PROFILE"),
+                                 #l10n: 'profiling' refers to performance testing
+                                 help=_("perform profiling, storing the result to the supplied filename."))
+        # nargs='?' makes this genuinely optional and means argparse itself
+        # rejects more than one positional argument (with its own
+        # "unrecognized arguments" error) - no need for optparse's old
+        # manual get_startup_file()/len(args) check any more.
+        parser.add_argument("translation_file", nargs="?", default=None)
 
 
         def set_logging(options):
@@ -121,8 +120,6 @@ def main(argv):
             level = options.debug and logging.DEBUG or logging.INFO
             if options.debug:
                 format = '%(levelname)7s %(module)s.%(funcName)s:%(lineno)d: %(message)s'
-                if sys.version_info[:2] < (2, 5):
-                    format = '%(levelname)7s %(module)s [%(filename)s:%(lineno)d]: %(message)s'
             else:
                 format = '%(asctime)s %(levelname)s %(message)s'
             if options.log is None:
@@ -138,25 +135,17 @@ def main(argv):
 
         def set_config(options):
             try:
-                if options.config != None:
+                if options.config is not None:
                     pan_app.settings = pan_app.Settings(path.abspath(options.config))
-            except:
+            except Exception:
                 parser.error(_("Could not read configuration file '%(filename)s'") % {"filename": options.config})
 
-        def get_startup_file(options):
-            if len(args) > 1:
-                parser.error(_("invalid number of arguments"))
-            elif len(args) == 1:
-                return args[0]
-            else:
-                return None
 
-
-        options, args = parser.parse_args(argv[1:])
+        options = parser.parse_args(argv[1:])
         pan_app.DEBUG = options.debug
         set_config(options)
         set_logging(options)
-        startup_file = get_startup_file(options)
+        startup_file = options.translation_file
     else:
         # No arguments given, so we save some time by avoiding all the things
         # that could have happened on the command line

--- a/bin/virtaal
+++ b/bin/virtaal
@@ -22,6 +22,21 @@
 import sys
 from os import path
 
+# A frozen build has no separate "python" executable to hand "-m" to
+# for launching a helper subprocess (see localtm.py's tmserver) -
+# sys.executable there *is* this launcher. Dispatch via runpy instead.
+if len(sys.argv) > 2 and sys.argv[1] == '--run-module':
+    import runpy
+    module_name = sys.argv[2]
+    sys.argv = sys.argv[2:]
+    runpy.run_module(module_name, run_name='__main__')
+    sys.exit(0)
+
+# A frozen build needs pycairo's C-API initialized before GTK's
+# foreign-struct registration for cairo.Context runs, or every draw
+# call fails with a TypeError. Harmless to do unconditionally.
+import cairo  # noqa: F401
+
 from virtaal.common import pan_app
 
 # Some behaviour should vary, depending on whether Virtaal is packaged or not
@@ -35,7 +50,7 @@ if not packaged:
     # We can't meaningfully report on these, and we build our own windows
     # version, so let's leave this out for the benefit of startup time.
     from virtaal.support import depcheck
-    optional_modules = ['enchant', 'gtkspell', 'psycopg2', 'libproxy']
+    optional_modules = ['enchant', 'gtkspell', 'libproxy']
     error_messages = {
         'translate':  'Translate Toolkit >= %s is required for Virtaal to function.' % str(depcheck.MIN_TRANSLATE_VERSION),
         'gtk':        'Gtk >= %s and PyGTK is required for Virtaal to function.' % str(depcheck.MIN_GTK_VERSION),
@@ -46,7 +61,6 @@ if not packaged:
         'wsgiref':    'WSGIRef is required for Virtaal to function.',
         'enchant':    'Enchant not installed: Spell checking will not work.',
         'gtkspell':   'GtkSpell not installed: Spell checking will not work.',
-        'psycopg2':   'PsycoPG not installed: The TinyTM plug-in will not work.',
         'libproxy':   'libproxy is not installed: it improves support for network proxies on Linux.',
         'diff_match_patch': 'diff_match_patch is not installed: it is required for TM functionality.',
     }
@@ -201,4 +215,12 @@ def main(argv):
     runner(startup_file)
 
 if __name__ == "__main__":
-    main(sys.argv)
+    try:
+        main(sys.argv)
+    except KeyboardInterrupt:
+        # Ctrl-C shouldn't dump a traceback. os._exit(), not sys.exit():
+        # the latter's interpreter finalization forces a gc.collect()
+        # despite Virtaal's gc.disable(), reproducing the GTK teardown
+        # segfault os._exit(0) dodges on the normal-quit path (main.py).
+        import os
+        os._exit(130)

--- a/devsupport/profiling.py
+++ b/devsupport/profiling.py
@@ -32,7 +32,7 @@ class KCacheGrind(object):
 
     def output(self, out_file):
         self.out_file = out_file
-        print >> out_file, 'events: Ticks'
+        print('events: Ticks', file=out_file)
         self._print_summary()
         for entry in self.data:
             self._entry(entry)
@@ -42,22 +42,22 @@ class KCacheGrind(object):
         for entry in self.data:
             totaltime = int(entry.totaltime * 1000)
             max_cost = max(max_cost, totaltime)
-        print >> self.out_file, 'summary: %d' % (max_cost,)
+        print('summary: %d' % (max_cost,), file=self.out_file)
 
     def _entry(self, entry):
         out_file = self.out_file
         code = entry.code
         inlinetime = int(entry.inlinetime * 1000)
-        #print >> out_file, 'ob=%s' % (code.co_filename,)
+        #print('ob=%s' % (code.co_filename,), file=out_file)
         if isinstance(code, str):
-            print >> out_file, 'fi=~'
+            print('fi=~', file=out_file)
         else:
-            print >> out_file, 'fi=%s' % (code.co_filename,)
-        print >> out_file, 'fn=%s' % (label(code),)
+            print('fi=%s' % (code.co_filename,), file=out_file)
+        print('fn=%s' % (label(code),), file=out_file)
         if isinstance(code, str):
-            print >> out_file, '0 ', inlinetime
+            print('0 ', inlinetime, file=out_file)
         else:
-            print >> out_file, '%d %d' % (code.co_firstlineno, inlinetime)
+            print('%d %d' % (code.co_firstlineno, inlinetime), file=out_file)
         # recursive calls are counted in entry.calls
         if entry.calls:
             calls = entry.calls
@@ -69,22 +69,22 @@ class KCacheGrind(object):
             lineno = code.co_firstlineno
         for subentry in calls:
             self._subentry(lineno, subentry)
-        print >> out_file
+        print(file=out_file)
 
     def _subentry(self, lineno, subentry):
         out_file = self.out_file
         code = subentry.code
         totaltime = int(subentry.totaltime * 1000)
-        #print >> out_file, 'cob=%s' % (code.co_filename,)
-        print >> out_file, 'cfn=%s' % (label(code),)
+        #print('cob=%s' % (code.co_filename,), file=out_file)
+        print('cfn=%s' % (label(code),), file=out_file)
         if isinstance(code, str):
-            print >> out_file, 'cfi=~'
-            print >> out_file, 'calls=%d 0' % (subentry.callcount,)
+            print('cfi=~', file=out_file)
+            print('calls=%d 0' % (subentry.callcount,), file=out_file)
         else:
-            print >> out_file, 'cfi=%s' % (code.co_filename,)
-            print >> out_file, 'calls=%d %d' % (
-                subentry.callcount, code.co_firstlineno)
-        print >> out_file, '%d %d' % (lineno, totaltime)
+            print('cfi=%s' % (code.co_filename,), file=out_file)
+            print('calls=%d %d' % (
+                subentry.callcount, code.co_firstlineno), file=out_file)
+        print('%d %d' % (lineno, totaltime), file=out_file)
 
 def profile_func(filename=None, mode='w+'):
     """Function/method decorator that will cause only the decorated callable

--- a/virtaal/common/gobjectwrapper.py
+++ b/virtaal/common/gobjectwrapper.py
@@ -30,7 +30,7 @@ class GObjectWrapper(GObject.GObject):
 
     # INITIALIZERS #
     def __init__(self):
-        super(GObjectWrapper, self).__init__()
+        super().__init__()
         self._all_signals = []
         for type_ in self.__class__.mro():
             if issubclass(type_, GObject.GObject):
@@ -58,4 +58,4 @@ class GObjectWrapper(GObject.GObject):
     def emit(self, signame, *args):
         if signame in self._enabled_signals:
             #logging.debug('emit("%s", %s)' % (signame, ','.join([repr(arg) for arg in args])))
-            super(GObjectWrapper, self).emit(signame, *args)
+            super().emit(signame, *args)

--- a/virtaal/controllers/maincontroller.py
+++ b/virtaal/controllers/maincontroller.py
@@ -28,6 +28,7 @@ from gi.repository import Gtk, GObject
 
 from .basecontroller import BaseController
 from virtaal.common import GObjectWrapper, pan_app
+from virtaal.models.storemodel import SaveCancelled
 from virtaal.views.mainview import MainView
 
 
@@ -255,6 +256,9 @@ class MainController(BaseController):
         try:
             self.store_controller.save_file(filename)
             return True
+        except SaveCancelled:
+            # Expected, not an error - no traceback, no dialog.
+            pass
         except IOError as exc:
             self.show_error(
                 _("Could not save file.\n\n%(error_message)s\n\nTry saving to a different location.") % {'error_message': str(exc)}

--- a/virtaal/models/basemodel.py
+++ b/virtaal/models/basemodel.py
@@ -33,7 +33,7 @@ class BaseModel(GObject.GObject):
 
     # INITIALIZERS #
     def __init__(self):
-        super(BaseModel, self).__init__()
+        super().__init__()
 
 
     # ACCESSORS #

--- a/virtaal/models/langmodel.py
+++ b/virtaal/models/langmodel.py
@@ -44,7 +44,7 @@ class LanguageModel(BaseModel):
         """Constructor.
             Looks up the language information based on the given language code
             (C{langcode})."""
-        super(LanguageModel, self).__init__()
+        super().__init__()
         if not self.languages:
             self.languages.update(toolkit_langs)
         self.languages.update(more_langs)

--- a/virtaal/models/storemodel.py
+++ b/virtaal/models/storemodel.py
@@ -61,7 +61,7 @@ class StoreModel(BaseModel):
 
     # INITIALIZERS #
     def __init__(self, fileobj, controller):
-        super(StoreModel, self).__init__()
+        super().__init__()
         self.controller = controller
         self.load_file(fileobj)
 

--- a/virtaal/models/storemodel.py
+++ b/virtaal/models/storemodel.py
@@ -25,6 +25,12 @@ from virtaal.common import pan_app
 from .basemodel import BaseModel
 
 
+class SaveCancelled(Exception):
+    """Raised when the user cancels the translator info prompt during
+        save - expected, not an error, so handled separately from a
+        real save failure."""
+
+
 def fix_indexes(stats, valid_units=None):
     """convert statsdb array to use model index instead of storage class index"""
     if valid_units is None:
@@ -259,7 +265,7 @@ class StoreModel(BaseModel):
             team = self.controller.main_controller.get_translator_team()
             if name is None or email is None or team is None:
                 # User cancelled
-                raise Exception('Save cancelled.')
+                raise SaveCancelled()
             pan_app.settings.translator["name"] = name
             pan_app.settings.translator["email"] = email
             pan_app.settings.translator["team"] = team

--- a/virtaal/models/undomodel.py
+++ b/virtaal/models/undomodel.py
@@ -29,7 +29,7 @@ class UndoModel(BaseModel):
     def __init__(self, controller):
         self.controller = controller
 
-        super(UndoModel, self).__init__()
+        super().__init__()
         self.index = -1
         self.recording = False
         self.undo_stack = []

--- a/virtaal/plugins/_ipython_console/__init__.py
+++ b/virtaal/plugins/_ipython_console/__init__.py
@@ -15,7 +15,7 @@ class IPythonWindow(Gtk.Window):
 
     # INITIALIZERS #
     def __init__(self, namespace={}, destroy_cb=None):
-        super(IPythonWindow, self).__init__()
+        super().__init__()
         self._setup_console()
         self.console.updateNamespace(namespace)
 

--- a/virtaal/plugins/_ipython_console/ipython_view.py
+++ b/virtaal/plugins/_ipython_console/ipython_view.py
@@ -256,7 +256,7 @@ class ConsoleView(Gtk.TextView):
     '''
     Initialize console view.
     '''
-    super(ConsoleView, self).__init__()
+    super().__init__()
     self.modify_font(Pango.FontDescription('Mono'))
     self.set_cursor_visible(True)
     self.text_buffer = self.get_buffer()

--- a/virtaal/plugins/_python_console.py
+++ b/virtaal/plugins/_python_console.py
@@ -14,7 +14,7 @@ from virtaal.controllers.baseplugin import BasePlugin
 
 class PythonConsole(Gtk.ScrolledWindow):
     def __init__(self, namespace = {}, destroy_cb = None):
-        super(PythonConsole, self).__init__()
+        super().__init__()
 
         self.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC);
         self.set_shadow_type(Gtk.ShadowType.IN)

--- a/virtaal/plugins/autocompletor.py
+++ b/virtaal/plugins/autocompletor.py
@@ -34,7 +34,7 @@ except ImportError:
 
         def __getitem__(self, key):
             if key in self:
-                return super(defaultdict, self).__getitem__(key)
+                return super().__getitem__(key)
             else:
                 return self.__factory()
 

--- a/virtaal/plugins/terminology/models/autoterm.py
+++ b/virtaal/plugins/terminology/models/autoterm.py
@@ -47,7 +47,7 @@ class TerminologyModel(BaseTerminologyModel):
 
     # INITIALIZERS #
     def __init__(self, internal_name, controller):
-        super(TerminologyModel, self).__init__(controller)
+        super().__init__(controller)
         self.internal_name = internal_name
         self.client = HTTPClient()
         self.client.set_virtaal_useragent()

--- a/virtaal/plugins/terminology/models/basetermmodel.py
+++ b/virtaal/plugins/terminology/models/basetermmodel.py
@@ -47,7 +47,7 @@ class BaseTerminologyModel(BaseModel):
 
             Only call this from child classes once the object was successfully
             created and want to be connected to signals."""
-        super(BaseTerminologyModel, self).__init__()
+        super().__init__()
         self.config = {}
         self.controller = controller
         self._connect_ids = []

--- a/virtaal/plugins/terminology/models/localfile/__init__.py
+++ b/virtaal/plugins/terminology/models/localfile/__init__.py
@@ -51,7 +51,7 @@ class TerminologyModel(BaseTerminologyModel):
 
     # INITIALIZERS #
     def __init__(self, internal_name, controller):
-        super(TerminologyModel, self).__init__(controller)
+        super().__init__(controller)
 
         self.matcher = None
         self.internal_name = internal_name
@@ -66,7 +66,7 @@ class TerminologyModel(BaseTerminologyModel):
     def destroy(self):
         self.view.destroy()
         self.save_config()
-        super(TerminologyModel, self).destroy()
+        super().destroy()
         if self.matcher in TerminologyPlaceable.matchers:
             TerminologyPlaceable.matchers.remove(self.matcher)
 
@@ -104,7 +104,7 @@ class TerminologyModel(BaseTerminologyModel):
         return units
 
     def load_config(self):
-        super(TerminologyModel, self).load_config()
+        super().load_config()
         conffiles = []
         for filename in self.config['files'].split(','):
             if os.path.exists(filename):

--- a/virtaal/plugins/terminology/termview.py
+++ b/virtaal/plugins/terminology/termview.py
@@ -44,7 +44,7 @@ class TerminologyGUIInfo(StringElemGUI):
 
     def __init__(self, elem, textbox, **kwargs):
         assert elem.__class__.__name__ == 'TerminologyPlaceable'
-        super(TerminologyGUIInfo, self).__init__(elem, textbox, **kwargs)
+        super().__init__(elem, textbox, **kwargs)
 
 
     # METHODS #
@@ -74,7 +74,7 @@ class TerminologyCombo(Gtk.ComboBox):
 
     # INITIALIZERS #
     def __init__(self, elem):
-        super(TerminologyCombo, self).__init__()
+        super().__init__()
         self.elem = elem
         self.insert_iter = None
         self.selected_string = None

--- a/virtaal/plugins/tm/models/_dummytm.py
+++ b/virtaal/plugins/tm/models/_dummytm.py
@@ -31,7 +31,7 @@ class TMModel(BaseTMModel):
     # INITIALIZERS #
     def __init__(self, internal_name, controller):
         self.internal_name = internal_name
-        super(TMModel, self).__init__(controller)
+        super().__init__(controller)
 
 
     # METHODS #

--- a/virtaal/plugins/tm/models/apertium.py
+++ b/virtaal/plugins/tm/models/apertium.py
@@ -66,7 +66,7 @@ class TMModel(BaseTMModel):
             lambda langreq, response: self.got_language_pairs(response)
         )
 
-        super(TMModel, self).__init__(controller)
+        super().__init__(controller)
 
 
     # METHODS #

--- a/virtaal/plugins/tm/models/basetmmodel.py
+++ b/virtaal/plugins/tm/models/basetmmodel.py
@@ -68,7 +68,7 @@ class BaseTMModel(BaseModel):
 
             Only call this from child classes once the object was successfully
             created and want to be connected to signals."""
-        super(BaseTMModel, self).__init__()
+        super().__init__()
         self.config = {}
         self.controller = controller
         self._connect_ids = []

--- a/virtaal/plugins/tm/models/currentfile.py
+++ b/virtaal/plugins/tm/models/currentfile.py
@@ -34,7 +34,7 @@ class TMModel(BaseTMModel):
 
     # INITIALIZERS #
     def __init__(self, internal_name, controller):
-        super(TMModel, self).__init__(controller)
+        super().__init__(controller)
 
         self.matcher = None
         self.internal_name = internal_name

--- a/virtaal/plugins/tm/models/google_translate.py
+++ b/virtaal/plugins/tm/models/google_translate.py
@@ -66,7 +66,7 @@ class TMModel(BaseTMModel):
     # INITIALIZERS #
     def __init__(self, internal_name, controller):
         self.internal_name = internal_name
-        super(TMModel, self).__init__(controller)
+        super().__init__(controller)
         self.load_config()
         if not self.config['api_key']:
             self._disable_all("An API key is needed to use the Google Translate plugin")

--- a/virtaal/plugins/tm/models/moses.py
+++ b/virtaal/plugins/tm/models/moses.py
@@ -37,7 +37,7 @@ class TMModel(BaseTMModel):
     # INITIALIZERS #
     def __init__(self, internal_name, controller):
         self.internal_name = internal_name
-        super(TMModel, self).__init__(controller)
+        super().__init__(controller)
 
         self.load_config()
         self.clients = {}

--- a/virtaal/plugins/tm/models/remotetm.py
+++ b/virtaal/plugins/tm/models/remotetm.py
@@ -38,7 +38,7 @@ class TMModel(BaseTMModel):
 
     # INITIALIZERS #
     def __init__(self, internal_name, controller):
-        super(TMModel, self).__init__(controller)
+        super().__init__(controller)
         self.internal_name = internal_name
         self.load_config()
         url = "http://%s:%s/tmserver" % (self.config["host"], self.config["port"])

--- a/virtaal/plugins/tm/tmwidgets.py
+++ b/virtaal/plugins/tm/tmwidgets.py
@@ -34,7 +34,7 @@ class TMWindow(Gtk.Window):
 
     # INITIALIZERS #
     def __init__(self, view):
-        super(TMWindow, self).__init__(Gtk.WindowType.POPUP)
+        super().__init__(Gtk.WindowType.POPUP)
         self.view = view
 
         # set_has_frame is the method of Gtk.Enter, not found on Gtk.Window
@@ -175,7 +175,7 @@ class TMSourceColRenderer(Gtk.CellRenderer):
 
     # INITIALIZERS #
     def __init__(self, view):
-        super(TMSourceColRenderer, self).__init__()
+        super().__init__()
 
         self.view = view
         self.matchdata = None
@@ -248,7 +248,7 @@ class TMMatchRenderer(Gtk.CellRenderer):
 
     # INITIALIZERS #
     def __init__(self, view):
-        super(TMMatchRenderer, self).__init__()
+        super().__init__()
 
         self.view = view
         self.layout = None

--- a/virtaal/plugins/tm/tmwidgets.py
+++ b/virtaal/plugins/tm/tmwidgets.py
@@ -137,6 +137,10 @@ class TMWindow(Gtk.Window):
         match_data = tree_model.get_value(iter, 0)
         if match_data.get('quality', None) is not None:
             quality = int(match_data['quality'])
+            # Should never legitimately be outside 0-100; GtkCellRendererProgress's
+            # "value" property is a C gint, so an out-of-range value crashes
+            # with OverflowError. Clamp defensively regardless of root cause.
+            quality = max(0, min(100, quality))
             cell_renderer.set_property('value', quality)
             #l10n: This message allows you to customize the appearance of the match percentage. Most languages can probably leave it unchanged.
             cell_renderer.set_property('text', _("%(match_quality)s%%") % \

--- a/virtaal/support/httpclient.py
+++ b/virtaal/support/httpclient.py
@@ -166,7 +166,7 @@ class RESTRequest(HTTPRequest):
     """Single HTTP REST request, blocking if used standalone."""
 
     def __init__(self, url, id, method='GET', data=None, headers=None, user_agent=None, params=None):
-        super(RESTRequest, self).__init__(url, method, data, headers, user_agent=user_agent, follow_location=True)
+        super().__init__(url, method, data, headers, user_agent=user_agent, follow_location=True)
 
         url = self.url
         self.id = id

--- a/virtaal/support/mosesclient.py
+++ b/virtaal/support/mosesclient.py
@@ -20,7 +20,7 @@
 
 import logging
 
-import xmlrpclib
+import xmlrpc.client as xmlrpclib
 from gi.repository import GObject
 
 from virtaal.support.httpclient import HTTPClient, HTTPRequest
@@ -66,7 +66,7 @@ class MosesClient(GObject.GObject, HTTPClient):
     }
 
     def __init__(self, url):
-        super(MosesClient, self).__init__()
+        super().__init__()
         HTTPClient.__init__(self)
 
         self.url = url + '/RPC2'

--- a/virtaal/support/openmailto.py
+++ b/virtaal/support/openmailto.py
@@ -291,37 +291,39 @@ def mailto(address, to=None, cc=None, bcc=None, subject=None, body=None,
 
 
 if __name__ == '__main__':
-    from optparse import OptionParser
+    from argparse import ArgumentParser
 
-    version = '%%prog %s' % __version__
     usage = (
-        '\n\n%prog FILENAME [FILENAME(s)] -- for opening files'
-        '\n\n%prog -m [OPTIONS] ADDRESS [ADDRESS(es)] -- for sending e-mails'
+        '\n\n%(prog)s FILENAME [FILENAME(s)] -- for opening files'
+        '\n\n%(prog)s -m [OPTIONS] ADDRESS [ADDRESS(es)] -- for sending e-mails'
     )
 
-    parser = OptionParser(usage=usage, version=version, description=__doc__)
-    parser.add_option('-m', '--mailto', dest='mailto_mode', default=False, \
-                      action='store_true', help='set mailto mode. '
-                      'If not set any other option is ignored')
-    parser.add_option('--cc', dest='cc', help='specify a recipient to be '
-                      'copied on the e-mail')
-    parser.add_option('--bcc', dest='bcc', help='specify a recipient to be '
-                      'blindly copied on the e-mail')
-    parser.add_option('--subject', dest='subject',
-                      help='specify a subject for the e-mail')
-    parser.add_option('--body', dest='body', help='specify a body for the '
-                      'e-mail. Since the user will be able to make changes '
-                      'before actually sending the e-mail, this can be used '
-                      'to provide the user with a template for the e-mail '
-                      'text may contain linebreaks')
-    parser.add_option('--attach', dest='attach', help='specify an attachment '
-                      'for the e-mail. file must point to an existing file')
+    parser = ArgumentParser(usage=usage, description=__doc__)
+    parser.add_argument('-v', '--version', action='version',
+                         version='%(prog)s ' + __version__)
+    parser.add_argument('-m', '--mailto', dest='mailto_mode', default=False,
+                         action='store_true', help='set mailto mode. '
+                         'If not set any other option is ignored')
+    parser.add_argument('--cc', dest='cc', help='specify a recipient to be '
+                         'copied on the e-mail')
+    parser.add_argument('--bcc', dest='bcc', help='specify a recipient to be '
+                         'blindly copied on the e-mail')
+    parser.add_argument('--subject', dest='subject',
+                         help='specify a subject for the e-mail')
+    parser.add_argument('--body', dest='body', help='specify a body for the '
+                         'e-mail. Since the user will be able to make changes '
+                         'before actually sending the e-mail, this can be used '
+                         'to provide the user with a template for the e-mail '
+                         'text may contain linebreaks')
+    parser.add_argument('--attach', dest='attach', help='specify an attachment '
+                         'for the e-mail. file must point to an existing file')
+    # nargs='+' makes argparse itself require at least one FILENAME/ADDRESS
+    # and reject zero, with its own error - no need for optparse's old
+    # manual "if not args: print_usage(); exit(1)" check any more.
+    parser.add_argument('args', nargs='+', metavar='FILENAME/ADDRESS')
 
-    (options, args) = parser.parse_args()
-
-    if not args:
-        parser.print_usage()
-        parser.exit(1)
+    options = parser.parse_args()
+    args = options.args
 
     if options.mailto_mode:
         if not mailto(args, None, options.cc, options.bcc, options.subject,

--- a/virtaal/support/openmailto.py
+++ b/virtaal/support/openmailto.py
@@ -58,7 +58,7 @@ class Controller(BaseController):
     '''Controller for a generic open program.'''
 
     def __init__(self, *args):
-        super(Controller, self).__init__(os.path.basename(args[0]))
+        super().__init__(os.path.basename(args[0]))
         self.args = list(args)
 
     def _invoke(self, cmdline):
@@ -143,7 +143,7 @@ else:
         '''Controller for the KDE kfmclient program.'''
 
         def __init__(self, kfmclient='kfmclient'):
-            super(KfmClient, self).__init__(kfmclient, 'exec')
+            super().__init__(kfmclient, 'exec')
 
 
     def detect_desktop_environment():

--- a/virtaal/support/thread.py
+++ b/virtaal/support/thread.py
@@ -19,6 +19,7 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 
+import logging
 import queue
 import threading
 
@@ -29,7 +30,13 @@ def run_in_thread(widget, target, args):
     # Idea from tortoisehg's gtklib.py
     q = queue.Queue()
     def func(*kwargs):
-        q.put(target(*kwargs))
+        # An uncaught exception here used to kill the thread silently,
+        # with the caller getting back None indistinguishable from a
+        # real cancel.
+        try:
+            q.put(target(*kwargs))
+        except Exception:
+            logging.exception("run_in_thread: %r raised", target)
 
     thread = threading.Thread(target=func, args=args)
     thread.start()

--- a/virtaal/views/mainview.py
+++ b/virtaal/views/mainview.py
@@ -45,7 +45,7 @@ class EntryDialog(Gtk.Dialog):
     """A simple dialog containing a dialog for user input."""
 
     def __init__(self, parent):
-        super(EntryDialog, self).__init__(title='Input Dialog', parent=parent)
+        super().__init__(title='Input Dialog', parent=parent)
         self.set_size_request(450, 100)
 
         self.lbl_message = Gtk.Label()
@@ -70,7 +70,7 @@ class EntryDialog(Gtk.Dialog):
 
         self.show_all()
         self.ent_input.grab_focus()
-        response = super(EntryDialog, self).run()
+        response = super().run()
 
         return response, get_unicode(self.ent_input.get_text(), 'utf-8')
 
@@ -78,7 +78,7 @@ class EntryDialog(Gtk.Dialog):
         self.lbl_message.set_markup(message)
 
     def set_title(self, title):
-        super(EntryDialog, self).set_title(title)
+        super().set_title(title)
 
 # XXX: This class is based on main_window.py:Virtaal from the pre-MVC days (Virtaal 0.2).
 class MainView(BaseView):

--- a/virtaal/views/unitview.py
+++ b/virtaal/views/unitview.py
@@ -292,7 +292,7 @@ class UnitView(Gtk.EventBox, GObjectWrapper, Gtk.CellEditable, BaseView):
         self.emit('modified')
 
     def show(self):
-        super(UnitView, self).show()
+        super().show()
 
     def update_languages(self):
         srclang = self.controller.main_controller.lang_controller.source_lang.code

--- a/virtaal/views/widgets/aboutdialog.py
+++ b/virtaal/views/widgets/aboutdialog.py
@@ -27,7 +27,7 @@ from virtaal.support import openmailto
 
 class AboutDialog(Gtk.AboutDialog):
     def __init__(self, parent):
-        super(AboutDialog, self).__init__()
+        super().__init__()
         self._register_uri_handlers()
         self.set_name("Virtaal")
         self.set_version(__version__.ver)

--- a/virtaal/views/widgets/cellrendererwidget.py
+++ b/virtaal/views/widgets/cellrendererwidget.py
@@ -52,7 +52,7 @@ class CellRendererWidget(Gtk.CellRenderer):
 
     # INITIALIZERS #
     def __init__(self, strfunc, default_width=-1, widget_func=None):
-        super(CellRendererWidget, self).__init__()
+        super().__init__()
 
         self.default_width = default_width
         self._editing = False
@@ -155,7 +155,7 @@ class CellWidget(Gtk.HBox, Gtk.CellEditable):
 
     # INITIALIZERS #
     def __init__(self, *widgets):
-        super(CellWidget, self).__init__()
+        super().__init__()
         for w in widgets:
             if w.get_parent() is not None:
                 w.get_parent().remove(w)
@@ -177,7 +177,7 @@ if __name__ == "__main__":
     class Tree(Gtk.TreeView):
         def __init__(self):
             self.store = Gtk.ListStore(str, TYPE_PYOBJECT, bool)
-            super(Tree, self).__init__()
+            super().__init__()
             self.set_model(self.store)
             self.set_headers_visible(True)
 

--- a/virtaal/views/widgets/demo_selectview.py
+++ b/virtaal/views/widgets/demo_selectview.py
@@ -27,7 +27,7 @@ from .selectview import SelectView
 
 class SelectViewTestWindow(Gtk.Window):
     def __init__(self):
-        super(SelectViewTestWindow, self).__init__()
+        super().__init__()
         self.connect('destroy', lambda *args: Gtk.main_quit())
         self.add(self.create_selectview())
 

--- a/virtaal/views/widgets/demo_selectview.py
+++ b/virtaal/views/widgets/demo_selectview.py
@@ -17,6 +17,13 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
+
+"""Manual, interactive demo for SelectView - opens a real window for a
+human to eyeball, not an automated test. Run directly:
+python demo_selectview.py
+(Renamed from test_selectview.py, which pytest was picking up by
+filename convention alone despite having no assertions.)"""
+
 import gi
 
 gi.require_version('Gtk', '3.0')

--- a/virtaal/views/widgets/demo_textbox.py
+++ b/virtaal/views/widgets/demo_textbox.py
@@ -25,7 +25,7 @@ from .textbox import TextBox
 
 class TextWindow(Gtk.Window):
     def __init__(self, textbox=None):
-        super(TextWindow, self).__init__()
+        super().__init__()
         if textbox is None:
             textbox = TextBox(self)
 

--- a/virtaal/views/widgets/demo_textbox.py
+++ b/virtaal/views/widgets/demo_textbox.py
@@ -18,6 +18,11 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
+"""Manual, interactive demo for TextBox - opens a real window for a human
+to eyeball, not an automated test. Run directly: python demo_textbox.py
+(Renamed from test_textbox.py, which pytest was picking up by filename
+convention alone despite having no assertions.)"""
+
 from gi.repository import Gtk
 
 from .textbox import TextBox

--- a/virtaal/views/widgets/label_expander.py
+++ b/virtaal/views/widgets/label_expander.py
@@ -35,7 +35,7 @@ class LabelExpander(Gtk.EventBox):
     }
 
     def __init__(self, widget, get_text, expanded=False):
-        super(LabelExpander, self).__init__()
+        super().__init__()
 
         label_text = Gtk.Label()
         label_text.set_single_line_mode(False)

--- a/virtaal/views/widgets/langadddialog.py
+++ b/virtaal/views/widgets/langadddialog.py
@@ -31,7 +31,7 @@ class LanguageAddDialog(object):
 
     # INITIALIZERS #
     def __init__(self, parent=None):
-        super(LanguageAddDialog, self).__init__()
+        super().__init__()
 
         self.gui = BaseView.load_builder_file(
             ["virtaal", "virtaal.ui"],

--- a/virtaal/views/widgets/langselectdialog.py
+++ b/virtaal/views/widgets/langselectdialog.py
@@ -33,7 +33,7 @@ class LanguageSelectDialog(object):
 
     # INITIALIZERS #
     def __init__(self, languages, parent=None):
-        super(LanguageSelectDialog, self).__init__()
+        super().__init__()
 
         self.gui = BaseView.load_builder_file(
             ["virtaal", "virtaal.ui"],
@@ -174,4 +174,3 @@ class LanguageSelectDialog(object):
         path = model.get_path(i)
         treeview.get_selection().select_iter(i)
         treeview.scroll_to_cell(path)
-

--- a/virtaal/views/widgets/listnav.py
+++ b/virtaal/views/widgets/listnav.py
@@ -43,7 +43,7 @@ class ListNavigator(Gtk.HBox):
 
     # INITIALIZERS #
     def __init__(self):
-        super(ListNavigator, self).__init__()
+        super().__init__()
         self._init_widgets()
 
     def _init_treeview(self):

--- a/virtaal/views/widgets/popupwidgetbutton.py
+++ b/virtaal/views/widgets/popupwidgetbutton.py
@@ -67,7 +67,7 @@ class PopupWidgetButton(Gtk.ToggleButton):
 
     # INITIALIZERS #
     def __init__(self, widget, label='Pop-up', popup_pos=POS_NW_SW, main_window=None, sticky=False):
-        super(PopupWidgetButton, self).__init__(label=label)
+        super().__init__(label=label)
         if not sticky:
             self.connect('focus-out-event', self._on_focus_out_event)
         if main_window:

--- a/virtaal/views/widgets/selectdialog.py
+++ b/virtaal/views/widgets/selectdialog.py
@@ -40,7 +40,7 @@ class SelectDialog(GObjectWrapper):
 
     # INITIALIZERS #
     def __init__(self, items=None, title=None, message=None, parent=None, size=None):
-        super(SelectDialog, self).__init__()
+        super().__init__()
         self.sview = SelectView(items)
         self._create_gui(title, message, parent)
         self._connect_signals()

--- a/virtaal/views/widgets/selectview.py
+++ b/virtaal/views/widgets/selectview.py
@@ -224,7 +224,7 @@ class SelectView(Gtk.TreeView, GObjectWrapper):
                     self._create_widget_for_item(row)
                 ])
 
-        super(SelectView, self).set_model(self._model)
+        super().set_model(self._model)
 
 
     # EVENT HANDLERS #

--- a/virtaal/views/widgets/storecellrenderer.py
+++ b/virtaal/views/widgets/storecellrenderer.py
@@ -138,7 +138,7 @@ class StoreCellRenderer(Gtk.CellRenderer):
 
     # INITIALIZERS #
     def __init__(self, view):
-        super(StoreCellRenderer, self).__init__()
+        super().__init__()
         self.set_property('mode', Gtk.CellRendererMode.EDITABLE)
         self.view = view
         self.__unit = None

--- a/virtaal/views/widgets/storetreemodel.py
+++ b/virtaal/views/widgets/storetreemodel.py
@@ -40,7 +40,7 @@ class StoreTreeModel(GObject.GObject, Gtk.TreeModel):
     """
 
     def __init__(self, storemodel):
-        super(StoreTreeModel, self).__init__()
+        super().__init__()
         self._store = storemodel
         self._store_len = len(storemodel)
         self._current_editable = 0

--- a/virtaal/views/widgets/storetreeview.py
+++ b/virtaal/views/widgets/storetreeview.py
@@ -42,7 +42,7 @@ class StoreTreeView(Gtk.TreeView):
     # INITIALIZERS #
     def __init__(self, view):
         self.view = view
-        super(StoreTreeView, self).__init__()
+        super().__init__()
 
         self.set_headers_visible(False)
         # self.set_direction(Gtk.TextDirection.LTR)
@@ -124,7 +124,7 @@ class StoreTreeView(Gtk.TreeView):
             model = StoreTreeModel(storemodel)
         else:
             model = None
-        super(StoreTreeView, self).set_model(model)
+        super().set_model(model)
 
     def _keyboard_move(self, offset):
         if not self.view.controller.get_store():

--- a/virtaal/views/widgets/textbox.py
+++ b/virtaal/views/widgets/textbox.py
@@ -93,7 +93,7 @@ class TextBox(Gtk.TextView):
         @type  selector_textbox: C{TextBox}
         @param selector_textbox: The text box in which placeable selection
             (@see{select_elem}) should happen. Optional."""
-        super(TextBox, self).__init__()
+        super().__init__()
         self.buffer = self.get_buffer()
         self.elem = None
         self.main_controller = main_controller

--- a/virtaal/views/widgets/welcomescreen.py
+++ b/virtaal/views/widgets/welcomescreen.py
@@ -37,7 +37,7 @@ class WelcomeScreen(Gtk.ScrolledWindow):
         """Constructor.
             @type  gui: C{Gtk.Builder}
             @param gui: The GtkBuilder XML object to retrieve the welcome screen from."""
-        super(WelcomeScreen, self).__init__()
+        super().__init__()
 
         self.gui = gui
 


### PR DESCRIPTION
## Dev hygiene & small fixes (part 2c of 5)

Builds on the previous PR in this chain.

TM match-quality clamping (a real, reproducible `OverflowError` from an
out-of-range value hitting `GtkCellRendererProgress`'s C `gint`
property); treating a cancelled save as normal, not an error;
`super()` modernization; logging exceptions raised inside
`run_in_thread`'s background thread instead of losing them silently;
`optparse`→`argparse` in `bin/virtaal` and `openmailto.py`'s self-test;
and a leftover Python 2 print-statement fix in `devsupport/profiling.py`.

Depends on the previous PR in this chain.
