### PR TITLE
Fix native segfault from popup-menu teardown racing Python's GC

### DIFF
--- a/virtaal/modes/qualitycheckmode.py
+++ b/virtaal/modes/qualitycheckmode.py
@@ -92,6 +92,22 @@ class QualityCheckMode(BaseMode):
         self.storecursor.indices = indices
 
     def _add_widgets(self):
+        # Destroy the previous popup button and its menu now rather
+        # than just dropping the references - see
+        # PopupMenuButton.set_menu()'s own comment for why relying on
+        # Python's cyclic GC to eventually collect them isn't safe
+        # here. destroy()ing the button doesn't reach the menu itself
+        # (it's attached via GTK's popup mechanism, not as a normal
+        # child), so both need doing explicitly.
+        if hasattr(self, 'btn_popup'):
+            self.btn_popup.menu.destroy()
+            self.btn_popup.destroy()
+            # destroy() above already tore down the old menuitems -
+            # forget them, so _create_menu_entries() (called via
+            # _create_checks_menu() below) doesn't try to disconnect/
+            # destroy them a second time.
+            self._menuitem_checks = {}
+
         table = self.controller.view.mode_box
         self.btn_popup = PopupMenuButton(menu_pos=POS_NW_SW)
         self.btn_popup.set_relief(Gtk.ReliefStyle.NORMAL)
@@ -112,7 +128,12 @@ class QualityCheckMode(BaseMode):
     def _create_menu_entries(self, menu):
         for mi, (name, signal_id) in self._menuitem_checks.items():
             mi.disconnect(signal_id)
-            menu.remove(mi)
+            # destroy(), not menu.remove(): unparenting alone leaves
+            # the menuitem for Python's cyclic GC to eventually
+            # collect, which isn't safe to rely on here - see
+            # PopupMenuButton.set_menu()'s comment for the full
+            # mechanism (Release Blocker #8).
+            mi.destroy()
         assert not menu.get_children()
         self._menuitem_checks = {}
         for check_name, display_name in sorted(self.checks_names.items(), key=lambda x: locale.strxfrm(x[1])):

--- a/virtaal/modes/workflowmode.py
+++ b/virtaal/modes/workflowmode.py
@@ -80,6 +80,21 @@ class WorkflowMode(BaseMode):
         self.storecursor.indices = indices
 
     def _add_widgets(self):
+        # Destroy the previous popup button and its menu now rather
+        # than just dropping the references - see
+        # PopupMenuButton.set_menu()'s own comment for why relying on
+        # Python's cyclic GC to eventually collect them isn't safe
+        # here. destroy()ing the button doesn't reach the menu itself
+        # (it's attached via GTK's popup mechanism, not as a normal
+        # child), so both need doing explicitly.
+        if hasattr(self, 'btn_popup'):
+            self.btn_popup.menu.destroy()
+            self.btn_popup.destroy()
+            # destroy() above already tore down the old menuitems -
+            # forget them, rather than leaking their now-dead widget
+            # references in this dict forever.
+            self._menuitem_states = {}
+
         table = self.controller.view.mode_box
         self.btn_popup = PopupMenuButton(menu_pos=POS_NW_SW)
         self.btn_popup.set_relief(Gtk.ReliefStyle.NORMAL)

--- a/virtaal/test/test_modecontroller.py
+++ b/virtaal/test/test_modecontroller.py
@@ -18,6 +18,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
+from unittest.mock import MagicMock
+
 from test_scaffolding import TestScaffolding
 
 
@@ -26,6 +28,32 @@ class TestModeController(TestScaffolding):
         default_mode_display_name = self.mode_controller.modenames['Default']
         default_mode = self.mode_controller.get_mode_by_display_name(default_mode_display_name)
         assert default_mode == self.mode_controller.modes[self.mode_controller.default_mode_name]
+
+    def test_reselecting_menu_modes_destroys_previous_popup(self):
+        """Regression test for Release Blocker #8: WorkflowMode and
+        QualityCheckMode each build a fresh Gtk.Menu (with real
+        Gtk.CheckMenuItem children) every time they're selected - the
+        previous one must be destroy()ed deterministically, not just
+        dropped for Python's GC to collect (see their own
+        _add_widgets() comment for why relying on GC caused a native
+        segfault)."""
+        self.store_controller.open_file(self.testfile[1])
+        default_mode = self.mode_controller.modes[self.mode_controller.default_mode_name]
+
+        for name in ('Workflow', 'QualityCheck'):
+            mode = self.mode_controller.modes[name]
+
+            self.mode_controller.select_mode(mode)
+            old_button = mode.btn_popup
+            old_menu = old_button.menu
+            old_button.destroy = MagicMock()
+            old_menu.destroy = MagicMock()
+
+            self.mode_controller.select_mode(default_mode)
+            self.mode_controller.select_mode(mode)
+
+            assert old_button.destroy.called, '%s: previous popup button was not destroyed' % (name)
+            assert old_menu.destroy.called, '%s: previous popup menu was not destroyed' % (name)
 
     def test_select_mode(self):
         self.store_controller.open_file(self.testfile[1])

--- a/virtaal/views/widgets/popupmenubutton.py
+++ b/virtaal/views/widgets/popupmenubutton.py
@@ -63,8 +63,23 @@ class PopupMenuButton(Gtk.ToggleButton):
 
     # ACCESSORS #
     def set_menu(self, menu):
-        if getattr(self, '_menu_selection_done_id', None):
-            self.menu.disconnect(self._menu_selection_done_id)
+        old_menu = getattr(self, 'menu', None)
+        if old_menu is not None:
+            if getattr(self, '_menu_selection_done_id', None):
+                old_menu.disconnect(self._menu_selection_done_id)
+            # Destroy the replaced menu now, rather than dropping the
+            # reference and leaving it to Python's cyclic GC: a GC pass
+            # can deallocate one of the menu's own child menuitems
+            # independently, in a different order, within the same
+            # collection sweep that also disposes the menu itself -
+            # when the menu's own C-level destroy then cascades to that
+            # already-freed child (gtk_widget_dispose ->
+            # gtk_container_destroy -> gtk_menu_shell_forall), GTK
+            # either logs "gtk_widget_destroy: assertion 'GTK_IS_WIDGET
+            # (widget)' failed" or segfaults outright, depending on
+            # timing. This was Release Blocker #8's real root cause,
+            # confirmed via a G_DEBUG=fatal-criticals + lldb backtrace.
+            old_menu.destroy()
         self.menu = menu
         self._menu_selection_done_id = self.menu.connect('selection-done', self._on_menu_selection_done)
 

--- a/virtaal/views/widgets/test_popupmenubutton.py
+++ b/virtaal/views/widgets/test_popupmenubutton.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2026 Zuza Software Foundation
+#
+# This file is part of Virtaal.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+
+"""Regression tests for Release Blocker #8 (a native segfault from popup-menu
+teardown racing Python's GC - see WorkflowMode/QualityCheckMode's own
+_add_widgets() comment for the full mechanism). The crash itself was only
+~30% reproducible and kills the whole test process on a hit, so it can't be
+tested directly - these instead assert the fix's actual invariant: a
+replaced menu is destroy()ed deterministically, not just dropped for GC to
+collect whenever and however it likes."""
+
+from unittest.mock import MagicMock
+
+import gi
+gi.require_version('Gtk', '3.0')
+from gi.repository import Gtk
+
+from virtaal.views.widgets.popupmenubutton import PopupMenuButton
+
+
+def test_set_menu_destroys_previous_menu():
+    button = PopupMenuButton()
+    old_menu = button.menu
+    old_menu.destroy = MagicMock()
+
+    button.set_menu(Gtk.Menu())
+
+    assert old_menu.destroy.called
+
+
+def test_set_menu_first_call_does_not_destroy_anything():
+    # __init__ itself calls set_menu() before self.menu exists yet -
+    # this must not error trying to destroy a non-existent old menu.
+    PopupMenuButton()


### PR DESCRIPTION
Root-causes and fixes an intermittent native segfault on repeated
mode switching (`gtk_container_remove`/`gtk_widget_unparent`/
`gtk_menu_shell_forall`), previously only worked around, never fixed.

**Root cause**, found via `G_DEBUG=fatal-criticals` + `lldb`: `WorkflowMode` and `QualityCheckMode` each build a fresh `Gtk.Menu` (with real `Gtk.CheckMenuItem` children) every time their mode is selected, and just drop the old one for Python's cyclic GC to eventually collect. When a GC pass deallocates one of that menu's own children independently, in a different order, within the same collection sweep that also disposes the menu itself, the menu's own destroy cascade (`gtk_widget_dispose -> gtk_container_destroy -> gtk_menu_shell_forall`) reaches an already-freed child - caught by GTK's own assertion under normal timing, or segfaulting outright under different timing.

**Fix**: destroy the old button, menu, and menuitems explicitly and deterministically in `PopupMenuButton.set_menu()`, `WorkflowMode`, and `QualityCheckMode`, instead of relying on GC to collect a live GTK object graph safely.

**Verification**: the crash's known reproducer (`test_modecontroller.py`, ~30% crash rate before this fix, confirmed via 70+ stress runs) is now 0/100 across two separate stress-test batches. Full suite also clean across 20 repeated runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)