### PR TITLE
ci: trigger on merge_group so the merge queue's checks actually run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  merge_group:
   workflow_dispatch:
     inputs:
       debug_windows:


### PR DESCRIPTION
The "Merge to main" ruleset's `merge_queue` rule creates a temporary
`gh-readonly-queue/main/...` ref and waits for `core checks` to report
against it before merging - but this workflow had no `merge_group`
trigger, so nothing ever ran there. #3363 is currently stuck in the
queue because of exactly this: its queue entry has no way to ever go
green.

This one needs merging directly (not through the queue itself) to
break the chicken-and-egg - the queue can't work until this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)