### PR TITLE
Migrate GObject.idle_add/timeout_add/source_remove/PRIORITY_* to GLib

### DIFF
--- a/virtaal/controllers/checkscontroller.py
+++ b/virtaal/controllers/checkscontroller.py
@@ -20,7 +20,8 @@
 
 import logging
 
-from gi.repository.GObject import SIGNAL_RUN_FIRST, timeout_add, PRIORITY_LOW
+from gi.repository import GLib
+from gi.repository.GObject import SIGNAL_RUN_FIRST
 
 from virtaal.common import GObjectWrapper
 from .basecontroller import BaseController
@@ -209,7 +210,7 @@ class ChecksController(BaseController):
             # haven't changed units yet, probably strange timing issue
             return
         self._check_timer_active = True
-        timeout_add(self.CHECK_TIMEOUT, self._check_timer_expired, self.last_unit, priority=PRIORITY_LOW)
+        GLib.timeout_add(self.CHECK_TIMEOUT, self._check_timer_expired, self.last_unit, priority=GLib.PRIORITY_LOW)
 
     def get_check_name(self, check):
         """Return the human readable form of the given check name."""

--- a/virtaal/controllers/plugincontroller.py
+++ b/virtaal/controllers/plugincontroller.py
@@ -22,7 +22,8 @@ import logging
 import os
 import sys
 
-from gi.repository.GObject import SIGNAL_RUN_FIRST, TYPE_PYOBJECT, idle_add
+from gi.repository import GLib
+from gi.repository.GObject import SIGNAL_RUN_FIRST, TYPE_PYOBJECT
 
 from virtaal.common import pan_app, GObjectWrapper
 from virtaal.common.utils import get_unicode
@@ -138,7 +139,7 @@ class PluginController(BaseController):
             if name in disabled_plugins:
                 continue
             # We use idle_add(), so that the UI will respond sooner
-            idle_add(self.enable_plugin, name)
+            GLib.idle_add(self.enable_plugin, name)
         logging.info('Queued all plugins for loading')
 
     def shutdown(self):

--- a/virtaal/controllers/undocontroller.py
+++ b/virtaal/controllers/undocontroller.py
@@ -18,7 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-from gi.repository import GObject
+from gi.repository import GLib
 from gi.repository import Gdk
 from gi.repository import Gtk
 from translate.storage.placeables import StringElem
@@ -159,7 +159,7 @@ class UndoController(BaseController):
             textbox.refresh(update=True)
             self._enable_unit_signals()
 
-        GObject.idle_add(refresh)
+        GLib.idle_add(refresh)
 
     def _select_unit(self, unit):
         """Select the given unit in the store view.

--- a/virtaal/controllers/welcomescreencontroller.py
+++ b/virtaal/controllers/welcomescreencontroller.py
@@ -56,8 +56,8 @@ class WelcomeScreenController(BaseController):
     def activate(self):
         """Show the welcome screen and trigger activation logic (ie. find
             recent files)."""
-        from gi.repository import GObject
-        GObject.idle_add(self.update_recent, priority=GObject.PRIORITY_LOW)
+        from gi.repository import GLib
+        GLib.idle_add(self.update_recent, priority=GLib.PRIORITY_LOW)
         self.view.show()
 
     def open_cheatsheat(self):

--- a/virtaal/main.py
+++ b/virtaal/main.py
@@ -26,7 +26,7 @@
 # after the GUI is already showing.
 
 
-from gi.repository import GObject
+from gi.repository import GLib
 
 
 class _Deferer:
@@ -49,7 +49,7 @@ class _Deferer:
 
         if not self._todo:
             # No existing jobs, so start one
-            GObject.idle_add(next_job, priority=GObject.PRIORITY_LOW)
+            GLib.idle_add(next_job, priority=GLib.PRIORITY_LOW)
         self._todo.append((func, args))
 
 

--- a/virtaal/modes/searchmode.py
+++ b/virtaal/modes/searchmode.py
@@ -21,7 +21,7 @@
 
 import logging
 
-from gi.repository import GObject, Gtk, Gdk
+from gi.repository import GLib, Gtk, Gdk
 
 from virtaal.common.utils import get_unicode
 from virtaal.controllers.cursor import Cursor
@@ -141,7 +141,7 @@ class SearchMode(BaseMode):
             return False
 
         # FIXME: The following line is a VERY UGLY HACK, but at least it works.
-        GObject.timeout_add(100, grab_focus)
+        GLib.timeout_add(100, grab_focus)
 
     def select_match(self, match):
         """Select the specified match in the GUI."""
@@ -177,7 +177,7 @@ class SearchMode(BaseMode):
             return False
 
         # TODO: Implement for 'notes' and 'locations' parts
-        GObject.idle_add(select_match_text)
+        GLib.idle_add(select_match_text)
 
     def replace_match(self, match, replace_str):
         main_controller = self.controller.main_controller
@@ -250,7 +250,7 @@ class SearchMode(BaseMode):
             self.ent_search.set_position(curpos)
             return False
 
-        GObject.idle_add(grabfocus)
+        GLib.idle_add(grabfocus)
 
     def unselected(self):
         # TODO: Unhightlight the previously selected unit
@@ -476,12 +476,12 @@ class SearchMode(BaseMode):
             before calling update_search() directly, bypassing the
             debounce, so a stale timeout doesn't also fire later."""
         if self._search_timeout:
-            GObject.source_remove(self._search_timeout)
+            GLib.source_remove(self._search_timeout)
             self._search_timeout = 0
 
     def _on_search_text_changed(self, entry):
         self._cancel_search_timeout()
-        self._search_timeout = GObject.timeout_add(self.SEARCH_DELAY, self.update_search)
+        self._search_timeout = GLib.timeout_add(self.SEARCH_DELAY, self.update_search)
 
     def _on_start_search(self, _accel_group, _acceleratable, _keyval, _modifier):
         """This is called via the accelerator."""

--- a/virtaal/modes/workflowmode.py
+++ b/virtaal/modes/workflowmode.py
@@ -19,7 +19,7 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 from gi.repository import Gtk
-from gi.repository.GObject import idle_add
+from gi.repository import GLib
 
 from virtaal.views.widgets.popupmenubutton import PopupMenuButton, POS_NW_SW
 from .basemode import BaseMode
@@ -133,7 +133,7 @@ class WorkflowMode(BaseMode):
                 continue
             if menuitem in self._menuitem_states:
                 self.filter_states.append(self._menuitem_states[menuitem])
-        idle_add(self._apply_filter_states)
+        GLib.idle_add(self._apply_filter_states)
         self._update_button_label()
 
     def _apply_filter_states(self):

--- a/virtaal/plugins/_ipython_console/ipython_view.py
+++ b/virtaal/plugins/_ipython_console/ipython_view.py
@@ -20,7 +20,7 @@ from functools import reduce
 from io import StringIO
 
 import IPython
-from gi.repository import Pango, Gtk
+from gi.repository import GLib, Pango, Gtk
 
 
 class IterableIPShell:
@@ -276,7 +276,7 @@ class ConsoleView(Gtk.TextView):
     self.connect('key-press-event', self.onKeyPress)
 
   def write(self, text, editable=False):
-      GObject.idle_add(self._write, text, editable)
+      GLib.idle_add(self._write, text, editable)
 
   def _write(self, text, editable=False):
     '''
@@ -310,7 +310,7 @@ class ConsoleView(Gtk.TextView):
 
 
   def showPrompt(self, prompt):
-      GObject.idle_add(self._showPrompt, prompt)
+      GLib.idle_add(self._showPrompt, prompt)
 
   def _showPrompt(self, prompt):
     '''
@@ -324,7 +324,7 @@ class ConsoleView(Gtk.TextView):
                                self.text_buffer.get_end_iter())
 
   def changeLine(self, text):
-      GObject.idle_add(self._changeLine, text)
+      GLib.idle_add(self._changeLine, text)
 
   def _changeLine(self, text):
     '''
@@ -351,7 +351,7 @@ class ConsoleView(Gtk.TextView):
     return rv
 
   def showReturned(self, text):
-      GObject.idle_add(self._showReturned, text)
+      GLib.idle_add(self._showReturned, text)
 
   def _showReturned(self, text):
     '''

--- a/virtaal/plugins/_python_console.py
+++ b/virtaal/plugins/_python_console.py
@@ -4,7 +4,7 @@ import re
 import sys
 import traceback
 
-from gi.repository import GObject
+from gi.repository import GLib
 from gi.repository import Gdk
 from gi.repository import Gtk
 from gi.repository import Pango
@@ -88,7 +88,7 @@ class PythonConsole(Gtk.ScrolledWindow):
                 cur = buffer.get_end_iter()
 
             buffer.place_cursor(cur)
-            GObject.idle_add(self.scroll_to_end)
+            GLib.idle_add(self.scroll_to_end)
             return True
 
         elif event.keyval == Gdk.KEY_Return:
@@ -132,7 +132,7 @@ class PythonConsole(Gtk.ScrolledWindow):
             cur = buffer.get_end_iter()
             buffer.move_mark(inp_mark, cur)
             buffer.place_cursor(cur)
-            GObject.idle_add(self.scroll_to_end)
+            GLib.idle_add(self.scroll_to_end)
             return True
 
         elif event.keyval == Gdk.KEY_KP_Down or \
@@ -140,7 +140,7 @@ class PythonConsole(Gtk.ScrolledWindow):
             # Next entry from history
             view.emit_stop_by_name("key_press_event")
             self.history_down()
-            GObject.idle_add(self.scroll_to_end)
+            GLib.idle_add(self.scroll_to_end)
             return True
 
         elif event.keyval == Gdk.KEY_KP_Up or \
@@ -148,7 +148,7 @@ class PythonConsole(Gtk.ScrolledWindow):
             # Previous entry from history
             view.emit_stop_by_name("key_press_event")
             self.history_up()
-            GObject.idle_add(self.scroll_to_end)
+            GLib.idle_add(self.scroll_to_end)
             return True
 
         elif event.keyval == Gdk.KEY_KP_Left or \
@@ -221,7 +221,7 @@ class PythonConsole(Gtk.ScrolledWindow):
             buffer.insert(buffer.get_end_iter(), text)
         else:
             buffer.insert_with_tags(buffer.get_end_iter(), text, tag)
-        GObject.idle_add(self.scroll_to_end)
+        GLib.idle_add(self.scroll_to_end)
 
     def eval(self, command, display_command = False):
         buffer = self.view.get_buffer()

--- a/virtaal/plugins/autocompletor.py
+++ b/virtaal/plugins/autocompletor.py
@@ -23,7 +23,7 @@
 
 import re
 
-from gi.repository import GObject
+from gi.repository import GLib
 
 try:
     from collections import defaultdict
@@ -178,7 +178,7 @@ class AutoCompletor(object):
             if completed_word:
                 # Updating of the buffer is deferred until after this signal
                 # and its side effects are taken care of. We abuse
-                # GObject.idle_add for that.
+                # GLib.idle_add for that.
                 insert_offset = offset + 1 # len(text) == 1
                 def suggest_completion():
                     textbox.handler_block(self._textbox_insert_ids[textbox])
@@ -192,7 +192,7 @@ class AutoCompletor(object):
 
                     return False
 
-                GObject.idle_add(suggest_completion, priority=GObject.PRIORITY_HIGH)
+                GLib.idle_add(suggest_completion, priority=GLib.PRIORITY_HIGH)
 
     def _remove_textbox(self, textbox):
         """Remove the given L{TextBox} from the list of widgets to do
@@ -274,7 +274,7 @@ class Plugin(BasePlugin):
                         self.autocomp.add_words(self.autocomp.wordsep_re.split(str(self.lastunit.target)))
             self.lastunit = cursor.deref()
 
-        GObject.idle_add(add_widgets)
+        GLib.idle_add(add_widgets)
 
     def _on_store_loaded(self, storecontroller):
         self.autocomp.add_words_from_units(storecontroller.get_store().get_units())

--- a/virtaal/plugins/autocorrector.py
+++ b/virtaal/plugins/autocorrector.py
@@ -26,7 +26,7 @@ import os
 import re
 import zipfile
 
-from gi.repository import GObject
+from gi.repository import GLib
 
 from virtaal.common import pan_app
 from virtaal.controllers.baseplugin import BasePlugin
@@ -226,7 +226,7 @@ class AutoCorrector(object):
             if reprange is not None:
                 # Updating of the buffer is deferred until after this signal
                 # and its side effects are taken care of. We abuse
-                # GObject.idle_add for that.
+                # GLib.idle_add for that.
                 def correct_text():
                     buffer = textbox.buffer
                     start_iter = elem.gui_info.treeindex_to_iter(reprange[0])
@@ -242,10 +242,10 @@ class AutoCorrector(object):
                         textbox.refresh_cursor_pos = newcursorpos
                         textbox.refresh()
 
-                    GObject.idle_add(refresh)
+                    GLib.idle_add(refresh)
                     return False
 
-                GObject.idle_add(correct_text)
+                GLib.idle_add(correct_text)
 
     def _remove_textbox(self, textbox):
         """Remove the given C{TextBox} from the list of widgets to do
@@ -279,7 +279,7 @@ class Plugin(BasePlugin):
                     self.autocorr.add_widget(target)
                 return False
 
-            GObject.idle_add(add_widgets)
+            GLib.idle_add(add_widgets)
 
         def on_store_loaded(storecontroller):
             self.autocorr.load_dictionary(lang=self.main_controller.lang_controller.target_lang.code)

--- a/virtaal/plugins/spellchecker.py
+++ b/virtaal/plugins/spellchecker.py
@@ -25,7 +25,7 @@ import re
 import sys
 from gettext import dgettext
 
-from gi.repository import GObject
+from gi.repository import GLib
 
 from virtaal.controllers.baseplugin import PluginUnsupported, BasePlugin
 
@@ -293,7 +293,7 @@ class Plugin(BasePlugin):
         if getattr(text_view, 'spell_lang', None) == language:
             # No change necessary - already enabled
             return
-        GObject.idle_add(self._activate_checker, text_view, language, priority=GObject.PRIORITY_LOW)
+        GLib.idle_add(self._activate_checker, text_view, language, priority=GLib.PRIORITY_LOW)
 
     def _activate_checker(self, text_view, language):
         # All the expensive stuff in here called on idle.
@@ -320,7 +320,7 @@ class Plugin(BasePlugin):
     def _on_populate_popup(self, textbox, menu):
         # We can't work with the menu immediately, since gtkspell only adds its
         # entries in the event handler.
-        GObject.idle_add(self._fix_menu, menu)
+        GLib.idle_add(self._fix_menu, menu)
 
     def _fix_menu(self, menu):
         _entries_above_separator = False

--- a/virtaal/plugins/tm/tmcontroller.py
+++ b/virtaal/plugins/tm/tmcontroller.py
@@ -21,7 +21,7 @@
 
 import os.path
 
-from gi.repository import GObject
+from gi.repository import GLib, GObject
 from translate.lang.data import normalize
 
 from virtaal.controllers.basecontroller import BaseController
@@ -199,8 +199,8 @@ class TMController(BaseController):
             return False
 
         if self._delay_id:
-            GObject.source_remove(self._delay_id)
-        self._delay_id = GObject.timeout_add(self.QUERY_DELAY, start_query)
+            GLib.source_remove(self._delay_id)
+        self._delay_id = GLib.timeout_add(self.QUERY_DELAY, start_query)
 
 
     # EVENT HANDLERS #
@@ -243,7 +243,7 @@ class TMController(BaseController):
             self._on_cursor_changed(self.storecursor)
             return False
 
-        GObject.idle_add(handle_first_unit)
+        GLib.idle_add(handle_first_unit)
 
     def _on_target_focused(self, unitcontroller, target_n):
         #import logging

--- a/virtaal/plugins/tm/tmview.py
+++ b/virtaal/plugins/tm/tmview.py
@@ -21,7 +21,7 @@
 
 import logging
 
-from gi.repository import Gdk
+from gi.repository import GLib, GObject, Gdk
 
 from virtaal.common import GObjectWrapper
 from virtaal.views.baseview import BaseView
@@ -257,7 +257,7 @@ class TMView(BaseView, GObjectWrapper):
             if selected:
                 self.tmwindow.update_geometry(selected)
 
-        GObject.idle_add(update)
+        GLib.idle_add(update)
 
     def _get_selected_unit_view(self):
         n = self.controller.main_controller.unit_controller.view.focused_target_n

--- a/virtaal/support/httpclient.py
+++ b/virtaal/support/httpclient.py
@@ -22,7 +22,7 @@ import logging
 from io import BytesIO
 
 import pycurl
-from gi.repository import GObject
+from gi.repository import GLib, GObject
 from urllib import request, parse
 
 try:
@@ -205,7 +205,7 @@ class HTTPClient(object):
     def run(self):
         """client should not be running when request queue is empty"""
         if self.running: return
-        GObject.timeout_add(100, self.perform)
+        GLib.timeout_add(100, self.perform)
         self.running = True
 
     def close_request(self, handle):

--- a/virtaal/views/langview.py
+++ b/virtaal/views/langview.py
@@ -22,7 +22,7 @@ import locale
 import logging
 import os
 
-from gi.repository import GObject
+from gi.repository import GLib
 from gi.repository import Gdk
 from gi.repository import Gtk
 
@@ -98,7 +98,7 @@ class LanguageView(BaseView):
             for s in [Gtk.StateType.ACTIVE, Gtk.StateType.NORMAL, Gtk.StateType.PRELIGHT, Gtk.StateType.SELECTED]:
                 self.popupbutton.modify_fg(s, Gdk.color_parse('#f66'))
 
-        GObject.idle_add(notify)
+        GLib.idle_add(notify)
 
     def notify_diff_langs(self):
         def notify():
@@ -106,7 +106,7 @@ class LanguageView(BaseView):
             for state in states:
                 self.popupbutton.modify_fg(state, None)
 
-        GObject.idle_add(notify)
+        GLib.idle_add(notify)
 
     def show(self):
         """Add the managed C{PopupMenuButton} to the C{MainView}'s status bar."""

--- a/virtaal/views/mainview.py
+++ b/virtaal/views/mainview.py
@@ -216,8 +216,8 @@ class MainView(BaseView):
         self._setup_key_bindings()
         self._track_window_state()
         self._setup_dnd()
-        from gi.repository import GObject
-        GObject.idle_add(self._setup_recent_files, priority=GObject.PRIORITY_LOW)
+        from gi.repository import GLib
+        GLib.idle_add(self._setup_recent_files, priority=GLib.PRIORITY_LOW)
         self.main_window.connect('style-set', self._on_style_set)
         self.main_window.connect('style-updated', self._on_style_set)
 
@@ -591,8 +591,6 @@ class MainView(BaseView):
         if pan_app.settings.general['maximized']:
             self.main_window.maximize()
         self.main_window.show()
-        from gi.repository.GObject import threads_init
-        threads_init()
 
         # Uncomment this line to measure startup time until the window shows.
         # It causes the program to quit immediately when the window is shown:

--- a/virtaal/views/unitview.py
+++ b/virtaal/views/unitview.py
@@ -21,8 +21,8 @@
 import logging
 import re
 
-from gi.repository import Gtk, Gdk
-from gi.repository.GObject import idle_add, PARAM_READWRITE, SIGNAL_RUN_FIRST, TYPE_PYOBJECT
+from gi.repository import GLib, Gtk, Gdk
+from gi.repository.GObject import PARAM_READWRITE, SIGNAL_RUN_FIRST, TYPE_PYOBJECT
 from translate.lang import factory
 
 from virtaal.common import GObjectWrapper
@@ -407,7 +407,7 @@ class UnitView(Gtk.EventBox, GObjectWrapper, Gtk.CellEditable, BaseView):
 
             # Alt-Down
             elif eventname == 'alt-down':
-                idle_add(self.copy_original, textbox)
+                GLib.idle_add(self.copy_original, textbox)
                 return True
 
             # Shift-Tab

--- a/virtaal/views/util.py
+++ b/virtaal/views/util.py
@@ -18,7 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-from gi.repository import GObject
+from gi.repository import GLib
 from gi.repository import Gtk
 
 __all__ = ['pulse']
@@ -72,7 +72,7 @@ def pulse_step(widget, steptime, colordiff, stopcolor, component):
         return
 
     modify_func(Gtk.StateType.NORMAL, col)
-    GObject.timeout_add(steptime, pulse_step, widget, steptime, colordiff, stopcolor, component)
+    GLib.timeout_add(steptime, pulse_step, widget, steptime, colordiff, stopcolor, component)
 
 def pulse(widget, color, fadetime=5000, steptime=10, component='bg'):
     """Fade the background colour of the current widget from the given colour
@@ -109,4 +109,4 @@ def pulse(widget, color, fadetime=5000, steptime=10, component='bg'):
         blue=color[COL_BLUE]
     )
     modify_func(Gtk.StateType.NORMAL, pulsecol)
-    GObject.timeout_add(steptime, pulse_step, widget, steptime, colordiff, stopcolor, component)
+    GLib.timeout_add(steptime, pulse_step, widget, steptime, colordiff, stopcolor, component)

--- a/virtaal/views/welcomescreenview.py
+++ b/virtaal/views/welcomescreenview.py
@@ -19,8 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-from gi.repository import Gtk
-from gi.repository.GObject import idle_add
+from gi.repository import GLib, Gtk
 
 from virtaal.common.pan_app import get_abs_data_filename, ui_language
 from virtaal.views.widgets.welcomescreen import WelcomeScreen
@@ -91,7 +90,7 @@ class WelcomeScreenView(BaseView):
                 width = int(maxwidth)
 
             txt.set_size_request(width, -1)
-        idle_add(calculate_width)
+        GLib.idle_add(calculate_width)
 
     def update_recent_buttons(self, items):
         # if there are no items (maybe failure in xbel), hide the whole widget

--- a/virtaal/views/widgets/storetreeview.py
+++ b/virtaal/views/widgets/storetreeview.py
@@ -21,7 +21,7 @@
 
 import logging
 
-from gi.repository import GObject
+from gi.repository import GLib, GObject
 from gi.repository import Gtk
 
 from .storecellrenderer import StoreCellRenderer
@@ -60,7 +60,7 @@ class StoreTreeView(Gtk.TreeView):
         # to you.
         self._waiting_for_row_change = 0
 
-        # GObject.timeout_add() id for the pending debounced
+        # GLib.timeout_add() id for the pending debounced
         # on_configure_event() action - see that method for why.
         self._configure_timeout_id = None
 
@@ -151,7 +151,7 @@ class StoreTreeView(Gtk.TreeView):
                     return
                 self.set_cursor(newpath, self.get_columns()[0], start_editing=True)
             self._waiting_for_row_change += 1
-            GObject.idle_add(change_cursor, priority=GObject.PRIORITY_DEFAULT_IDLE)
+            GLib.idle_add(change_cursor, priority=GLib.PRIORITY_DEFAULT_IDLE)
 
     def set_model(self, storemodel):
         if storemodel:
@@ -230,19 +230,19 @@ class StoreTreeView(Gtk.TreeView):
         # settle-then-restore-cursor housekeeping.
         logging.debug("storetreeview: configure-event %dx%d", event.width, event.height)
         if self._configure_timeout_id is not None:
-            GObject.source_remove(self._configure_timeout_id)
-        self._configure_timeout_id = GObject.timeout_add(200, self._on_configure_settled)
+            GLib.source_remove(self._configure_timeout_id)
+        self._configure_timeout_id = GLib.timeout_add(200, self._on_configure_settled)
         return False
 
     def _on_configure_settled(self):
         self._configure_timeout_id = None
         logging.debug("storetreeview: debounce settled, window=%s", self._window_size())
         self._restore_cursor()
-        return False  # one-shot: don't repeat this GObject.timeout_add
+        return False  # one-shot: don't repeat this GLib.timeout_add
 
     def _on_destroy(self, _widget):
         if self._configure_timeout_id is not None:
-            GObject.source_remove(self._configure_timeout_id)
+            GLib.source_remove(self._configure_timeout_id)
             self._configure_timeout_id = None
 
     def _on_focus_in(self, widget, _event, *_user_args):
@@ -276,7 +276,7 @@ class StoreTreeView(Gtk.TreeView):
             self.view.cursor.index = index
 
         # We defer the scrolling until GTK has finished all its current drawing
-        # tasks, hence the GObject.idle_add. If we don't wait, then the TreeView
+        # tasks, hence the GLib.idle_add. If we don't wait, then the TreeView
         # draws the editor widget in the wrong position. Presumably GTK issues
         # a redraw event for the editor widget at a given x-y position and then also
         # issues a TreeView scroll; thus, the editor widget gets drawn at the wrong
@@ -290,7 +290,7 @@ class StoreTreeView(Gtk.TreeView):
                 self.scroll_to_cell(path, self.get_column(0), True, 0.5, 0.0)
             return False
 
-        GObject.idle_add(do_scroll)
+        GLib.idle_add(do_scroll)
         return True
 
     def _on_key_press(self, _widget, _event, _data=None):

--- a/virtaal/views/widgets/welcomescreen.py
+++ b/virtaal/views/widgets/welcomescreen.py
@@ -18,7 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-from gi.repository import GObject, Gtk, Gdk
+from gi.repository import GLib, GObject, Gtk, Gdk
 
 from virtaal.views.theme import current_theme
 
@@ -109,7 +109,7 @@ class WelcomeScreen(Gtk.ScrolledWindow):
             background = context.get_background_color(Gtk.StateType.NORMAL)
             txt_features.override_background_color(Gtk.StateType.NORMAL, background)
 
-        GObject.idle_add(_set_text, features, priority=GObject.PRIORITY_LOW)
+        GLib.idle_add(_set_text, features, priority=GLib.PRIORITY_LOW)
 
 
     # METHODS #


### PR DESCRIPTION
First of a few smaller PRs cleaning up PyGIDeprecationWarning/
PyGTKDeprecationWarning noise. These symbols moved to GLib as part of
GObject Introspection's own API cleanup - the GObject-namespaced
spellings still work but warn on every call.

Also drops a dead `threads_init()` call in `mainview.py` (not needed
since PyGObject 3.11), and fixes a real bug found along the way:
`virtaal/plugins/_ipython_console/ipython_view.py` called
`GObject.idle_add` four times with no import of `GObject` anywhere in
the file - a latent `NameError`, presumably never hit since this
debug-only console plugin only loads under `--debug`.

Verified via a real launch with all warnings enabled: these symbols
are completely gone from the warning list, no new errors.

Follow-ups, not included here: `GObject.SIGNAL_RUN_FIRST`/
`PARAM_READWRITE` → `GObject.SignalFlags`/`ParamFlags`, the
`PyGTKDeprecationWarning` positional-constructor-argument warnings,
and a harder tier (`Gtk.Table`, style/CSS-based widget deprecations,
custom cell-renderer drawing) that needs real behavioral verification
rather than a mechanical rename.