### PR TITLE
Python 3 + GTK3 port, part 2d: app-behaviour bugs found via manual QA

### DIFF
--- a/devsupport/testfiles/workflow.po
+++ b/devsupport/testfiles/workflow.po
@@ -1,0 +1,32 @@
+# A PO file with a deliberate mix of workflow states, for testing
+# Virtaal's Workflow navigation mode. One unit in each of the three
+# states plain gettext PO can represent (untranslated/fuzzy/translated) -
+# the other three WorkflowMode.StateEnum values need a richer format.
+# Copyright 2026 Zuza Software Foundation
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: translate-devel@lists.sourceforge.net\n"
+"POT-Creation-Date: 2026-08-25 00:00+0000\n"
+"PO-Revision-Date: 2026-08-25 00:00+0000\n"
+"Last-Translator: Virtaal test suite\n"
+"Language-Team: translate-dev@lists.sourceforge.net\n"
+"Language: en_GB\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. Untranslated state: empty target.
+msgid "This string has not been translated yet"
+msgstr ""
+
+#. Needs-work state: the fuzzy flag, usually set by msgmerge when a
+#. source string changes and the old translation may no longer match.
+#, fuzzy
+msgid "This string's translation may be out of date"
+msgstr "This string's translation may possibly be out of date"
+
+#. Translated state: has a target, not fuzzy - the normal "done" state.
+msgid "This string has been translated normally"
+msgstr "This string has been translated normally, in British English"

--- a/virtaal/controllers/storecontroller.py
+++ b/virtaal/controllers/storecontroller.py
@@ -142,6 +142,11 @@ class StoreController(BaseController):
     def is_modified(self):
         return self._modified
 
+    def set_modified(self, value):
+        """Set the modified flag, also updating set_saveable()."""
+        self._modified = value
+        self.main_controller.set_saveable(value)
+
     def _get_unitcontroller(self):
         return self._unit_controller
 
@@ -294,8 +299,10 @@ class StoreController(BaseController):
                         self.main_controller.open_file(filename)
                         self.cursor.pos = cursor_pos
                     self._proj_file_saved_id = self.connect('store-saved', post_save)
-        self._modified = False
-        self.main_controller.set_saveable(False)
+        self.set_modified(False)
+        # Unlike open_file()/close_file(), a save doesn't clear the undo
+        # stack, so it needs its own explicit clean-point mark.
+        self.main_controller.undo_controller.model.mark_clean()
         self.emit('store-saved')
 
     def binary_export(self, filename):
@@ -311,8 +318,7 @@ class StoreController(BaseController):
         del self.project
         self.project = None
         self.store = None
-        self._modified = False
-        self.main_controller.set_saveable(False)
+        self.set_modified(False)
         self.view.hide() # This MUST be called BEFORE `self.cursor = None`
         self.emit('store-closed') # This should be emitted BEFORE `self.cursor = None` to allow any other modules to disconnect from the cursor
         self.cursor = None

--- a/virtaal/controllers/storecontroller.py
+++ b/virtaal/controllers/storecontroller.py
@@ -562,5 +562,11 @@ class StoreController(BaseController):
         self.store.set_target_language(langcode)
 
     def _unit_modified(self, emitter, unit):
-        self._modified = True
-        self.main_controller.set_saveable(self._modified)
+        # Guard against a late "modified" signal from a just-closed or
+        # just-replaced file's teardown - both no file open at all, and
+        # a unit belonging to a store that's since been replaced.
+        if self.store is None:
+            return
+        if unit not in self.store.get_units():
+            return
+        self.set_modified(True)

--- a/virtaal/controllers/undocontroller.py
+++ b/virtaal/controllers/undocontroller.py
@@ -146,7 +146,13 @@ class UndoController(BaseController):
         def refresh():
             textbox.refresh_cursor_pos = undo_info['cursorpos']
             # TODO: try to avoid full refresh
+            # This runs via idle_add, after _enable_unit_signals() above
+            # has already re-enabled everything - textbox.refresh()'s
+            # set_text() would otherwise fire the "changed" signal and
+            # re-mark the document modified right after undo cleared it.
+            self._disable_unit_signals()
             textbox.refresh(update=True)
+            self._enable_unit_signals()
 
         GObject.idle_add(refresh)
 
@@ -177,6 +183,12 @@ class UndoController(BaseController):
                 self._perform_undo(ui)
         else:
             self._perform_undo(undo_info)
+
+        # Clear the modified flag once undo lands back at the position
+        # the file was last opened/saved (UndoModel.mark_clean()) -
+        # _modified is otherwise never touched by undo.
+        if self.model.is_at_clean_position():
+            self.main_controller.store_controller.set_modified(False)
 
     @if_enabled
     def _on_unit_delete_text(self, unit_controller, unit, deleted, parent, offset, cursor_pos, elem, target_num):

--- a/virtaal/controllers/undocontroller.py
+++ b/virtaal/controllers/undocontroller.py
@@ -143,7 +143,12 @@ class UndoController(BaseController):
         self._enable_unit_signals()
 
         textbox = self.unit_controller.view.targets[undo_info['targetn']]
+        # Guard against this deferred refresh() running after a
+        # different, reused unit is now loaded into the same textbox.
+        scheduled_unit = undo_info['unit']
         def refresh():
+            if self.unit_controller.current_unit is not scheduled_unit:
+                return
             textbox.refresh_cursor_pos = undo_info['cursorpos']
             # TODO: try to avoid full refresh
             # This runs via idle_add, after _enable_unit_signals() above

--- a/virtaal/models/undomodel.py
+++ b/virtaal/models/undomodel.py
@@ -33,6 +33,9 @@ class UndoModel(BaseModel):
         self.index = -1
         self.recording = False
         self.undo_stack = []
+        # Undo-stack position at the last "file is unmodified" point
+        # (open/save) - see mark_clean()/is_at_clean_position().
+        self.clean_index = -1
 
 
     # METHODS #
@@ -40,6 +43,19 @@ class UndoModel(BaseModel):
         """Clear the undo stack and reset the index pointer."""
         self.undo_stack = []
         self.index = -1
+        self.clean_index = -1
+
+    def mark_clean(self):
+        """Record the current undo-stack position as "the file is
+            unmodified" - call this right after a file is opened or
+            saved."""
+        self.clean_index = self.index
+
+    def is_at_clean_position(self):
+        """Whether the undo stack is currently at the position last marked
+            clean by mark_clean() - i.e. whatever's changed since then has
+            all been undone."""
+        return self.index == self.clean_index
 
     def pop(self, permanent=False):
         if not self.undo_stack or not (0 <= self.index < len(self.undo_stack)):

--- a/virtaal/modes/searchmode.py
+++ b/virtaal/modes/searchmode.py
@@ -199,7 +199,9 @@ class SearchMode(BaseMode):
 
     def update_search(self):
         self._search_timeout = 0
-        from translate.tools.pogrep import GrepFilter
+        # See virtaal.support.pogrep_compat for why this isn't imported
+        # straight from translate.tools.pogrep.
+        from virtaal.support.pogrep_compat import GrepFilter
         self.filter = GrepFilter(
             searchstring=get_unicode(self.ent_search.get_text(), 'utf-8'),
             searchparts=('source', 'target'),

--- a/virtaal/modes/searchmode.py
+++ b/virtaal/modes/searchmode.py
@@ -145,6 +145,8 @@ class SearchMode(BaseMode):
     def select_match(self, match):
         """Select the specified match in the GUI."""
         main_controller = self.controller.main_controller
+        logging.debug('select_match: unit=%r part=%s part_n=%d' % (
+            getattr(match.unit, 'source', match.unit), match.part, match.part_n))
         main_controller.select_unit(match.unit)
         view = main_controller.unit_controller.view
 
@@ -375,6 +377,8 @@ class SearchMode(BaseMode):
 
     def _move_match(self, offset):
         if self.controller.current_mode is not self:
+            logging.debug('_move_match: not the current mode (%s is current) - ignoring' % (
+                self.controller.current_mode.name if self.controller.current_mode else None))
             return
 
         if getattr(self, 'matchcursor', None) is None:
@@ -384,6 +388,7 @@ class SearchMode(BaseMode):
 
         old_match_index = self.matchcursor.index
         if not self.matches or old_match_index != self.matchcursor.index:
+            logging.debug('_move_match: no matches or stale matchcursor - re-searching instead of moving')
             self.update_search()
             return
 
@@ -406,6 +411,7 @@ class SearchMode(BaseMode):
 
     # EVENT HANDLERS #
     def _on_entry_activate(self, entry):
+        logging.debug('_on_entry_activate: Enter activated ent_search (text=%r)' % (entry.get_text()))
         self.update_search()
         self._move_match(0) # Select the current match.
 

--- a/virtaal/modes/searchmode.py
+++ b/virtaal/modes/searchmode.py
@@ -98,12 +98,16 @@ class SearchMode(BaseMode):
         Gtk.AccelMap.add_entry("<Virtaal>/Edit/Search: Next", Gdk.KEY_G, Gdk.ModifierType.CONTROL_MASK)
         Gtk.AccelMap.add_entry("<Virtaal>/Edit/Search: Previous", Gdk.KEY_G,
                                Gdk.ModifierType.CONTROL_MASK | Gdk.ModifierType.SHIFT_MASK)
+        # tmview.py has its own global Escape accelerator ("Hide TM") -
+        # both fire when relevant, deliberately (see _on_close_search()).
+        Gtk.AccelMap.add_entry("<Virtaal>/Edit/Search: Close", Gdk.KEY_Escape, 0)
 
         self.accel_group = Gtk.AccelGroup()
         self.accel_group.connect_by_path("<Virtaal>/Edit/Search", self._on_start_search)
         self.accel_group.connect_by_path("<Virtaal>/Edit/Search Ctrl+F", self._on_start_search)
         self.accel_group.connect_by_path("<Virtaal>/Edit/Search: Next", self._on_search_next)
         self.accel_group.connect_by_path("<Virtaal>/Edit/Search: Previous", self._on_search_prev)
+        self.accel_group.connect_by_path("<Virtaal>/Edit/Search: Close", self._on_close_search)
 
         self.controller.main_controller.view.add_accel_group(self.accel_group)
 
@@ -464,6 +468,16 @@ class SearchMode(BaseMode):
         if self.controller.main_controller.store_controller.store is None:
             return
         self.controller.select_mode(self)
+
+    def _on_close_search(self, *args):
+        """Escape leaves Search mode and returns to the default mode.
+            This accelerator is always registered (see _setup_key_bindings()),
+            not just while Search is the active mode, so guard on that here -
+            otherwise Escape would do this from *any* mode."""
+        if self.controller.current_mode is not self:
+            return False
+        self.controller.select_default_mode()
+        return True
 
     def _on_style_set(self, widget, prev_style=None):
         self.default_base = widget.get_style_context().get_background_color(Gtk.StateType.NORMAL)

--- a/virtaal/modes/workflowmode.py
+++ b/virtaal/modes/workflowmode.py
@@ -19,6 +19,7 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 from gi.repository import Gtk
+from gi.repository.GObject import idle_add
 
 from virtaal.views.widgets.popupmenubutton import PopupMenuButton, POS_NW_SW
 from .basemode import BaseMode
@@ -123,11 +124,18 @@ class WorkflowMode(BaseMode):
 
     # EVENT HANDLERS #
     def _on_state_menuitem_toggled(self, checkmenuitem):
+        # update_indices() rebuilds the treeview; deferred to idle_add
+        # so that doesn't happen while the popup's own grab is still
+        # held (a plausible segfault source - see the commit message).
         self.filter_states = []
         for menuitem in self.btn_popup.menu:
             if not isinstance(menuitem, Gtk.CheckMenuItem) or not menuitem.get_active():
                 continue
             if menuitem in self._menuitem_states:
                 self.filter_states.append(self._menuitem_states[menuitem])
-        self.update_indices()
+        idle_add(self._apply_filter_states)
         self._update_button_label()
+
+    def _apply_filter_states(self):
+        self.update_indices()
+        return False

--- a/virtaal/plugins/autocompletor.py
+++ b/virtaal/plugins/autocompletor.py
@@ -261,7 +261,10 @@ class Plugin(BasePlugin):
         def add_widgets():
             if hasattr(self, 'lastunit'):
                 if self.lastunit.hasplural():
-                    for target in self.lastunit.target:
+                    # target is a multistring (subclasses str) - iterate
+                    # target.strings, not target itself, or this yields
+                    # characters of the first plural form only.
+                    for target in self.lastunit.target.strings:
                         if target:
                             #logging.debug('Adding words: %s' % (self.autocomp.wordsep_re.split(str(target))))
                             self.autocomp.add_words(self.autocomp.wordsep_re.split(str(target)))

--- a/virtaal/plugins/migration.py
+++ b/virtaal/plugins/migration.py
@@ -60,6 +60,29 @@ class Plugin(BasePlugin):
         self._init_plugin()
 
     def _init_plugin(self):
+        # Source paths need to be set up before the evidence check below.
+        if sys.platform == "darwin":
+            self.poedit_dir = path.expanduser('~/Library/Preferences')
+        else:
+            self.poedit_dir = path.expanduser('~/.poedit')
+
+        # KDE moved app configs/data from ~/.kde/share/{config,apps}/ to
+        # the XDG base dirs with the KDE4->Frameworks 5 transition
+        # (~2014) - these are the current locations, not the ~/.kde/...
+        # ones this code originally targeted.
+        xdg_config_home = os.environ.get('XDG_CONFIG_HOME') or path.expanduser('~/.config')
+        xdg_data_home = os.environ.get('XDG_DATA_HOME') or path.expanduser('~/.local/share')
+        self.lokalize_rc = path.join(xdg_config_home, 'lokalizerc')
+        self.lokalize_tm_dir = path.join(xdg_data_home, 'lokalize')
+
+        # No evidence of anything to migrate - stay silent, and persist
+        # that with write() so it sticks across launches.
+        if not self._has_anything_to_migrate():
+            logging.debug('Migration: nothing found to import - staying silent')
+            pan_app.settings.plugin_state[self.internal_name] = "disabled"
+            pan_app.settings.write()
+            return
+
         message = _('Should Virtaal try to import settings and data from other applications?')
         must_migrate = self.main_controller.show_prompt(_('Import data from other applications?'), message)
         if not must_migrate:
@@ -69,20 +92,6 @@ class Plugin(BasePlugin):
             self.tmdb = tmdb.TMDB(self.config["tmdb"])
             # We actually need source, target, context, targetlanguage
             self.migrated = []
-
-            if sys.platform == "darwin":
-                self.poedit_dir = path.expanduser('~/Library/Preferences')
-            else:
-                self.poedit_dir = path.expanduser('~/.poedit')
-
-            # KDE moved app configs/data from ~/.kde/share/{config,apps}/ to
-            # the XDG base dirs with the KDE4->Frameworks 5 transition
-            # (~2014) - these are the current locations, not the ~/.kde/...
-            # ones this code originally targeted.
-            xdg_config_home = os.environ.get('XDG_CONFIG_HOME') or path.expanduser('~/.config')
-            xdg_data_home = os.environ.get('XDG_DATA_HOME') or path.expanduser('~/.local/share')
-            self.lokalize_rc = path.join(xdg_config_home, 'lokalizerc')
-            self.lokalize_tm_dir = path.join(xdg_data_home, 'lokalize')
 
             self.poedit_settings_import()
             self.lokalize_settings_import()
@@ -100,6 +109,40 @@ class Plugin(BasePlugin):
             logging.debug('Migration plugin executed')
 
         pan_app.settings.plugin_state[self.internal_name] = "disabled"
+        pan_app.settings.write()
+
+    def _has_anything_to_migrate(self):
+        """Cheap existence-only checks (no parsing) for whether *any*
+            supported source has real data to offer - the gate for
+            whether to prompt at all."""
+        if self._poedit_config_exists():
+            return True
+        if path.exists(self.lokalize_rc):
+            return True
+        if path.isdir(self.lokalize_tm_dir):
+            if any(name.endswith('.db') and not name.endswith('-journal.db')
+                   for name in os.listdir(self.lokalize_tm_dir)):
+                return True
+        return False
+
+    def _poedit_config_exists(self):
+        if sys.platform == 'darwin':
+            config_filename = path.join(self.poedit_dir, 'net.poedit.Poedit.cfg')
+        else:
+            config_filename = path.join(self.poedit_dir, 'config')
+        if path.exists(config_filename):
+            return True
+        if sys.platform != 'win32':
+            return False
+        try:
+            import winreg
+        except ImportError:
+            return False
+        try:
+            winreg.OpenKey(winreg.HKEY_CURRENT_USER, r"Software\Vaclav Slavik\Poedit")
+            return True
+        except OSError:
+            return False
 
     def poedit_settings_import(self):
         """Attempt to import the settings from Poedit."""
@@ -109,15 +152,17 @@ class Plugin(BasePlugin):
             config_filename = path.join(self.poedit_dir, 'config')
         get_thing = None
         if not path.exists(config_filename):
+            # winreg (no underscore) is the Python 3 name; the Python 2
+            # name was _winreg.
             try:
-                import _winreg
+                import winreg
             except Exception as e:
                 return
 
             def get_thing(section, item):
                 key = None
                 try:
-                    key = _winreg.OpenKey(_winreg.HKEY_CURRENT_USER, r"Software\Vaclav Slavik\Poedit\%s" % section)
+                    key = winreg.OpenKey(winreg.HKEY_CURRENT_USER, r"Software\Vaclav Slavik\Poedit\%s" % section)
                 except WindowsError:
                     return
 
@@ -125,7 +170,7 @@ class Plugin(BasePlugin):
                 try:
                     # This is very inefficient, but who cares?
                     for i in range(100):
-                        name, data, type = _winreg.EnumValue(key, i)
+                        name, data, type = winreg.EnumValue(key, i)
                         if name == item:
                             break
                 except EnvironmentError as e:

--- a/virtaal/plugins/terminology/models/autoterm.py
+++ b/virtaal/plugins/terminology/models/autoterm.py
@@ -178,11 +178,13 @@ class TerminologyModel(BaseTerminologyModel):
         return ext
 
     def _get_ext_from_store_guess(self, content):
-        from io import StringIO
-        from translate.storage.factory import _guessextention
-        s = StringIO(content)
+        # content is real bytes, not str - BytesIO, not StringIO.
+        # _guessextention was also renamed upstream to _guess_extension.
+        from io import BytesIO
+        from translate.storage.factory import _guess_extension
+        s = BytesIO(content)
         try:
-            return _guessextention(s)
+            return _guess_extension(s)
         except ValueError:
             pass
         return None
@@ -201,14 +203,16 @@ class TerminologyModel(BaseTerminologyModel):
                 localfile = self._get_curr_term_filename(ext=ext)
                 localfile = os.path.join(self.TERMDIR, localfile)
             logging.debug('Saving to %s' % (localfile))
-            open(localfile, 'w').write(result)
+            # result is real bytes - 'wb' preserves it exactly.
+            open(localfile, 'wb').write(result)
 
-            # Find ETag header and save the value
+            # Headers are bytes too; only the stored etag value itself
+            # is decoded to str (used later as a str header value).
             headers = request.result_headers.getvalue().splitlines()
             etag = ''
-            etagline = [l for l in headers if l.lower().startswith('etag:')]
+            etagline = [l for l in headers if l.lower().startswith(b'etag:')]
             if etagline:
-                etag = etagline[0][7:-1]
+                etag = etagline[0][7:-1].decode('ascii', errors='replace')
             self.config[os.path.abspath(localfile)] = etag
         else:
             logging.debug('Unhandled status code: %d' % (request.status))

--- a/virtaal/plugins/tm/models/currentfile.py
+++ b/virtaal/plugins/tm/models/currentfile.py
@@ -20,6 +20,8 @@
 
 from translate.search import match
 
+from virtaal.support.match_compat import matcher as _matcher
+
 from .basetmmodel import BaseTMModel
 
 
@@ -62,7 +64,7 @@ class TMModel(BaseTMModel):
                 'max_candidates': self.controller.max_matches,
                 'min_similarity': self.controller.min_quality
             }
-            self.matcher = match.matcher(store, **options)
+            self.matcher = _matcher(store, **options)
         else:
             self.matcher.extendtm(store.units)
         self.cache = {}

--- a/virtaal/support/match_compat.py
+++ b/virtaal/support/match_compat.py
@@ -1,0 +1,79 @@
+# Copyright 2026 Zuza Software Foundation
+#
+# This file is part of Virtaal.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+
+"""Compatibility shim around translate-toolkit's search.match.matcher.
+
+matcher.matches() keeps its top-N candidates in a min-heap of
+(similarity, candidate) tuples; on a similarity tie, heapq falls back
+to comparing the candidates themselves, and TranslationUnit defines no
+ordering - "TypeError: '<' not supported between instances of
+'TranslationUnit' and 'TranslationUnit'". Upstream bug; drop this shim
+once translate-toolkit fixes it.
+"""
+
+import heapq
+from itertools import count
+from operator import itemgetter
+
+from translate.search.match import matcher as _UpstreamMatcher
+from translate.search.match import sourcelen
+
+
+class matcher(_UpstreamMatcher):
+    """matcher with the heapq tie-breaking crash fixed."""
+
+    def matches(self, text):
+        # Identical to upstream, except the heap tuples carry an extra
+        # monotonic tiebreaker so heapq never compares candidates directly.
+        tiebreaker = count()
+        bestcandidates = [(0.0, next(tiebreaker), None)] * self.MAX_CANDIDATES
+        min_similarity = self.MIN_SIMILARITY
+
+        startlength = self.getstartlength(min_similarity, text)
+        startindex = 0
+        endindex = len(self.candidates.units)
+        while startindex < endindex:
+            mid = (startindex + endindex) // 2
+            if sourcelen(self.candidates.units[mid]) < startlength:
+                startindex = mid + 1
+            else:
+                endindex = mid
+
+        stoplength = self.getstoplength(min_similarity, text)
+        lowestscore = 0
+
+        for candidate in self.candidates.units[startindex:]:
+            cmpstring = candidate.source
+            if len(cmpstring) > stoplength:
+                break
+            similarity = self.comparer.similarity(text, cmpstring, min_similarity)
+            if similarity < min_similarity:
+                continue
+            if similarity > lowestscore:
+                heapq.heapreplace(bestcandidates, (similarity, next(tiebreaker), candidate))
+                lowestscore = bestcandidates[0][0]
+                if lowestscore >= 100:
+                    break
+                if min_similarity < lowestscore:
+                    min_similarity = lowestscore
+                    stoplength = self.getstoplength(min_similarity, text)
+
+        # Remove the empty ones, drop the tiebreaker (buildunits() below
+        # expects plain (score, candidate) pairs, same as upstream).
+        bestcandidates = [(item[0], item[2]) for item in bestcandidates if item[0] != 0]
+        bestcandidates.sort(key=itemgetter(0), reverse=True)
+        return self.buildunits(bestcandidates)

--- a/virtaal/support/pogrep_compat.py
+++ b/virtaal/support/pogrep_compat.py
@@ -1,0 +1,86 @@
+# Copyright 2026 Zuza Software Foundation
+#
+# This file is part of Virtaal.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+
+"""Compatibility shim around translate-toolkit's pogrep.GrepFilter.
+
+GrepFilter.getmatches() always ORs re.LOCALE into its flags, even
+though it only ever compiles str patterns - Python 3.14+ raises
+"ValueError: cannot use LOCALE flag with a str pattern" instead of
+silently accepting it, crashing every search/replace. Upstream bug;
+drop this shim once translate-toolkit fixes it.
+"""
+
+import re
+
+from translate.tools.pogrep import GrepFilter as _UpstreamGrepFilter
+
+
+class GrepFilter(_UpstreamGrepFilter):
+    """GrepFilter with the re.LOCALE/str-pattern crash fixed."""
+
+    def getmatches(self, units):
+        if not self.searchstring:
+            return [], []
+
+        searchstring = self.searchstring
+        # Same flags as upstream, minus re.LOCALE (invalid for str
+        # patterns - see module docstring above).
+        flags = re.MULTILINE | re.UNICODE
+
+        if self.ignorecase:
+            flags |= re.IGNORECASE
+        if not self.useregexp:
+            searchstring = re.escape(searchstring)
+        self.re_search = re.compile(f"({searchstring})", flags)
+
+        # Everything below here is unchanged from upstream's
+        # getmatches() - only the flags above differ.
+        from translate.tools.pogrep import find_matches
+
+        matches = []
+        indexes = []
+
+        for index, unit in enumerate(units):
+            old_length = len(matches)
+
+            if self.search_target:
+                targets = unit.target.strings if unit.hasplural() else [unit.target]
+                matches.extend(find_matches(unit, "target", targets, self.re_search))
+            if self.search_source:
+                sources = unit.source.strings if unit.hasplural() else [unit.source]
+                matches.extend(find_matches(unit, "source", sources, self.re_search))
+            if self.search_notes:
+                matches.extend(
+                    find_matches(unit, "notes", unit.getnotes(), self.re_search)
+                )
+
+            if self.search_locations:
+                matches.extend(
+                    find_matches(unit, "locations", unit.getlocations(), self.re_search)
+                )
+
+            # A search for a single letter or an all-inclusive regular
+            # expression could give enough results to cause performance
+            # problems. The answer is probably not very useful at this scale.
+            if self.max_matches and len(matches) > self.max_matches:
+                raise ValueError("Too many matches found")
+
+            if len(matches) > old_length:
+                old_length = len(matches)
+                indexes.append(index)
+
+        return matches, indexes

--- a/virtaal/views/unitview.py
+++ b/virtaal/views/unitview.py
@@ -139,7 +139,8 @@ class UnitView(Gtk.EventBox, GObjectWrapper, Gtk.CellEditable, BaseView):
             self.targets[self.focused_target_n].move_elem_selection(-1)
         def on_transfer(*args):
             focused = get_focused(self.targets)
-            self.copy_original(focused)
+            if focused is not None:
+                self.copy_original(focused)
         mnu_next.connect('activate', on_next)
         mnu_prev.connect('activate', on_prev)
         mnu_transfer.connect('activate', on_transfer)

--- a/virtaal/views/widgets/storetreeview.py
+++ b/virtaal/views/widgets/storetreeview.py
@@ -60,6 +60,10 @@ class StoreTreeView(Gtk.TreeView):
         # to you.
         self._waiting_for_row_change = 0
 
+        # GObject.timeout_add() id for the pending debounced
+        # on_configure_event() action, or None.
+        self._configure_timeout_id = None
+
     def _enable_tooltips(self):
         if hasattr(self, "set_tooltip_column"):
             self.set_tooltip_column(COLUMN_NOTE)
@@ -69,7 +73,13 @@ class StoreTreeView(Gtk.TreeView):
         self.connect('key-press-event', self._on_key_press)
         self.connect("cursor-changed", self._on_cursor_changed)
         self.connect("button-press-event", self._on_button_press)
-        self.connect('focus-in-event', self.on_configure_event)
+        self.connect('focus-in-event', self._on_focus_in)
+        # Keeps the FIXED-sizing column's width tied to this treeview's
+        # own real allocation - see _make_column() for why this exists.
+        self.connect('size-allocate', self._on_size_allocate)
+        # Cancel the pending debounce timer on teardown - it would
+        # otherwise fire after this widget is destroyed.
+        self.connect('destroy', self._on_destroy)
 
         # The following connections are necessary, because Gtk+ apparently *only* uses accelerators
         # to add pretty key-bindings next to menu items and does not really care if an accelerator
@@ -88,8 +98,23 @@ class StoreTreeView(Gtk.TreeView):
 
     def _make_column(self, renderer):
         column = Gtk.TreeViewColumn(None, renderer, unit=COLUMN_UNIT, editable=COLUMN_EDITABLE)
-        column.set_expand(True)
+        # FIXED sizing avoids set_expand(True)'s natural-size
+        # renegotiation, which could grow the column unboundedly on
+        # some GTK3 builds - see _on_size_allocate() for the real width.
+        column.set_sizing(Gtk.TreeViewColumnSizing.FIXED)
+        column.set_fixed_width(1)  # corrected on the first real size-allocate
         return column
+
+    def _on_size_allocate(self, _widget, allocation):
+        # A couple of pixels of margin avoids fighting a vertical
+        # scrollbar for the same space; guarded on an actual change so
+        # this doesn't itself trigger another reallocation.
+        column = self.get_columns()[0] if self.get_columns() else None
+        if not column:
+            return
+        new_width = max(1, allocation.width - 2)
+        if column.get_fixed_width() != new_width:
+            column.set_fixed_width(new_width)
 
 
     # METHODS #
@@ -111,6 +136,10 @@ class StoreTreeView(Gtk.TreeView):
             #      still have no idea why exactly it is needed. This just seems
             #      to be the correct GTK black magic incantation to make it
             #      "work".
+            #
+            # No Gtk.main_iteration() flush here - it re-entered
+            # UnitView.load_unit()'s signal-blocking window and
+            # spuriously marked a just-opened file modified.
             self.set_cursor(newpath, self.get_columns()[0], start_editing=True)
             self.get_model().set_editable(newpath)
             def change_cursor():
@@ -189,17 +218,46 @@ class StoreTreeView(Gtk.TreeView):
             return self._keyboard_move(1)
         return True
 
-    def on_configure_event(self, widget, _event, *_user_args):
-        path, column = self.get_cursor()
-
-        self.columns_autosize()
-        if path != None:
-            def do_setcursor():
-                self.set_cursor(path, column, start_editing=True)
-
-            GObject.idle_add(do_setcursor)
-
+    def on_configure_event(self, widget, event, *_user_args):
+        # Debounced - restoring cursor state on every raw configure-event
+        # tick during a live resize drag is wasteful. The growth bug
+        # itself is fixed at the source (_make_column()); this is just
+        # settle-then-restore-cursor housekeeping.
+        logging.debug("storetreeview: configure-event %dx%d", event.width, event.height)
+        if self._configure_timeout_id is not None:
+            GObject.source_remove(self._configure_timeout_id)
+        self._configure_timeout_id = GObject.timeout_add(200, self._on_configure_settled)
         return False
+
+    def _on_configure_settled(self):
+        self._configure_timeout_id = None
+        logging.debug("storetreeview: debounce settled, window=%s", self._window_size())
+        self._restore_cursor()
+        return False  # one-shot: don't repeat this GObject.timeout_add
+
+    def _on_destroy(self, _widget):
+        if self._configure_timeout_id is not None:
+            GObject.source_remove(self._configure_timeout_id)
+            self._configure_timeout_id = None
+
+    def _on_focus_in(self, widget, _event, *_user_args):
+        # Restore cursor/editing state on refocus, same as
+        # on_configure_event()'s settle handler.
+        self._restore_cursor()
+        return False
+
+    def _window_size(self):
+        window = self.get_toplevel()
+        if window and isinstance(window, Gtk.Window) and window.get_realized():
+            return window.get_size()
+        return None
+
+    def _restore_cursor(self):
+        # Safety-net check only, no corrective action: a reactive
+        # resize() here is what caused the original growth bug.
+        size = self._window_size()
+        if size and size[0] > 1024:
+            logging.warning("storetreeview: window width %d after a resize/focus settle - investigate if seen again", size[0])
 
     def _on_cursor_changed(self, _treeview):
         path, _column = self.get_cursor()

--- a/virtaal/views/widgets/storetreeview.py
+++ b/virtaal/views/widgets/storetreeview.py
@@ -61,7 +61,7 @@ class StoreTreeView(Gtk.TreeView):
         self._waiting_for_row_change = 0
 
         # GObject.timeout_add() id for the pending debounced
-        # on_configure_event() action, or None.
+        # on_configure_event() action - see that method for why.
         self._configure_timeout_id = None
 
     def _enable_tooltips(self):
@@ -142,9 +142,14 @@ class StoreTreeView(Gtk.TreeView):
             # spuriously marked a just-opened file modified.
             self.set_cursor(newpath, self.get_columns()[0], start_editing=True)
             self.get_model().set_editable(newpath)
+            # Guard against change_cursor() below (deferred via idle_add)
+            # running after a different file's model is now current.
+            scheduled_model = model
             def change_cursor():
-                self.set_cursor(newpath, self.get_columns()[0], start_editing=True)
                 self._waiting_for_row_change -= 1
+                if self.get_model() is not scheduled_model:
+                    return
+                self.set_cursor(newpath, self.get_columns()[0], start_editing=True)
             self._waiting_for_row_change += 1
             GObject.idle_add(change_cursor, priority=GObject.PRIORITY_DEFAULT_IDLE)
 


### PR DESCRIPTION
## App-behaviour bugs found via manual QA (part 2d of 5)

Builds on the previous PR in this chain. This is the bulk of the real
bug-hunting work - every fix here was found by actually running the
app, not by inspection.

A real GTK3 `TreeViewColumn` autosize growth loop; the undo/modified-
marker bug family (undo not clearing the modified flag, three related
deferred/late-signal spurious-modified guards); Search mode fixes
(Escape now exits Search, a crash on every search/filter under Python
3.14, the `_search_timeout` tracking race across its debounced and
direct callers); a real crash on Alt+Down with no focused target
textbox; the migration plugin prompting on every launch instead of
gating on real evidence; an `autocompletor` bug iterating a plural
unit's characters instead of its forms; three compounding bytes/str
bugs breaking every real `autoterm` download; a `workflowmode` fix
deferring a treeview refilter out of a menu-toggle handler (chasing a
still-unconfirmed native segfault); and a `heapq`/`TranslationUnit`
crash in the "Current File" TM plugin.

### Known gap, not fixed here

A native segfault reachable from `PopupMenuButton`-based selectors -
`EXC_BAD_ACCESS` inside GTK's own `gtk_grab_notify` widget-tree walk.
The `workflowmode` fix above addresses one contributing factor as a
reasoned, low-risk change, but it isn't confirmed as the actual root
cause - not reliably reproducible via this branch's own macOS
automation. Flagging loudly rather than claiming it's closed.

Depends on the previous PR in this chain.
