### PR TITLE
localtm: dispatch tmserver via --run-module in a frozen build

### DIFF
--- a/virtaal/plugins/tm/models/localtm.py
+++ b/virtaal/plugins/tm/models/localtm.py
@@ -61,8 +61,18 @@ class TMModel(remotetm.TMModel):
         # "-m virtaal.support.tmserver" under our own interpreter needs
         # nothing installed or on PATH, and works the same on Windows and
         # POSIX, so there's no more need for a separate .exe case.
-        command = [
-            sys.executable, "-m", "virtaal.support.tmserver",
+        #
+        # A frozen build (PyInstaller) has no separate "python" to hand
+        # "-m" to - sys.executable there *is* the bundled app's own
+        # compiled launcher, which doesn't understand "-m" at all. bin/
+        # virtaal handles a "--run-module <name>" sentinel for exactly this
+        # case (dispatches via runpy, same as -m would), gated the same
+        # way this branches.
+        if getattr(sys, "frozen", False):
+            command = [sys.executable, "--run-module", "virtaal.support.tmserver"]
+        else:
+            command = [sys.executable, "-m", "virtaal.support.tmserver"]
+        command += [
             "-b", self.config["tmserver_bind"],
             "-p", str(port),
             "-d", self.config["tmdb"],
@@ -76,17 +86,20 @@ class TMModel(remotetm.TMModel):
         logging.debug("launching tmserver with command {}".format(" ".join(command)))
         try:
             import subprocess
-            import virtaal
             from virtaal.support import tmclient
 
-            # Make sure the subprocess can "import virtaal.support.tmserver"
-            # regardless of how *this* process ended up able to (an explicit
-            # PYTHONPATH from a source checkout, an editable install, ...) -
-            # harmless to add even if it's already on sys.path some other way.
-            virtaal_parent = os.path.dirname(os.path.dirname(os.path.abspath(virtaal.__file__)))
             env = os.environ.copy()
-            existing_path = env.get("PYTHONPATH", "")
-            env["PYTHONPATH"] = os.pathsep.join(filter(None, [virtaal_parent, existing_path]))
+            if not getattr(sys, "frozen", False):
+                # Make sure the subprocess can "import virtaal.support.tmserver"
+                # regardless of how *this* process ended up able to (an
+                # explicit PYTHONPATH from a source checkout, an editable
+                # install, ...) - harmless to add even if it's already on
+                # sys.path some other way. Not needed (or meaningful) when
+                # frozen - everything's already bundled together.
+                import virtaal
+                virtaal_parent = os.path.dirname(os.path.dirname(os.path.abspath(virtaal.__file__)))
+                existing_path = env.get("PYTHONPATH", "")
+                env["PYTHONPATH"] = os.pathsep.join(filter(None, [virtaal_parent, existing_path]))
 
             self.tmserver = subprocess.Popen(command, env=env)
             url = "http://%s:%d/tmserver" % (self.config["tmserver_bind"], port)


### PR DESCRIPTION
`sys.executable -m virtaal.support.tmserver` only works when
`sys.executable` is a real Python interpreter. A frozen build's
`sys.executable` is the bundled app's own compiled launcher - it
doesn't understand `-m` at all, so the local TM server subprocess
silently fails to start in every frozen build: the Windows installer
(already merged, #3353) and the macOS `.app` (#3354, in review).

`bin/virtaal` already handles a `--run-module <name>` sentinel for
exactly this (dispatches via `runpy`, same effect as `-m`) - this
switches `localtm.py` to use it when `sys.frozen`. The `PYTHONPATH`-
injection block right after is also skipped when frozen: it exists to
make the subprocess's own `import virtaal.support.tmserver` resolve
regardless of how this process itself became able to, which doesn't
apply once everything's already bundled together.

Found while checking whether an unrelated already-merged commit had
been correctly ported forward - it hadn't; this half of it was still
missing.

Verified both paths: the frozen-style dispatch directly (`bin/virtaal
--run-module virtaal.support.tmserver --help`) and the existing
non-frozen path unchanged via a real launch (`checks.po` opens
cleanly, no new warnings). Full test suite still 26/26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)