### PR TITLE
Migrate GObject.SIGNAL_RUN_FIRST/PARAM_READWRITE to SignalFlags/ParamFlags

### DIFF
--- a/virtaal/controllers/checkscontroller.py
+++ b/virtaal/controllers/checkscontroller.py
@@ -20,8 +20,7 @@
 
 import logging
 
-from gi.repository import GLib
-from gi.repository.GObject import SIGNAL_RUN_FIRST
+from gi.repository import GLib, GObject
 
 from virtaal.common import GObjectWrapper
 from .basecontroller import BaseController
@@ -83,8 +82,8 @@ class ChecksController(BaseController):
 
     __gtype_name__ = 'ChecksController'
     __gsignals__ = {
-        'checker-set':  (SIGNAL_RUN_FIRST, None, (object,)),
-        'unit-checked': (SIGNAL_RUN_FIRST, None, (object, object, object))
+        'checker-set':  (GObject.SignalFlags.RUN_FIRST, None, (object,)),
+        'unit-checked': (GObject.SignalFlags.RUN_FIRST, None, (object, object, object))
     }
 
     CHECK_TIMEOUT = 500

--- a/virtaal/controllers/cursor.py
+++ b/virtaal/controllers/cursor.py
@@ -21,7 +21,7 @@
 import logging
 from bisect import bisect_left
 
-from gi.repository.GObject import SIGNAL_RUN_FIRST
+from gi.repository import GObject
 
 from virtaal.common import GObjectWrapper
 
@@ -37,8 +37,8 @@ class Cursor(GObjectWrapper):
     __gtype_name__ = "Cursor"
 
     __gsignals__ = {
-        "cursor-changed": (SIGNAL_RUN_FIRST, None, ()),
-        "cursor-empty":   (SIGNAL_RUN_FIRST, None, ()),
+        "cursor-changed": (GObject.SignalFlags.RUN_FIRST, None, ()),
+        "cursor-empty":   (GObject.SignalFlags.RUN_FIRST, None, ()),
     }
 
 

--- a/virtaal/controllers/langcontroller.py
+++ b/virtaal/controllers/langcontroller.py
@@ -20,7 +20,7 @@
 
 import os
 
-from gi.repository.GObject import SIGNAL_RUN_FIRST
+from gi.repository import GObject
 
 from virtaal.common import GObjectWrapper, pan_app
 from virtaal.models.langmodel import LanguageModel
@@ -34,8 +34,8 @@ class LanguageController(BaseController):
 
     __gtype_name__ = 'LanguageController'
     __gsignals__ = {
-        'source-lang-changed': (SIGNAL_RUN_FIRST, None, (str,)),
-        'target-lang-changed': (SIGNAL_RUN_FIRST, None, (str,)),
+        'source-lang-changed': (GObject.SignalFlags.RUN_FIRST, None, (str,)),
+        'target-lang-changed': (GObject.SignalFlags.RUN_FIRST, None, (str,)),
     }
 
     NUM_RECENT = 5

--- a/virtaal/controllers/plugincontroller.py
+++ b/virtaal/controllers/plugincontroller.py
@@ -22,8 +22,8 @@ import logging
 import os
 import sys
 
-from gi.repository import GLib
-from gi.repository.GObject import SIGNAL_RUN_FIRST, TYPE_PYOBJECT
+from gi.repository import GLib, GObject
+from gi.repository.GObject import TYPE_PYOBJECT
 
 from virtaal.common import pan_app, GObjectWrapper
 from virtaal.common.utils import get_unicode
@@ -44,8 +44,8 @@ class PluginController(BaseController):
 
     __gtype_name__ = 'PluginController'
     __gsignals__ = {
-        'plugin-enabled':  (SIGNAL_RUN_FIRST, None, (TYPE_PYOBJECT,)),
-        'plugin-disabled': (SIGNAL_RUN_FIRST, None, (TYPE_PYOBJECT,)),
+        'plugin-enabled':  (GObject.SignalFlags.RUN_FIRST, None, (TYPE_PYOBJECT,)),
+        'plugin-disabled': (GObject.SignalFlags.RUN_FIRST, None, (TYPE_PYOBJECT,)),
     }
 
     # The following class variables are set for the main plug-in controller.

--- a/virtaal/plugins/tm/tmwidgets.py
+++ b/virtaal/plugins/tm/tmwidgets.py
@@ -167,7 +167,7 @@ class TMSourceColRenderer(Gtk.CellRenderer):
             GObject.TYPE_PYOBJECT,
             "The match data.",
             "The match data that this renderer is currently handling",
-            GObject.PARAM_READWRITE
+            GObject.ParamFlags.READWRITE
         ),
     }
 
@@ -234,7 +234,7 @@ class TMMatchRenderer(Gtk.CellRenderer):
             GObject.TYPE_PYOBJECT,
             "The match data.",
             "The match data that this renderer is currently handling",
-            GObject.PARAM_READWRITE
+            GObject.ParamFlags.READWRITE
         ),
     }
 

--- a/virtaal/views/prefsview.py
+++ b/virtaal/views/prefsview.py
@@ -20,7 +20,7 @@
 
 from gi.repository import Gtk, Gdk
 from gi.repository import Pango
-from gi.repository.GObject import SIGNAL_RUN_FIRST
+from gi.repository import GObject
 
 from virtaal.common import GObjectWrapper, pan_app
 from virtaal.views.widgets.selectview import SelectView
@@ -32,7 +32,7 @@ class PreferencesView(BaseView, GObjectWrapper):
 
     __gtype_name__ = 'PreferencesView'
     __gsignals__ = {
-        'prefs-done': (SIGNAL_RUN_FIRST, None, ()),
+        'prefs-done': (GObject.SignalFlags.RUN_FIRST, None, ()),
     }
 
     # INITIALIZERS #

--- a/virtaal/views/unitview.py
+++ b/virtaal/views/unitview.py
@@ -21,8 +21,8 @@
 import logging
 import re
 
-from gi.repository import GLib, Gtk, Gdk
-from gi.repository.GObject import PARAM_READWRITE, SIGNAL_RUN_FIRST, TYPE_PYOBJECT
+from gi.repository import GLib, GObject, Gtk, Gdk
+from gi.repository.GObject import TYPE_PYOBJECT
 from translate.lang import factory
 
 from virtaal.common import GObjectWrapper
@@ -38,18 +38,18 @@ class UnitView(Gtk.EventBox, GObjectWrapper, Gtk.CellEditable, BaseView):
 
     __gtype_name__ = "UnitView"
     __gsignals__ = {
-        'delete-text':    (SIGNAL_RUN_FIRST, None, (TYPE_PYOBJECT, TYPE_PYOBJECT, int, int, TYPE_PYOBJECT, int)),
-        'insert-text':    (SIGNAL_RUN_FIRST, None, (TYPE_PYOBJECT, int, TYPE_PYOBJECT, int)),
-        'paste-start':    (SIGNAL_RUN_FIRST, None, (TYPE_PYOBJECT, TYPE_PYOBJECT, int)),
-        'modified':       (SIGNAL_RUN_FIRST, None, ()),
-        'unit-done':      (SIGNAL_RUN_FIRST, None, (TYPE_PYOBJECT,)),
-        'targets-created':(SIGNAL_RUN_FIRST, None, (TYPE_PYOBJECT,)),
-        'sources-created':(SIGNAL_RUN_FIRST, None, (TYPE_PYOBJECT,)),
-        'target-focused': (SIGNAL_RUN_FIRST, None, (int,)),
-        'textview-language-changed': (SIGNAL_RUN_FIRST, None, (TYPE_PYOBJECT, TYPE_PYOBJECT)),
+        'delete-text':    (GObject.SignalFlags.RUN_FIRST, None, (TYPE_PYOBJECT, TYPE_PYOBJECT, int, int, TYPE_PYOBJECT, int)),
+        'insert-text':    (GObject.SignalFlags.RUN_FIRST, None, (TYPE_PYOBJECT, int, TYPE_PYOBJECT, int)),
+        'paste-start':    (GObject.SignalFlags.RUN_FIRST, None, (TYPE_PYOBJECT, TYPE_PYOBJECT, int)),
+        'modified':       (GObject.SignalFlags.RUN_FIRST, None, ()),
+        'unit-done':      (GObject.SignalFlags.RUN_FIRST, None, (TYPE_PYOBJECT,)),
+        'targets-created':(GObject.SignalFlags.RUN_FIRST, None, (TYPE_PYOBJECT,)),
+        'sources-created':(GObject.SignalFlags.RUN_FIRST, None, (TYPE_PYOBJECT,)),
+        'target-focused': (GObject.SignalFlags.RUN_FIRST, None, (int,)),
+        'textview-language-changed': (GObject.SignalFlags.RUN_FIRST, None, (TYPE_PYOBJECT, TYPE_PYOBJECT)),
     }
     __gproperties__ = {
-        'editing-canceled': (bool, 'Editing cancelled', 'Editing was cancelled', False, PARAM_READWRITE),
+        'editing-canceled': (bool, 'Editing cancelled', 'Editing was cancelled', False, GObject.ParamFlags.READWRITE),
     }
 
     first_word_re = re.compile("(?m)(?u)^(<[^>]+>|\\\\[nt]|[\\W$^\n])*(\\b|\\Z)")

--- a/virtaal/views/widgets/label_expander.py
+++ b/virtaal/views/widgets/label_expander.py
@@ -31,7 +31,7 @@ class LabelExpander(Gtk.EventBox):
                      "expanded",
                      "A boolean indicating whether this widget has been expanded to show its contained widget",
                      False,
-                     GObject.PARAM_READWRITE),
+                     GObject.ParamFlags.READWRITE),
     }
 
     def __init__(self, widget, get_text, expanded=False):

--- a/virtaal/views/widgets/popupwidgetbutton.py
+++ b/virtaal/views/widgets/popupwidgetbutton.py
@@ -25,7 +25,7 @@ pop-up window.
 
 from gi.repository import Gdk
 from gi.repository import Gtk
-from gi.repository.GObject import SIGNAL_RUN_FIRST
+from gi.repository import GObject
 
 # XXX: Kudo's to Toms Bauģis <toms.baugis at gmail.com> who wrote the
 #      ActivityEntry widget for the hamster-applet project. A lot of this
@@ -61,8 +61,8 @@ class PopupWidgetButton(Gtk.ToggleButton):
     """Extends a C{Gtk.ToggleButton} to show a given widget in a pop-up window."""
     __gtype_name__ = 'PopupWidgetButton'
     __gsignals__ = {
-        'shown':  (SIGNAL_RUN_FIRST, None, ()),
-        'hidden': (SIGNAL_RUN_FIRST, None, ()),
+        'shown':  (GObject.SignalFlags.RUN_FIRST, None, ()),
+        'hidden': (GObject.SignalFlags.RUN_FIRST, None, ()),
     }
 
     # INITIALIZERS #

--- a/virtaal/views/widgets/selectdialog.py
+++ b/virtaal/views/widgets/selectdialog.py
@@ -19,7 +19,8 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 from gi.repository import Gtk
-from gi.repository.GObject import SIGNAL_RUN_FIRST, TYPE_PYOBJECT
+from gi.repository import GObject
+from gi.repository.GObject import TYPE_PYOBJECT
 
 from virtaal.common import GObjectWrapper
 from .selectview import SelectView
@@ -32,10 +33,10 @@ class SelectDialog(GObjectWrapper):
 
     __gtype_name__ = 'SelectDialog'
     __gsignals__ = {
-        'item-enabled':   (SIGNAL_RUN_FIRST, None, (TYPE_PYOBJECT,)),
-        'item-disabled':  (SIGNAL_RUN_FIRST, None, (TYPE_PYOBJECT,)),
-        'item-selected':  (SIGNAL_RUN_FIRST, None, (TYPE_PYOBJECT,)),
-        'selection-done': (SIGNAL_RUN_FIRST, None, (TYPE_PYOBJECT,)),
+        'item-enabled':   (GObject.SignalFlags.RUN_FIRST, None, (TYPE_PYOBJECT,)),
+        'item-disabled':  (GObject.SignalFlags.RUN_FIRST, None, (TYPE_PYOBJECT,)),
+        'item-selected':  (GObject.SignalFlags.RUN_FIRST, None, (TYPE_PYOBJECT,)),
+        'selection-done': (GObject.SignalFlags.RUN_FIRST, None, (TYPE_PYOBJECT,)),
     }
 
     # INITIALIZERS #

--- a/virtaal/views/widgets/selectview.py
+++ b/virtaal/views/widgets/selectview.py
@@ -21,7 +21,8 @@
 from locale import strxfrm
 
 from gi.repository import Gtk
-from gi.repository.GObject import SIGNAL_RUN_FIRST, TYPE_PYOBJECT
+from gi.repository import GObject
+from gi.repository.GObject import TYPE_PYOBJECT
 
 from virtaal.common import GObjectWrapper
 from virtaal.views.widgets.cellrendererwidget import CellRendererWidget
@@ -43,9 +44,9 @@ class SelectView(Gtk.TreeView, GObjectWrapper):
 
     __gtype_name__ = 'SelectView'
     __gsignals__ = {
-        'item-enabled':  (SIGNAL_RUN_FIRST, None, (TYPE_PYOBJECT,)),
-        'item-disabled': (SIGNAL_RUN_FIRST, None, (TYPE_PYOBJECT,)),
-        'item-selected': (SIGNAL_RUN_FIRST, None, (TYPE_PYOBJECT,)),
+        'item-enabled':  (GObject.SignalFlags.RUN_FIRST, None, (TYPE_PYOBJECT,)),
+        'item-disabled': (GObject.SignalFlags.RUN_FIRST, None, (TYPE_PYOBJECT,)),
+        'item-selected': (GObject.SignalFlags.RUN_FIRST, None, (TYPE_PYOBJECT,)),
     }
 
     CONTENT_VBOX = 'vb_content'

--- a/virtaal/views/widgets/storecellrenderer.py
+++ b/virtaal/views/widgets/storecellrenderer.py
@@ -114,14 +114,14 @@ class StoreCellRenderer(Gtk.CellRenderer):
             object,
             "The unit",
             "The unit that this renderer is currently handling",
-            GObject.PARAM_READWRITE
+            GObject.ParamFlags.READWRITE
         ),
         "editable": (
             bool,
             "editable",
             "A boolean indicating whether this unit is currently editable",
             False,
-            GObject.PARAM_READWRITE
+            GObject.ParamFlags.READWRITE
         ),
     }
 


### PR DESCRIPTION
Second of a few smaller PRs cleaning up PyGIDeprecationWarning noise
(see #3376). SIGNAL_RUN_FIRST and PARAM_READWRITE moved under
GObject.SignalFlags/GObject.ParamFlags as part of GObject
Introspection's own API cleanup - the flat names still work but warn
on every __gsignals__/__gproperties__ declaration.

cellrendererwidget.py already used the modern SignalFlags/ParamFlags
API (just aliased to the old names locally) - left untouched, it was
never a warning source.

Verified via a real launch with all warnings enabled: both symbols
are completely gone from the warning list, no new errors.