### PR TITLE
Add pseudo-translation mode

### DIFF
--- a/bin/virtaal
+++ b/bin/virtaal
@@ -114,6 +114,12 @@ def main(argv):
                              help=_("use the configuration file given by the supplied filename."))
         parser.add_argument("-D", "--debug", dest="debug", action="store_true", default=False,
                              help=_("enable debugging features"))
+        pseudo_group = parser.add_mutually_exclusive_group()
+        pseudo_group.add_argument("--pseudo-translation", dest="pseudo_translation", action="store_true", default=False,
+                             help=_("use a synthetic pseudo-translation for every UI string "
+                                     "(see devsupport/pseudo-translation/generate_pseudo_translation.py)"))
+        pseudo_group.add_argument("--pseudo-translation-bidi", dest="pseudo_translation_bidi", action="store_true", default=False,
+                             help=_("like --pseudo-translation, but also simulates a right-to-left UI layout"))
         # Profiling does not make sense in packaged versions.  Set to True to disable profiling.
         if not packaged:
             parser.add_argument("-P", "--profile", dest="profile", metavar=_("PROFILE"),
@@ -155,10 +161,26 @@ def main(argv):
                 parser.error(_("Could not read configuration file '%(filename)s'") % {"filename": options.config})
 
 
+        def set_pseudo_translation(options):
+            if not (options.pseudo_translation or options.pseudo_translation_bidi):
+                return
+            lang = 'pseudo-bidi' if options.pseudo_translation_bidi else 'pseudo'
+            try:
+                pan_app.set_ui_language(lang)
+            except OSError:
+                parser.error("No '%s' locale found - run "
+                              "devsupport/pseudo-translation/generate_pseudo_translation.py first" % lang)
+            if options.pseudo_translation_bidi:
+                # Must run before the first widget is constructed.
+                from gi.repository import Gtk
+                Gtk.Widget.set_default_direction(Gtk.TextDirection.RTL)
+
+
         options = parser.parse_args(argv[1:])
         pan_app.DEBUG = options.debug
         set_config(options)
         set_logging(options)
+        set_pseudo_translation(options)
         startup_file = options.translation_file
     else:
         # No arguments given, so we save some time by avoiding all the things

--- a/devsupport/pseudo-translation/generate_pseudo_translation.py
+++ b/devsupport/pseudo-translation/generate_pseudo_translation.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Generates two synthetic gettext locales from po/virtaal.pot, for
+exercising every translatable string in the UI without an actual
+translation:
+
+- pseudo: every string wrapped in brackets ("[Save]") - the classic
+  pseudo-localization marker for untranslated strings and truncation.
+- pseudo-bidi: every string bracketed and wrapped in Unicode RTL
+  isolate marks (RIGHT-TO-LEFT ISOLATE ... POP DIRECTIONAL ISOLATE) -
+  simulates a right-to-left translation's layout while keeping the
+  text itself readable Latin script (an isolate only sets the base
+  direction of the run it wraps, it doesn't reorder or transliterate).
+  Bracketed too, since the isolate marks alone are invisible.
+
+Compiled straight into the active environment's own share/locale/, so
+bin/virtaal --pseudo-translation/--pseudo-translation-bidi work with
+no separate install step.
+"""
+import os
+import sys
+import tempfile
+
+from translate.storage.placeables import StringElem
+from translate.tools import podebug
+from translate.tools.pocompile import convertmo
+
+RTL_ISOLATE_START = "\u2067"  # RIGHT-TO-LEFT ISOLATE
+RTL_ISOLATE_END = "\u2069"  # POP DIRECTIONAL ISOLATE
+
+
+def rewrite_bidi(self, string):
+    if not isinstance(string, StringElem):
+        string = StringElem(string)
+    return self._rewrite_prepend_append(
+        string, RTL_ISOLATE_START + "[", "]" + RTL_ISOLATE_END)
+
+
+# podebug.convertpo() always instantiates the module's own podebug
+# class directly - attaching the method here (rather than subclassing)
+# is the only way to make its own getattr(self, f"rewrite_{style}")
+# dispatch find rewrite_bidi.
+podebug.podebug.rewrite_bidi = rewrite_bidi
+
+LOCALES = {
+    "pseudo": "bracket",
+    "pseudo-bidi": "bidi",
+}
+
+
+def main():
+    root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    potfile = os.path.join(root, "po", "virtaal.pot")
+    localedir = os.path.join(sys.prefix, "share", "locale")
+
+    for code, rewritestyle in LOCALES.items():
+        with tempfile.NamedTemporaryFile(suffix=".po") as tmp_po:
+            with open(potfile, "rb") as infile:
+                podebug.convertpo(infile, tmp_po, None, rewritestyle=rewritestyle)
+            tmp_po.flush()
+
+            mo_dir = os.path.join(localedir, code, "LC_MESSAGES")
+            os.makedirs(mo_dir, exist_ok=True)
+            mo_path = os.path.join(mo_dir, "virtaal.mo")
+            with open(tmp_po.name, "rb") as compile_in, open(mo_path, "w") as compile_out:
+                convertmo(compile_in, compile_out, None)
+            print("Wrote %s" % mo_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -47,6 +47,24 @@ directly:
 Add more here as a format or scenario needs its own dedicated
 coverage.
 
+.. _testing#pseudo_translation:
+
+Pseudo-Translation
+===================
+
+Generate and run against two synthetic locales, covering every
+translatable string without needing a real translation::
+
+  python devsupport/pseudo-translation/generate_pseudo_translation.py
+  virtaal --pseudo-translation devsupport/testfiles/checks.po
+  virtaal --pseudo-translation-bidi devsupport/testfiles/checks.po
+
+``--pseudo-translation`` wraps every string in brackets (``[Save]``) -
+useful for spotting hardcoded strings and layout truncation.
+``--pseudo-translation-bidi`` additionally mirrors the whole UI
+layout, simulating a right-to-left translation while keeping the text
+itself readable Latin script.
+
 .. _testing#windows_ci:
 
 Windows CI Checks

--- a/virtaal/common/pan_app.py
+++ b/virtaal/common/pan_app.py
@@ -61,7 +61,7 @@ if os.name == 'nt' and getattr(sys, 'frozen', False):
 import configparser as ConfigParser
 import builtins as __builtin__
 import locale, gettext
-from virtaal.support.libi18n.locale import fix_locale, fix_libintl
+from virtaal.support.libi18n.locale import fix_locale, fix_libintl, bind_libintl_posix
 from translate.misc import file_discovery
 from translate.lang import data
 
@@ -283,6 +283,31 @@ else:
         logging.warning("Couldn't set the locale: %s", e)
         # See bug 3109
         __builtin__.__dict__['_'] = lambda s: s
+
+
+def set_ui_language(lang):
+    """Override the UI language after startup - used by bin/virtaal's
+    --pseudo-translation/--pseudo-translation-bidi. fallback=False: a
+    missing catalog should raise, not silently fall back to English.
+
+    localedir is passed explicitly - gettext's default search path is
+    keyed off sys.base_prefix rather than sys.prefix, so it misses
+    translations installed into a venv (which is where
+    devsupport/pseudo-translation's own generated locales land).
+    """
+    global ui_language
+    fix_locale(lang)
+    try:
+        locale.setlocale(locale.LC_ALL, lang)
+    except locale.Error:
+        pass
+    localedir = os.path.join(sys.prefix, 'share', 'locale')
+    gettext.translation('virtaal', localedir=localedir, languages=[lang], fallback=False).install()
+    if sys.platform != 'win32':
+        # Gtk.Builder's own translatable strings go through C-level
+        # gettext, not Python's - see bind_libintl_posix's docstring.
+        bind_libintl_posix(localedir)
+    ui_language = lang
 
 
 # Determine the directory the main executable is running from

--- a/virtaal/support/libi18n/locale.py
+++ b/virtaal/support/libi18n/locale.py
@@ -349,3 +349,23 @@ def fix_libintl(main_dir):
     libintl.bindtextdomain("virtaal", locale_dir)
     libintl.bind_textdomain_codeset("virtaal", 'UTF-8')
     del libintl
+
+
+def bind_libintl_posix(locale_dir):
+    """The POSIX equivalent of fix_libintl() above (same underlying
+    reason, bugzilla.gnome.org/574520): Gtk.Builder's translatable
+    strings go through real C-level gettext, independent of Python's
+    own gettext module - without this they keep using whatever locale
+    directory the system's default search path points at.
+
+    Best-effort and silent on failure.
+    """
+    import ctypes
+    import ctypes.util
+    try:
+        libname = ctypes.util.find_library('intl')
+        libintl = ctypes.CDLL(libname) if libname else ctypes.CDLL(None)
+        libintl.bindtextdomain(b"virtaal", locale_dir.encode(sys.getfilesystemencoding()))
+        libintl.bind_textdomain_codeset(b"virtaal", b"UTF-8")
+    except (OSError, AttributeError):
+        pass


### PR DESCRIPTION
Adds --pseudo-translation/--pseudo-translation-bidi flags for
exercising every translatable string without a real translation.

- `devsupport/pseudo-translation/generate_pseudo_translation.py`
  generates two synthetic locales from `po/virtaal.pot` via
  translate-toolkit's `podebug`: `pseudo` brackets every string,
  `pseudo-bidi` brackets and RTL-isolate-wraps it (the isolate marks
  alone are invisible, so the brackets are the only visible proof a
  label went through the catalog).
- `pan_app.set_ui_language()` switches to one post-argparse, and binds
  libintl directly (`bind_libintl_posix`) so `Gtk.Builder`'s own
  strings (the menu bar, among others) are covered too, not just
  Python's `_()`.
- `--pseudo-translation-bidi` also forces RTL widget direction.
- The "locale not generated" error is deliberately untranslated - a
  dev-only setup diagnostic.

GTK's own stock menu items (Cut/Copy/Paste/etc.) aren't covered - a
separate gettext domain, fixed in #3372.

Verified end-to-end with real launches; documented in
`docs/testing.rst`.