### PR TITLE
ci: exclude the Linux test matrix from core-checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -688,7 +688,7 @@ jobs:
 
   core-checks:
     name: core checks
-    needs: [pre-commit, docs-and-translations, test]
+    needs: [pre-commit, docs-and-translations]
     if: always()
     runs-on: ubuntu-24.04
     steps:


### PR DESCRIPTION
Same known intermittent native GTK segfault class (widget-hierarchy
teardown racing Python's garbage collector) that already excluded
`test-windows`/`test-macos` from this gate - the Linux matrix carries
the same ~20-30% flake rate.

Didn't matter much for a plain PR (red just meant a manual rerun), but
the merge queue auto-dequeues an entry the moment a required check
fails - meaning routine re-enqueuing on every flake hit. Confirmed
directly: #3363 just got kicked from the queue this way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)