### PR TITLE
flatpak: fix appstreamcli duplicate-component error

### DIFF
--- a/devsupport/packaging/flatpak/io.github.translate.Virtaal.yml
+++ b/devsupport/packaging/flatpak/io.github.translate.Virtaal.yml
@@ -34,6 +34,14 @@ modules:
       # directly, which needs it already installed.
       - pip3 install --verbose --exists-action=i --no-build-isolation
         --prefix=${FLATPAK_DEST} .
+      # setup.py's own Linux data_files (this build is a real Linux
+      # install) already dropped plain-named virtaal.desktop/
+      # virtaal.metainfo.xml here - both now carry the same <id>
+      # io.github.translate.Virtaal as the renamed copies installed
+      # below, and appstreamcli compose fails with duplicate-component
+      # if both are left in place.
+      - rm -f ${FLATPAK_DEST}/share/applications/virtaal.desktop
+        ${FLATPAK_DEST}/share/metainfo/virtaal.metainfo.xml
       # share/applications/virtaal.desktop and share/metainfo/
       # virtaal.metainfo.xml are ./maketranslations' real,
       # already-translated output (run on the host before this build -


### PR DESCRIPTION
build-flatpak got past the earlier fluent.syntax gap (#3374) and hit
a new failure: appstreamcli compose errors with duplicate-component
for io.github.translate.Virtaal.

Root cause: this is a real Linux build inside the sandbox, so
setup.py's own Linux data_files also installs plain-named
virtaal.desktop/virtaal.metainfo.xml, alongside the manifest's own
renamed io.github.translate.Virtaal.* copies installed separately -
both now carry the same `<id>` internally, since the metainfo
modernization made the id independent of filename.

Removes the plain-named copies right after `pip3 install .`, before
installing the renamed ones. Verified directly (forcing setup.py's
sys.platform check, since the sandbox build itself can't be
reproduced on macOS) that its glob really does pick up both
plain-named files on a real Linux build.