### PR TITLE
Add Dependabot version-update config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      pre-commit-hooks:
+        patterns:
+          - "*"


### PR DESCRIPTION
Dependabot security updates are already on for this repo, but nothing
was configured for routine version updates - no dependabot.yml existed
at all.

Adds three ecosystems, matching what's actually used here:

- `github-actions` - the actions pinned in `ci.yml`.
- `pip` - `pyproject.toml`'s own dependencies.
- `pre-commit` - `.pre-commit-config.yaml`'s pinned hook revisions
  (e.g. shellcheck-py), a newer Dependabot ecosystem
  ([announced March 2026](https://github.blog/changelog/2026-03-10-dependabot-now-supports-pre-commit-hooks/))
  that parses the config directly and updates each hook's `rev:`.

Each ecosystem is grouped into a single weekly PR rather than one PR
per bump, to keep the noise manageable.