### PR TITLE
Remove repeated MimeType entry

### DIFF
--- a/share/applications/virtaal.desktop.in
+++ b/share/applications/virtaal.desktop.in
@@ -7,7 +7,7 @@ _Comment=A translation tool to help a human translator translate files into othe
 TryExec=virtaal
 Exec=virtaal %f
 Icon=virtaal
-MimeType=text/x-gettext-translation;text/x-gettext-translation-template;application/x-gettext;application/x-gettext-translation;application/x-po;application/x-gettext;text/x-po;application/x-xliff+xml;application/x-xliff;text/x-wordfast;application/x-tmx;application/x-tbx;application/x-linguist;application/x-qph;application/x-qm;
+MimeType=text/x-gettext-translation;text/x-gettext-translation-template;application/x-gettext;application/x-gettext-translation;application/x-po;text/x-po;application/x-xliff+xml;application/x-xliff;text/x-wordfast;application/x-tmx;application/x-tbx;application/x-linguist;application/x-qph;application/x-qm;
 # Not yet supported
 # application/x-sdf;
 # Monolingual


### PR DESCRIPTION
Cherry-pick of #3246, credited to its original author - that PR's
branch is a decade-old fork branch with no CI history at all under
the current required checks, which the merge queue won't accept
regardless of the actual one-line change being clean and conflict-free.

Same content: removes the duplicate `application/x-gettext` entry
from `virtaal.desktop.in`'s `MimeType=` line.