### PR TITLE
Restore two files emptied by a 2014 Pootle sync

### DIFF
--- a/po/lite/gtk30/gtk30.pot
+++ b/po/lite/gtk30/gtk30.pot
@@ -1,0 +1,512 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: GTK+ lite 3.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-09-04 00:32+0100\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Translate Toolkit 3.19.19\n"
+
+#. Translate to default:RTL if you want your widgets
+#. * to be RTL, otherwise translate to default:LTR.
+#. * Do *not* translate it to "predefinito:LTR", if it
+#. * it isn't default:LTR or default:RTL it will not work
+#. Configuration: Direction
+msgid "default:LTR"
+msgstr ""
+
+#. This is the text that should appear next to menu accelerators
+#. * that use the control key. If the text on this key isn't typically
+#. * translated on keyboards used for your language, don't translate
+#. * this.
+#. GTK HEAD (allows future proofing)
+#. Configuration: Ctrl modifier label
+msgctxt "keyboard label"
+msgid "Ctrl"
+msgstr ""
+
+#. This is the text that should appear next to menu accelerators
+#. * that use the alt key. If the text on this key isn't typically
+#. * translated on keyboards used for your language, don't translate
+#. * this.
+#. GTK >=2.16
+#. Configuration: Alt modifier label
+msgctxt "keyboard label"
+msgid "Alt"
+msgstr ""
+
+msgctxt "keyboard label"
+msgid "Return"
+msgstr ""
+
+#. This is the text that should appear next to menu accelerators
+#. * If the text on this key isn't typically
+#. * translated on keyboards used for your language, don't translate
+#. * this.
+#. *
+#. * Don't include the prefix "keyboard label|" in the translation.
+#. GTK HEAD (allows future proofing)
+#. Configuration: Up key label
+msgctxt "keyboard label"
+msgid "Up"
+msgstr ""
+
+#. This is the text that should appear next to menu accelerators
+#. * If the text on this key isn't typically
+#. * translated on keyboards used for your language, don't translate
+#. * this.
+#. *
+#. * Don't include the prefix "keyboard label|" in the translation.
+#. GTK HEAD (allows future proofing)
+#. Configuration: Down key label
+msgctxt "keyboard label"
+msgid "Down"
+msgstr ""
+
+#. This is the text that should appear next to menu accelerators
+#. * If the text on this key isn't typically
+#. * translated on keyboards used for your language, don't translate
+#. * this.
+#. *
+#. * Don't include the prefix "keyboard label|" in the translation.
+#. GTK HEAD (allows future proofing)
+#. Configuration: Page_Up key label
+msgctxt "keyboard label"
+msgid "Page_Up"
+msgstr ""
+
+#. This is the text that should appear next to menu accelerators
+#. * If the text on this key isn't typically
+#. * translated on keyboards used for your language, don't translate
+#. * this.
+#. *
+#. * Don't include the prefix "keyboard label|" in the translation.
+#. GTK HEAD (allows future proofing)
+#. Configuration: Page_Down key label
+msgctxt "keyboard label"
+msgid "Page_Down"
+msgstr ""
+
+msgctxt "keyboard label"
+msgid "Left"
+msgstr ""
+
+msgctxt "keyboard label"
+msgid "Right"
+msgstr ""
+
+#. File->Open
+msgid "_Open"
+msgstr ""
+
+#. File->Open
+msgctxt "Stock label"
+msgid "_Open"
+msgstr ""
+
+#. File->Save
+msgid "_Save"
+msgstr ""
+
+#. File->Save
+msgctxt "Stock label"
+msgid "_Save"
+msgstr ""
+
+#. File->Save As
+msgid "Save _As"
+msgstr ""
+
+#. File->Save As
+msgctxt "Stock label"
+msgid "Save _As"
+msgstr ""
+
+#. File->Revert
+msgid "_Revert"
+msgstr ""
+
+#. File->Revert
+msgctxt "Stock label"
+msgid "_Revert"
+msgstr ""
+
+#. File->Save As->Replace confirmation
+msgid "A file named \"%s\" already exists.  Do you want to replace it?"
+msgstr ""
+
+#. File->Save As->Replace confirmation
+msgid ""
+"The file already exists in \"%s\".  Replacing it will overwrite its contents."
+msgstr ""
+
+#. File->Save As->Replace confirmation
+#: ../gtk/gtkfilechooserdefault.c:8349
+#: ../gtk/gtkprintunixdialog.c:457
+msgid "_Replace"
+msgstr ""
+
+#. File ->Recent Files->No items found
+msgid "No items found"
+msgstr ""
+
+#. File->Recent Files->tooltip
+msgid "Open '%s'"
+msgstr ""
+
+#. This is the label format that is used for the first 10 items
+#. * in a recent files menu. The %d is the number of the item,
+#. * the %s is the name of the item. Please keep the _ in front
+#. * of the number to give these menu items a mnemonic.
+#. GTK HEAD (allows future proofing)
+#. File->Recent Files->Selection label
+msgctxt "recent menu label"
+msgid "_%d. %s"
+msgstr ""
+
+#. This is the format that is used for items in a recent files menu.
+#. * The %d is the number of the item, the %s is the name of the item.
+#. GTK HEAD (allows future proofing)
+#: ../gtk/gtkrecentchoosermenu.c:779
+msgctxt "recent menu label"
+msgid "%d. %s"
+msgstr ""
+
+msgctxt "Stock label"
+msgid "_Properties"
+msgstr ""
+
+#. File->Quit
+msgid "_Quit"
+msgstr ""
+
+#. File->Quit
+msgctxt "Stock label"
+msgid "_Quit"
+msgstr ""
+
+#. Edit->Undo
+msgid "_Undo"
+msgstr ""
+
+#. Edit->Undo
+msgctxt "Stock label"
+msgid "_Undo"
+msgstr ""
+
+#. Edit->Preferences
+msgid "_Preferences"
+msgstr ""
+
+#. Edit->Preferences
+msgctxt "Stock label"
+msgid "_Preferences"
+msgstr ""
+
+#. Navigation->Up
+#. GTK HEAD (allows future proofing)
+msgctxt "Stock label, navigation"
+msgid "_Up"
+msgstr ""
+
+#. Navigation->Down
+#. GTK HEAD (allows future proofing)
+msgctxt "Stock label, navigation"
+msgid "_Down"
+msgstr ""
+
+#. Help->About
+msgid "_About"
+msgstr ""
+
+#. Help->About
+msgctxt "Stock label"
+msgid "_About"
+msgstr ""
+
+#. About Dialog - Title
+msgid "About %s"
+msgstr ""
+
+#. About Dialog - Credits button
+msgid "C_redits"
+msgstr ""
+
+#. About Dialog - License button
+msgid "_License"
+msgstr ""
+
+#. About Dialog - Close button
+msgid "_Close"
+msgstr ""
+
+#. About Dialog - Close button
+msgctxt "Stock label"
+msgid "_Close"
+msgstr ""
+
+#. About Dialog - Credits dialog - Title
+msgid "Credits"
+msgstr ""
+
+#. About Dialog - Credits dialog - Tab - Written by
+msgid "Written by"
+msgstr ""
+
+#. About Dialog - Credits dialog - Tab - Translated by
+msgid "Translated by"
+msgstr ""
+
+#. About Dialog - Credits dialog - Tab - Artwork by
+msgid "Artwork by"
+msgstr ""
+
+#. About Dialog - License dialog - Title
+msgid "License"
+msgstr ""
+
+#. File dialog - Cancel button
+msgid "_Cancel"
+msgstr ""
+
+#. File dialog - Cancel button
+msgctxt "Stock label"
+msgid "_Cancel"
+msgstr ""
+
+#. File dialog - Add button
+msgid "_Add"
+msgstr ""
+
+#. Add button (various, add term, add terminology file)
+msgctxt "Stock label"
+msgid "_Add"
+msgstr ""
+
+#. File dialog - Add button - tooltip
+msgid "Add the folder '%s' to the bookmarks"
+msgstr ""
+
+#. File dialog - Add button - tooltip
+msgid "Add the current folder to the bookmarks"
+msgstr ""
+
+#. File dialog - Remove button
+msgid "_Remove"
+msgstr ""
+
+#. Remove button (remove terminology file)
+msgctxt "Stock label"
+msgid "_Remove"
+msgstr ""
+
+#. File dialog - Remove button - tooltip
+msgid "Remove the bookmark '%s'"
+msgstr ""
+
+#. File dialog - Remove button - tooltip
+msgid "Remove the selected bookmark"
+msgstr ""
+
+#. File dialog - Location - Label
+msgid "_Location:"
+msgstr ""
+
+#. File dialog - Search - Label
+#. Appears when you select Search from Places
+msgid "_Search:"
+msgstr ""
+
+#. File dialog - Location - Open/Close button - Tooltip
+msgid "Type a file name"
+msgstr ""
+
+#. File dialog - Places - Grid label - Places
+msgid "_Places"
+msgstr ""
+
+#. File dialog - Places - Entry - Search
+msgid "Search"
+msgstr ""
+
+#. File dialog - Places - Entry - Recently used
+msgid "Recently Used"
+msgstr ""
+
+#. File dialog - Places - Entry - Desktop
+msgid "Desktop"
+msgstr ""
+
+#. File dialog - Places - Entry - File System
+msgid "File System"
+msgstr ""
+
+#. File dialog - Places - Right-Click - Remove
+msgid "Remove"
+msgstr ""
+
+#. File dialog - Places - Right-Click - Rename...
+msgid "Rename..."
+msgstr ""
+
+#. File dialog - Files - Grid label - Name
+msgid "Name"
+msgstr ""
+
+#. File dialog - Files - Grid label - Size
+msgid "Size"
+msgstr ""
+
+#. File dialog - Files - Grid label - Modified
+msgid "Modified"
+msgstr ""
+
+#. File dialog - Files - Table - Date formats - HH:MM
+msgid "%H:%M"
+msgstr ""
+
+#. File dialog - Files - Table - Date formats - Today at
+msgid "Today at %H:%M"
+msgstr ""
+
+#. File dialog - Files - Table - Date formats - Yesterday at
+msgid "Yesterday at %H:%M"
+msgstr ""
+
+#. File dialog - Files - Right click - Show Hidden Files
+msgid "Show _Hidden Files"
+msgstr ""
+
+#. File dialog - Files - Right click - Show Size Column
+msgid "Show _Size Column"
+msgstr ""
+
+#. File dialog - Files - Right click - Add to Bookmarks
+msgid "_Add to Bookmarks"
+msgstr ""
+
+#. File dialog - File type list - tooltip
+msgid "Select which types of files are shown"
+msgstr ""
+
+#. File save dialog - Name:
+msgid "_Name:"
+msgstr ""
+
+#. File save dialog - Save in folder:
+msgid "Save in _folder:"
+msgstr ""
+
+#. File save dialog - Browse for other folders
+msgid "_Browse for other folders"
+msgstr ""
+
+#. File save dialog - Create folder button
+msgid "Create Fo_lder"
+msgstr ""
+
+#. File save dialg - Create folder button (after pressing) - Type name of new folder
+msgid "Type name of new folder"
+msgstr ""
+
+#. Right Click (on empty) -> Cut
+msgid "Cu_t"
+msgstr ""
+
+#. Right Click (on empty) -> Cut
+msgctxt "Stock label"
+msgid "Cu_t"
+msgstr ""
+
+#. Right Click (on empty) -> Copy
+msgid "_Copy"
+msgstr ""
+
+#. Right Click (on empty) -> Copy
+msgctxt "Stock label"
+msgid "_Copy"
+msgstr ""
+
+#. Right Click (on empty) -> Paste
+msgid "_Paste"
+msgstr ""
+
+#. Right Click (on empty) -> Paste
+msgctxt "Stock label"
+msgid "_Paste"
+msgstr ""
+
+#. Right Click (on empty) -> Delete
+msgid "_Delete"
+msgstr ""
+
+#. Right Click (on empty) -> Delete
+msgctxt "Stock label"
+msgid "_Delete"
+msgstr ""
+
+#. Right Click (on empty) -> Select All
+msgid "Select _All"
+msgstr ""
+
+#. Right Click (on empty) -> Select All
+msgctxt "Stock label"
+msgid "Select _All"
+msgstr ""
+
+#. Revert Confirmation Dialog -> Yes
+msgid "_Yes"
+msgstr ""
+
+#. Revert Confirmation Dialog -> Yes
+msgctxt "Stock label"
+msgid "_Yes"
+msgstr ""
+
+#. Revert Confirmation Dialog -> No
+msgid "_No"
+msgstr ""
+
+#. Revert Confirmation Dialog -> No
+msgctxt "Stock label"
+msgid "_No"
+msgstr ""
+
+#. Error Dialog -> OK
+msgid "_OK"
+msgstr ""
+
+#. Error Dialog -> OK
+msgctxt "Stock label"
+msgid "_OK"
+msgstr ""
+
+#. Font dialog: title
+msgid "Pick a Font"
+msgstr ""
+
+#. Font dialog: Family
+msgid "_Family:"
+msgstr ""
+
+#. Font dialog: Style
+msgid "_Style:"
+msgstr ""
+
+#. Font dialog: Size
+msgid "Si_ze:"
+msgstr ""
+
+#. Font dialog: Preview
+msgid "_Preview:"
+msgstr ""
+
+#. Font dailog: Preview default text
+#. This is the default text shown in the preview entry, though the user
+#. can set it. Remember that some fonts only have capital letters.
+msgid "abcdefghijk ABCDEFGHIJK"
+msgstr ""

--- a/po/lite/iso_639/zu.po
+++ b/po/lite/iso_639/zu.po
@@ -1,0 +1,41 @@
+# F Wolff <friedel@translate.org.za>, 2009
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2009-06-05 00:17+0200\n"
+"PO-Revision-Date: 2009-06-05 00:18+0200\n"
+"Last-Translator: F Wolff <friedel@translate.org.za>\n"
+"Language-Team: translate-discuss-zu@lists.sourceforge.net\n"
+"Language: zu\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Virtaal 0.3.1\n"
+
+msgid "Afrikaans"
+msgstr "isiBhunu"
+
+msgid "English"
+msgstr "isiNgisi"
+
+msgid "Sotho"
+msgstr "isiSuthu"
+
+msgid "Swazi"
+msgstr "isiSwazi"
+
+msgid "Tsonga"
+msgstr "isiTsonga"
+
+msgid "Tswana"
+msgstr "isiTshwana"
+
+msgid "Venda"
+msgstr "isiVenda"
+
+msgid "Xhosa"
+msgstr "isiXhosa"
+
+msgid "Zulu"
+msgstr "isiZulu"


### PR DESCRIPTION
78a72fa5 ("l10n: pull files from Pootle", 2014-02-11) blanked two files
to zero bytes while legitimately updating every other po/lite/ file in
the same commit - real content lost, not a rename/format issue. A
broader check confirms these are the only two currently-empty files
anywhere under po/ or po/lite/ on main.

- `po/lite/iso_639/zu.po`: restored 9 real Zulu language-name
  translations (South Africa's own official languages - Afrikaans,
  English, Sotho, Swazi, Tsonga, Tswana, Venda, Xhosa, Zulu), F Wolff,
  2009. Verified it compiles and resolves correctly via gettext.
- `po/lite/gtk30/gtk30.pot`: restored, scoped to what the real,
  currently-bundled po/lite/gtk30/*.po translations already cover -
  minus a handful of entries (keyboard label, recent menu label,
  Navigation) that used the old GTK <= 2.14 "context|msgid" convention
  and are dead weight against a real GTK3 catalog, which uses proper
  msgctxt for all of these instead (confirmed directly against a real
  installed gtk30.mo).