### PR TITLE
Add fluent.syntax dependency - Fluent (.ftl) support was silently broken

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,12 @@ classifiers = [
 # same reason most GTK Python projects don't declare it either.
 dependencies = [
     "translate-toolkit",
+    # translate-toolkit gates Fluent (.ftl) support behind its own
+    # "fluent" extra rather than a plain dependency - without this,
+    # translate.storage.factory still lists "Fluent file" in the
+    # supported-formats list (and Virtaal's Open dialog offers it),
+    # but actually opening one raises ModuleNotFoundError.
+    "fluent.syntax>=0.19,<0.20",
     "pycurl",
     "diff_match_patch",
     "lxml",


### PR DESCRIPTION
translate-toolkit gates Fluent support behind its own `"fluent"`
extra (`fluent.syntax>=0.19.0,<0.20`) rather than a plain dependency.
Virtaal never requested it, but `factory.supported_files()` - and so
the Open dialog's format list - still advertises "Fluent file"
regardless. Selecting an actual `.ftl` file raised an unhandled
`ModuleNotFoundError`, not a clean error message.

Found while building a `.ftl` test fixture (#3356).

Added `"fluent.syntax>=0.19,<0.20"` (matching translate-toolkit's own
declared constraint, verified against the real current PyPI release,
0.19.0) as a plain dependency in `pyproject.toml` - every existing
install path (`pip install --no-build-isolation .[test]` in CI, a
normal `pip install .`) picks it up automatically, no CI changes
needed. Verified directly: before the fix, opening a `.ftl` file
raised `ModuleNotFoundError`; after, it opens and parses correctly.
Full pytest suite still green.

Note: this only fixes *opening* a Fluent file at all. Fluent is a
monolingual format (no source/target pairing within one file), which
is a separate, unaddressed gap not touched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)