### PR TITLE
po/es.po quote fix + docs/building.rst stale dependency cleanup

### DIFF
--- a/docs/building.rst
+++ b/docs/building.rst
@@ -88,7 +88,7 @@ For users running from a tarball, we do some dependency checking when starting
 Virtaal to be able to give accurate error messages in case of missing
 dependencies. However, if you have all of these sorted out in your package
 dependencies, there is no need for Virtaal to do this any more. In the file
-`bin/virtaal`, uncomment the line 
+`bin/virtaal`, uncomment the line
 
 .. code-block:: python
 
@@ -111,7 +111,7 @@ Windows
    or just ensure that the Translate Toolkit is in your :envvar:`PYTHONPATH`.
 
 If you would like to build a stand-alone Windows installer, you will also need
-to get: 
+to get:
 
 - `Py2exe <http://py2exe.org>`_
 - `InnoSetup <http://www.jrsoftware.org/isinfo.php>`_
@@ -146,6 +146,6 @@ Older
 -----
 Older attempt, no success yet using this way:
 
-Install the Gtk+ Mac OSX framework: https://www.gtk.org/download/macos.php 
+Install the Gtk+ Mac OSX framework: https://www.gtk.org/download/macos.php
 Install pygtk and pygobject from the GNOME FTP mirrors: ftp://ftp.gnome.org./pub/GNOME/sources/
 (extract, still need to get pygobject installed)

--- a/docs/building.rst
+++ b/docs/building.rst
@@ -16,20 +16,22 @@ To get the source code direction from Git use this command::
 Required Packages
 =================
 
-- `GTK+ <http://www.gtk.org/download/index.php>`_ runtime (for Windows download
-  the `latest bundle <http://www.gtk.org/download/win32.php>`_)
-- `PyGTK <http://pygtk.org/downloads.html>`_
-- `lxml <https://pypi.python.org/pypi/lxml/>`_
-- libglade and its python bindings (might be called something like
-  pygtk2.0-libglade on your Linux distribution)
-- Translate-toolkit (if a current enough version is packaged, it might be
-  called python-translate on your Linux distribution)
-- simplejson (might be called something like python-simplejson on your Linux
-  distribution)
-- PyCurl (might be called something like python-curl or python-pycurl on your
-  Linux distribution)
-- sqlite3 (only required if using Python 2.4)
-- wsgiref (only required if using Python 2.4)
+- GTK3 and PyGObject (``python3-gi``/``gir1.2-gtk-3.0`` or similar on
+  Linux, Homebrew's ``pygobject3``/``gtk+3`` on macOS, `gvsbuild
+  <https://github.com/wingtk/gvsbuild>`_ on Windows) - a system
+  prerequisite, not something ``pip install`` provisions on its own;
+  see ``.github/workflows/ci.yml`` for exactly what each platform's CI
+  job installs
+- `Translate Toolkit <https://pypi.org/project/translate-toolkit/>`_
+- `lxml <https://pypi.org/project/lxml/>`_
+- `PyCurl <https://pypi.org/project/pycurl/>`_
+- `diff_match_patch <https://pypi.org/project/diff-match-patch/>`_
+- `python-Levenshtein <https://pypi.org/project/python-Levenshtein/>`_
+- `cheroot <https://pypi.org/project/cheroot/>`_
+
+The Python packages above are all declared in ``pyproject.toml`` and
+installed automatically by ``pip install .`` - only GTK3/PyGObject
+needs installing separately first.
 
 .. _building#optional_packages:
 

--- a/po/es.po
+++ b/po/es.po
@@ -2284,7 +2284,7 @@ msgstr "Archivo Gettext MO"
 
 #: ../devsupport/tmp_strings.py:25
 msgid "Qt .qm file"
-msgstr "Archivo .qm de Qt"
+msgstr "Archivo «.qm» de Qt"
 
 #: ../devsupport/tmp_strings.py:26
 msgid "OmegaT Glossary"


### PR DESCRIPTION
Two small, unrelated fixes found while reviewing #3322 and closing out follow-up work after PR-2.

- `po/es.po`: restores `« »` for the `.qm` file description, matching the other 18 uses of this convention already in the same file - one genuinely useful line out of #3322's 15 differences (the rest were capitalization/verb-form style preferences on already-translated strings, not merged).
- `docs/building.rst`: the "Required Packages" section was still describing PyGTK/GTK2 and `libglade` - long since replaced by GtkBuilder (`share/virtaal/virtaal.ui` is a GtkBuilder file, not a Glade one) - plus `simplejson` and Python-2.4-only entries. Replaced with the real current dependency list from `pyproject.toml`.

`building.rst` has more staleness beyond this (Optional Packages, the Unix/Windows build-command sections) - left for a dedicated pass once the Windows/macOS build PRs land, since the real replacement instructions belong there anyway.
