### PR TITLE
Fix PyGTKDeprecationWarning: use keyword args for GObject constructors

### DIFF
--- a/virtaal/modes/searchmode.py
+++ b/virtaal/modes/searchmode.py
@@ -65,7 +65,7 @@ class SearchMode(BaseMode):
         self.ent_search = Gtk.Entry()
         self.ent_search.connect('changed', self._on_search_text_changed)
         self.ent_search.connect('activate', self._on_entry_activate)
-        self.btn_search = Gtk.Button(_('Search'))
+        self.btn_search = Gtk.Button(label=_('Search'))
         self.btn_search.connect('clicked', self._on_search_clicked)
         self.chk_casesensitive = Gtk.CheckButton.new_with_mnemonic(_('_Case sensitive'))
         self.chk_casesensitive.connect('toggled', self._refresh_proxy)
@@ -82,7 +82,7 @@ class SearchMode(BaseMode):
         self.lbl_replace = Gtk.Label(label=_('Replace with'))
         self.ent_replace = Gtk.Entry()
         # l10n: Button text
-        self.btn_replace = Gtk.Button(_('Replace'))
+        self.btn_replace = Gtk.Button(label=_('Replace'))
         self.btn_replace.connect('clicked', self._on_replace_clicked)
         # l10n: Check box
         self.chk_replace_all = Gtk.CheckButton.new_with_mnemonic(_('Replace _All'))

--- a/virtaal/plugins/tm/tmwidgets.py
+++ b/virtaal/plugins/tm/tmwidgets.py
@@ -34,7 +34,7 @@ class TMWindow(Gtk.Window):
 
     # INITIALIZERS #
     def __init__(self, view):
-        super().__init__(Gtk.WindowType.POPUP)
+        super().__init__(type=Gtk.WindowType.POPUP)
         self.view = view
 
         # set_has_frame is the method of Gtk.Enter, not found on Gtk.Window

--- a/virtaal/views/checksprojview.py
+++ b/virtaal/views/checksprojview.py
@@ -43,7 +43,7 @@ class ChecksProjectView(BaseView):
             checkername = self.controller._checker_code_to_name[checkercode]
             names.append(checkername)
         for checkername in sorted(names, key=locale.strxfrm):
-            mitem = Gtk.MenuItem(checkername)
+            mitem = Gtk.MenuItem(label=checkername)
             mitem.show()
             mitem.connect('activate', self._on_menu_item_activate)
             menu.append(mitem)

--- a/virtaal/views/langview.py
+++ b/virtaal/views/langview.py
@@ -66,7 +66,7 @@ class LanguageView(BaseView):
 
         self.recent_items = []
         for i in range(self.controller.NUM_RECENT):
-            item = Gtk.MenuItem('')
+            item = Gtk.MenuItem(label='')
             item.connect('activate', self._on_pairitem_activated, i)
             self.recent_items.append(item)
         seperator = Gtk.SeparatorMenuItem()

--- a/virtaal/views/unitview.py
+++ b/virtaal/views/unitview.py
@@ -76,7 +76,7 @@ class UnitView(Gtk.EventBox, GObjectWrapper, Gtk.CellEditable, BaseView):
         self.connect('key-press-event', self._on_key_press_event)
         # We automatically inherrit the tooltip from the Treeview, so we have
         # to show our own custom one to not have a tooltip obscuring things
-        invisible_tooltip = Gtk.Window(Gtk.WindowType.POPUP)
+        invisible_tooltip = Gtk.Window(type=Gtk.WindowType.POPUP)
         invisible_tooltip.resize(1,1)
         invisible_tooltip.set_opacity(0)
         self.set_tooltip_window(invisible_tooltip)

--- a/virtaal/views/widgets/listnav.py
+++ b/virtaal/views/widgets/listnav.py
@@ -62,8 +62,8 @@ class ListNavigator(Gtk.HBox):
         # Create widgets
         self.btn_back = Gtk.Button()
         self.btn_forward = Gtk.Button()
-        self.btn_back.add(Gtk.Arrow(Gtk.ArrowType.LEFT, Gtk.ShadowType.NONE))
-        self.btn_forward.add(Gtk.Arrow(Gtk.ArrowType.RIGHT, Gtk.ShadowType.NONE))
+        self.btn_back.add(Gtk.Arrow(arrow_type=Gtk.ArrowType.LEFT, shadow_type=Gtk.ShadowType.NONE))
+        self.btn_forward.add(Gtk.Arrow(arrow_type=Gtk.ArrowType.RIGHT, shadow_type=Gtk.ShadowType.NONE))
 
         self.tvw_items, self.lst_items = self._init_treeview()
         frame = Gtk.Frame()


### PR DESCRIPTION
Third of a few smaller PRs cleaning up PyGIDeprecationWarning/
PyGTKDeprecationWarning noise (see #3376, #3377). PyGObject's own
initializer deprecation: positional arguments to a GObject constructor
are ambiguous once a class has GObject properties, since property-based
construction has no fixed positional order - keyword arguments only.

`Gtk.Button(label=...)`, `Gtk.MenuItem(label=...)`,
`Gtk.Window(type=...)`, `Gtk.Arrow(arrow_type=..., shadow_type=...)` -
all straightforward, each constructor's own property names.

Verified via a real launch with all warnings enabled: this class of
warning is completely gone, no new errors.

Remaining tier, not included here (needs real behavioral verification,
not a mechanical rename): `Gtk.Table`, style/CSS-based widget
deprecations (`Gtk.StyleContext.get_font`/`get_background_color`,
`Gtk.Widget.modify_fg`/`modify_font`/`override_background_color`/
`reparent`/`get_child_requisition`/`size_request`/`get_style`,
`Gtk.paint_layout`, `Gtk.TreeView.set_rules_hint`,
`Gtk.ScrolledWindow.add_with_viewport`, `Gtk.Window.set_opacity`).