### PR TITLE
ci: add a core-checks gate job for branch-protection status checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -493,3 +493,16 @@ jobs:
           name: Virtaal-windows-installer
           path: dist\installer\*.exe
           if-no-files-found: error
+
+  core-checks:
+    name: core checks
+    needs: [pre-commit, docs-and-translations, test]
+    if: always()
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Fail if any required job failed
+        run: |
+          if [ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" = "true" ]; then
+            echo "::error::One or more required jobs did not succeed."
+            exit 1
+          fi


### PR DESCRIPTION
Adds `core-checks`, a single aggregate job (`needs: [pre-commit,
docs-and-translations, test]`) that fails if any of those didn't
succeed. Gives branch-protection rulesets one fixed check name to
require, instead of a job whose name changes per matrix leg
(`test (3.10)`, `test (3.11)`, ...).

`test-windows`/`test-macos` are deliberately not included - both hit
a known intermittent native GTK segfault (widget-hierarchy teardown
racing Python's garbage collector), so a merge gate shouldn't block
on an already-tracked flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)