### PR TITLE
pre-commit: fix pre-existing hook failures for the --all-files fallback

### DIFF
--- a/docs/tips.rst
+++ b/docs/tips.rst
@@ -132,4 +132,3 @@ lookups. You can do that by adding open-tran.eu into your :wp:`hosts file
 
 If you don't know about hosts files and their syntax, it might be best not to
 play with this setting.
-

--- a/maketranslations
+++ b/maketranslations
@@ -4,11 +4,10 @@
 if [ $# == 1 ]; then
 	targetapp=$1
 else
-	targetapp=$(basename $(pwd))
+	targetapp=$(basename "$(pwd)")
 	echo "Guessing application name is \"${targetapp}\""
 fi
 
-share=share/$targetapp
 desktop=share/applications/$targetapp.desktop
 metainfo=share/metainfo/$targetapp.metainfo.xml
 mimetype=share/mime/packages/$targetapp-mimetype.xml
@@ -17,14 +16,14 @@ cache="po/.intltool-merge-cache"
 rm -f $cache
 
 if [ -d po ]; then
-	if [ -f  ${mimetype}.in ]; then
-		intltool-merge --xml-style --cache $cache po ${mimetype}.in $mimetype
+	if [ -f  "${mimetype}".in ]; then
+		intltool-merge --xml-style --cache "$cache" po "${mimetype}".in "$mimetype"
 	fi
-	if [ -f  ${metainfo}.in ]; then
-		intltool-merge --xml-style --cache $cache po ${metainfo}.in $metainfo
+	if [ -f  "${metainfo}".in ]; then
+		intltool-merge --xml-style --cache "$cache" po "${metainfo}".in "$metainfo"
 	fi
-	if [ -f  ${desktop}.in ]; then
-		intltool-merge --desktop-style --cache $cache po ${desktop}.in $desktop
+	if [ -f  "${desktop}".in ]; then
+		intltool-merge --desktop-style --cache "$cache" po "${desktop}".in "$desktop"
 	fi
 else
 	echo "$0: No translation directory"

--- a/virtaal/views/widgets/util.py
+++ b/virtaal/views/widgets/util.py
@@ -38,4 +38,3 @@ def forall_widgets(f, widget):
     f(widget)
     for child in get_children(widget):
         forall_widgets(f, child)
-


### PR DESCRIPTION
The pre-commit CI job only lints changed files, since many
pre-existing files don't pass the current hooks yet - it falls back
to `--all-files` when there's no usable diff base (first push to a
branch, a force push, or the repo's very first commit). That fallback
surfaced two real, pre-existing failures unrelated to whatever
triggered it:

- `end-of-file-fixer`: an extra trailing blank line in
  `virtaal/views/widgets/util.py` and `docs/tips.rst`.
- `shellcheck` on `maketranslations`: SC2046 (unquoted `$(pwd)`
  inside `$(basename ...)`), SC2034 (a `share=` variable assigned but
  never used), and several SC2086s (unquoted variable expansions in
  file-existence tests and `intltool-merge` invocations).

Verified `./maketranslations` still merges real translations
identically after the fix.