### PR TITLE
Fix docs/_themes submodule URL (git:// breaks CI checkout)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "docs/_themes"]
 	path = docs/_themes
-	url = git://github.com/translate/sphinx-themes.git
+	url = https://github.com/translate/sphinx-themes.git


### PR DESCRIPTION
`git://` is unreachable from GitHub-hosted Actions runners (times out, ~2.5 min per attempt, retried once). That's breaking `docs-and-translations` and every `test (3.x)` matrix job on checkout - currently failing on `main` itself (e.g. https://github.com/translate/virtaal/actions/runs/33682198924), not just PR branches.

Switches the submodule URL to `https://github.com/translate/sphinx-themes.git`, which clones fine. Verified locally with `git submodule sync && git submodule update --init`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)