### PR TITLE
Fix TypeError resolving hyphenated language codes (en-GB, etc.)

### DIFF
--- a/virtaal/models/langmodel.py
+++ b/virtaal/models/langmodel.py
@@ -89,7 +89,7 @@ class LanguageModel(BaseModel):
         self.plural = self.languages[langcode][2]
 
     def _match_normalized_langcode(self, langcode):
-        languages_keys = self.languages.keys()
+        languages_keys = list(self.languages.keys())
         normalized_keys = [data.normalize_code(lang) for lang in languages_keys]
         i =  normalized_keys.index(data.normalize_code(langcode))
         return languages_keys[i]

--- a/virtaal/test/test_langmodel.py
+++ b/virtaal/test/test_langmodel.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2026 Zuza Software Foundation
+#
+# This file is part of Virtaal.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+
+from virtaal.models.langmodel import LanguageModel
+
+
+def test_hyphenated_langcode():
+    """A code not stored exactly as given (e.g. XLIFF's hyphenated
+    "en-GB" vs. the underlying language table's "en_GB") should resolve
+    via _match_normalized_langcode(), not raise."""
+    model = LanguageModel("en-GB")
+    assert model.code == "en_GB"
+    assert model.nplurals == 2
+
+
+def test_underscored_langcode():
+    model = LanguageModel("en_GB")
+    assert model.code == "en_GB"
+
+
+def test_unknown_langcode_falls_back():
+    model = LanguageModel("not-a-real-language")
+    assert model.nplurals == 0


### PR DESCRIPTION
`LanguageModel._match_normalized_langcode()` indexed `dict.keys()`
directly, which is a view object in Python 3, not subscriptable. Any
language code not already an exact key in the language table -
XLIFF's own hyphenated form (`en-GB`) is a real example, unlike the
underscored `en_GB` Gettext PO's own header uses - hit this on every
attempt to open such a file, surfacing as an unhandled exception
logged from the `store-loaded` signal handler (non-fatal, but the
language pair silently fails to resolve).

Found while building XLIFF test fixtures (`en-GB` is XLIFF's own
`target-language` convention) - none of the existing `.po` fixtures
exercise this path since they use the underscored form throughout.

One-line fix (`languages_keys = list(self.languages.keys())`), plus a
regression test covering the hyphenated, underscored, and
unknown-code paths. Full suite still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)