### PR TITLE
Add in-process UI fuzzer for crash hardening

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,228 @@
+name: UI fuzzing
+
+# Not a pass/fail gate on every push - see
+# FEATURE-CRASH-HARDENING.md's "Where this runs". Runs Virtaal through
+# varied, randomised UI interaction well beyond what the pytest suite
+# covers, on a schedule, to shake out more instances of Release
+# Blocker #8's pattern (a live GTK object graph torn down in a way
+# that isn't safe against Python's own garbage collection) before a
+# release does. A red run here means a real native crash was found -
+# check the uploaded log/backtrace artifact, it's not a flaky test to
+# just re-run.
+
+on:
+  schedule:
+    - cron: "0 3 * * *" # 03:00 UTC nightly
+  workflow_dispatch:
+    inputs:
+      duration_seconds:
+        description: "How long to fuzz for, per platform (seconds)"
+        type: number
+        default: 600
+
+jobs:
+  fuzz-linux:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: true
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.x"
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            gdb \
+            gir1.2-gtk-3.0 \
+            gir1.2-gtkspell3-3.0 \
+            gobject-introspection \
+            libcairo2-dev \
+            libenchant-2-dev \
+            libgirepository-2.0-dev \
+            libglib2.0-dev \
+            libgnutls28-dev \
+            pkg-config \
+            python3-dev \
+            xvfb
+
+      - name: Install Python dependencies
+        run: |
+          pip install --upgrade pip
+          pip install setuptools wheel
+          pip install translate-toolkit
+          pip install pygobject
+          pip install pyenchant
+
+      - name: Install virtaal
+        run: pip install --no-build-isolation .
+
+      - name: Fuzz
+        run: |
+          xvfb-run -a --server-args="-screen 0 1024x768x24" \
+            devsupport/testing/fuzz/run_fuzz.sh \
+            --duration-seconds "${{ inputs.duration_seconds || 600 }}" \
+            --log fuzz-linux.log
+        env:
+          PYTHONFAULTHANDLER: "1"
+
+      - name: Upload fuzz log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fuzz-log-linux
+          path: fuzz-linux.log
+          if-no-files-found: ignore
+
+  fuzz-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: true
+
+      - name: Install system dependencies (Homebrew)
+        run: |
+          brew untap aws/tap || true
+          brew install pygobject3 gtk+3 gtk-mac-integration \
+            gobject-introspection cairo pkg-config gettext \
+            enchant gtkspell3
+
+      - name: Create venv with system site-packages
+        run: |
+          python3 -m venv --system-site-packages .venv
+          echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
+
+      - name: Install Python dependencies
+        run: |
+          pip install --upgrade pip
+          pip install setuptools wheel
+          pip install translate-toolkit
+          pip install pyenchant
+
+      - name: Install virtaal
+        run: pip install --no-build-isolation .
+
+      - name: Fuzz
+        run: |
+          devsupport/testing/fuzz/run_fuzz.sh \
+            --duration-seconds "${{ inputs.duration_seconds || 600 }}" \
+            --log fuzz-macos.log
+        env:
+          PYTHONFAULTHANDLER: "1"
+
+      - name: Collect any system crash reports
+        # run_fuzz.sh's lldb backtrace is usually enough on its own,
+        # but macOS's own crash reporter captures the same crash
+        # independently (see the Release Blocker #8 investigation) -
+        # cheap to grab as a second source.
+        if: always()
+        run: |
+          mkdir -p crash-reports
+          cp ~/Library/Logs/DiagnosticReports/Python-*.ips crash-reports/ 2>/dev/null || true
+
+      - name: Upload fuzz log and any crash reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fuzz-log-macos
+          path: |
+            fuzz-macos.log
+            crash-reports/
+          if-no-files-found: ignore
+
+  fuzz-windows:
+    runs-on: windows-latest
+    # See test-windows in ci.yml for why gvsbuild/MSVC, not MSYS2.
+    env:
+      gvsbuild_version: "2026.8.0"
+      CC: cl
+      CXX: cl
+      PKG_CONFIG_PATH: 'C:\gtk\lib\pkgconfig'
+      GI_TYPELIB_PATH: 'C:\gtk\lib\girepository-1.0'
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: true
+
+      - name: Cache GTK3 (gvsbuild)
+        id: cache-gtk
+        uses: actions/cache@v6
+        with:
+          path: C:\gtk
+          key: windows-gvsbuild-${{ env.gvsbuild_version }}
+
+      - name: Download prebuilt GTK3 (gvsbuild)
+        if: steps.cache-gtk.outputs.cache-hit != 'true'
+        shell: pwsh
+        run: |
+          gh release download --repo wingtk/gvsbuild "${{ env.gvsbuild_version }}" -p "GTK3_Gvsbuild_${{ env.gvsbuild_version }}_x64.zip"
+          7z x "GTK3_Gvsbuild_${{ env.gvsbuild_version }}_x64.zip" -oC:\gtk -y
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Add GTK3 to PATH
+        shell: pwsh
+        run: echo "C:\gtk\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - name: Set up MSVC build environment
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Add GTK3 to MSVC build environment
+        shell: pwsh
+        run: |
+          echo "INCLUDE=$env:INCLUDE;C:\gtk\include;C:\gtk\include\cairo;C:\gtk\include\glib-2.0;C:\gtk\include\gobject-introspection-1.0;C:\gtk\lib\glib-2.0\include" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          echo "LIB=$env:LIB;C:\gtk\lib" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.x"
+
+      - name: Restore PKG_CONFIG_PATH after setup-python
+        shell: pwsh
+        run: echo "PKG_CONFIG_PATH=C:\gtk\lib\pkgconfig" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: Ensure GTK3 DLLs are found by Python's extension loader
+        shell: pwsh
+        run: |
+          $sitepkgs = python -c "import sysconfig; print(sysconfig.get_paths()['purelib'])"
+          $content = "import os`nif os.name == 'nt':`n    os.add_dll_directory(r'C:\gtk\bin')`n"
+          Set-Content -Path "$sitepkgs\sitecustomize.py" -Value $content -NoNewline
+
+      - name: Install Python dependencies
+        run: |
+          pip install --upgrade pip
+          pip install setuptools wheel
+          pip install pycairo
+          pip install pygobject
+          pip install translate-toolkit
+          pip install python-Levenshtein
+          pip install pycurl
+          pip install lxml
+          pip install diff_match_patch
+          pip install cheroot
+
+      - name: Install virtaal
+        run: pip install --no-build-isolation .
+
+      - name: Fuzz
+        # No gdb/lldb equivalent readily available here - relies on
+        # faulthandler for the Python-level trace, same as
+        # test-windows in ci.yml. A crash still fails this step (a
+        # native access violation's exit code is never 0), it just
+        # won't have a native backtrace attached.
+        run: |
+          python devsupport/testing/fuzz/fuzz_ui.py --duration-seconds ${{ inputs.duration_seconds || 600 }} --log fuzz-windows.log
+        env:
+          PYTHONFAULTHANDLER: "1"
+
+      - name: Upload fuzz log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fuzz-log-windows
+          path: fuzz-windows.log
+          if-no-files-found: ignore

--- a/devsupport/testing/fuzz/fuzz_ui.py
+++ b/devsupport/testing/fuzz/fuzz_ui.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2026 Zuza Software Foundation
+#
+# This file is part of Virtaal.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+
+"""In-process UI fuzzer - see FEATURE-CRASH-HARDENING.md for the design this
+implements.
+
+Drives Virtaal's real controllers through varied, randomised interaction
+(navigate, switch mode, edit, undo, save, close/reopen, resize) well beyond
+what the pytest suite exercises, to shake out more instances of Release
+Blocker #8's pattern (a live GTK object graph torn down in a way that isn't
+safe against Python's own garbage collection) before a release does, not
+just the one instance already root-caused and fixed there.
+
+A found crash is a real native crash (the process dies, non-zero/negative
+exit code) - this script can't catch that itself, only leave behind enough
+of a trail (a flushed-per-action log, plus faulthandler) to diagnose it
+afterwards. Run it under gdb/lldb (see run_fuzz.sh) for a full backtrace.
+
+Usage:
+    python devsupport/testing/fuzz/fuzz_ui.py [--iterations N] [--seed N]
+        [--duration-seconds N] [--log PATH]
+
+Exit code 0 means it ran the requested iterations/duration without dying -
+not proof of no bugs, just no *native crash* in this run. Python-level
+exceptions raised by an action are caught, logged, and don't stop the run,
+since the goal is coverage of what happens *next*, not a clean stack trace
+for those (pytest's own suite is the place for behavioural correctness).
+"""
+
+import argparse
+import faulthandler
+import os
+import random
+import sys
+import tempfile
+import time
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+sys.path.insert(0, REPO_ROOT)
+
+import gi
+gi.require_version('Gtk', '3.0')
+from gi.repository import Gtk
+
+from virtaal.controllers.maincontroller import MainController
+from virtaal.controllers.storecontroller import StoreController
+from virtaal.controllers.unitcontroller import UnitController
+from virtaal.controllers.undocontroller import UndoController
+from virtaal.controllers.modecontroller import ModeController
+from virtaal.controllers.checkscontroller import ChecksController
+from virtaal.controllers.langcontroller import LanguageController
+
+TESTFILES_DIR = os.path.join(REPO_ROOT, 'devsupport', 'testfiles')
+DEFAULT_TESTFILES = ['workflow.po', 'workflow.xliff', 'workflow.ts', 'checks.po']
+
+# Deliberately excluded for now, see FEATURE-CRASH-HARDENING.md: toggling
+# spellcheck/TM requires main_controller.load_plugins(), which does real
+# network downloads and spawns a tmserver subprocess - too slow/flaky for
+# a tight fuzz loop. A plugin-aware fuzzer is a real, separate follow-up.
+
+
+class Fuzzer:
+    def __init__(self, seed, log_path, testfiles_dir=TESTFILES_DIR):
+        self.rng = random.Random(seed)
+        self.testfiles = [
+            os.path.join(testfiles_dir, name) for name in DEFAULT_TESTFILES
+            if os.path.exists(os.path.join(testfiles_dir, name))
+        ]
+        if not self.testfiles:
+            raise RuntimeError('No test fixtures found under %s' % (testfiles_dir))
+
+        self._log_file = open(log_path, 'a', buffering=1)
+        self._tempdir = tempfile.mkdtemp(prefix='virtaal-fuzz-')
+        self.iteration = 0
+
+        self._build_controllers()
+        self.store_controller.open_file(self.rng.choice(self.testfiles))
+        self._load_current_unit()
+
+        # weight, name, action
+        self.actions = [
+            (30, 'navigate', self._act_navigate),
+            (15, 'switch_mode', self._act_switch_mode),
+            (15, 'edit_target', self._act_edit_target),
+            (10, 'undo', self._act_undo),
+            (10, 'save_temp', self._act_save_temp),
+            (10, 'close_reopen', self._act_close_reopen),
+            (10, 'resize_window', self._act_resize_window),
+        ]
+
+    def _build_controllers(self):
+        # Same construction order as virtaal/test/test_scaffolding.py -
+        # a real, working controller hierarchy, minus pytest.
+        self.main_controller = MainController()
+        self.store_controller = StoreController(self.main_controller)
+        self.unit_controller = UnitController(self.store_controller)
+        self.undo_controller = UndoController(self.main_controller)
+        self.mode_controller = ModeController(self.main_controller)
+        self.checks_controller = ChecksController(self.main_controller)
+        self.lang_controller = LanguageController(self.main_controller)
+
+    def log(self, message):
+        timestamp = time.strftime('%H:%M:%S')
+        line = '%s [%d] %s' % (timestamp, self.iteration, message)
+        print(line)
+        self._log_file.write(line + '\n')
+        self._log_file.flush()
+
+    # ACTIONS #
+    # Each just calls the same real controller methods a user action
+    # (menu click, keyboard shortcut, navigation click) would end up
+    # calling - see each mode/controller's own view code for the real
+    # call site this mirrors.
+
+    def _load_current_unit(self):
+        # Real navigation loads the newly-selected unit for editing via
+        # the treeview's cell renderer (get_unit_celleditor() ->
+        # UnitController.load_unit()) - without a real treeview widget
+        # rendering anything, nothing else does this, so edit_target/
+        # save_temp would otherwise always find no unit loaded.
+        cursor = self.store_controller.cursor
+        unit = cursor and cursor.deref()
+        if unit is not None:
+            self.store_controller.get_unit_celleditor(unit)
+
+    def _act_navigate(self):
+        cursor = self.store_controller.cursor
+        if cursor is None:
+            return
+        offset = self.rng.choice([-100, -5, -1, 1, 5, 100])
+        cursor.move(offset)
+        self._load_current_unit()
+
+    def _act_switch_mode(self):
+        name = self.rng.choice(list(self.mode_controller.modes.keys()))
+        self.mode_controller.select_mode_by_name(name)
+
+    def _act_edit_target(self):
+        unit = self.store_controller.cursor and self.store_controller.cursor.deref()
+        if unit is None:
+            return
+        text = 'fuzz-%d-%s' % (self.iteration, self.rng.choice(['a', 'ab\tcd', '', '<x>y</x>', u'ünïcödé']))
+        self.unit_controller.set_unit_target(0, text)
+
+    def _act_undo(self):
+        self.undo_controller.mnu_undo.activate()
+
+    def _act_save_temp(self):
+        if self.store_controller.store is None:
+            return
+        ext = os.path.splitext(self.store_controller.get_store_filename() or '.po')[1] or '.po'
+        path = os.path.join(self._tempdir, 'fuzz-save-%d%s' % (self.iteration, ext))
+        self.store_controller.save_file(path)
+
+    def _act_close_reopen(self):
+        self.store_controller.close_file()
+        self.store_controller.open_file(self.rng.choice(self.testfiles))
+        self._load_current_unit()
+
+    def _act_resize_window(self):
+        window = self.main_controller.view.main_window
+        window.resize(self.rng.randint(300, 1200), self.rng.randint(200, 900))
+
+    # RUN LOOP #
+
+    def step(self):
+        self.iteration += 1
+        total_weight = sum(weight for weight, _, _ in self.actions)
+        pick = self.rng.uniform(0, total_weight)
+        upto = 0
+        for weight, name, action in self.actions:
+            upto += weight
+            if pick <= upto:
+                self.log(name)
+                try:
+                    action()
+                except Exception as exc:
+                    # A Python-level exception, not a crash - log and
+                    # keep going, we're after native crashes here.
+                    self.log('  exception (non-fatal): %r' % (exc,))
+                break
+
+        # Pump the real GTK main loop so anything the action deferred
+        # (GLib.idle_add/timeout_add, signal emission) actually runs
+        # before the next action - the same interleaving a real user
+        # session has, and exactly the kind of timing Release Blocker
+        # #8 depended on.
+        while Gtk.events_pending():
+            Gtk.main_iteration()
+
+    def run(self, iterations=None, duration_seconds=None):
+        self.log('fuzz run starting: seed reproduces this exact sequence')
+        start = time.monotonic()
+        count = 0
+        while True:
+            if iterations is not None and count >= iterations:
+                break
+            if duration_seconds is not None and time.monotonic() - start >= duration_seconds:
+                break
+            self.step()
+            count += 1
+        self.log('fuzz run completed %d iterations without a native crash' % (count))
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument('--iterations', type=int, default=500,
+                         help='Number of actions to perform (default: 500). Ignored if --duration-seconds is given.')
+    parser.add_argument('--duration-seconds', type=int, default=None,
+                         help='Run for this long instead of a fixed iteration count (for scheduled CI runs).')
+    parser.add_argument('--seed', type=int, default=None,
+                         help='RNG seed - printed at the start of every run so a crash can be replayed exactly.')
+    parser.add_argument('--log', default=None,
+                         help='Path to append the action log to (default: a temp file, path printed at startup).')
+    args = parser.parse_args()
+
+    seed = args.seed if args.seed is not None else random.SystemRandom().randrange(2**32)
+    log_path = args.log or os.path.join(tempfile.gettempdir(), 'virtaal-fuzz-%d.log' % (seed))
+
+    faulthandler.enable()
+    print('seed=%d log=%s' % (seed, log_path))
+
+    fuzzer = Fuzzer(seed=seed, log_path=log_path)
+    fuzzer.run(iterations=None if args.duration_seconds else args.iterations,
+               duration_seconds=args.duration_seconds)
+
+
+if __name__ == '__main__':
+    main()

--- a/devsupport/testing/fuzz/run_fuzz.sh
+++ b/devsupport/testing/fuzz/run_fuzz.sh
@@ -1,0 +1,65 @@
+#!/bin/sh
+# Runs fuzz_ui.py under whichever native debugger is available, so a crash
+# leaves behind a real backtrace instead of just "the process died" - see
+# FEATURE-CRASH-HARDENING.md's "Crash capture" section.
+#
+# Usage: devsupport/testing/fuzz/run_fuzz.sh [fuzz_ui.py arguments]
+#   devsupport/testing/fuzz/run_fuzz.sh --duration-seconds 1200
+#
+# Exit code is fuzz_ui.py's own real exit status (0 = completed without a
+# native crash; 128+signal, e.g. 139, for a crash) - neither gdb nor lldb
+# propagate the inferior's exit code as their own by default, so both
+# branches below extract it explicitly rather than trusting $?.
+
+set -eu
+# shellcheck disable=SC1007  # deliberate: CDPATH= scoped to this one cd
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+fuzz_script="$script_dir/fuzz_ui.py"
+
+PYTHON=${PYTHON:-python3}
+
+if command -v gdb >/dev/null 2>&1; then
+    echo "Running under gdb (Linux crash capture)"
+    # $_exitcode is only set after a normal exit - stays void (and the
+    # "if" below false) if the inferior is still stopped on a fatal
+    # signal instead, in which case "thread apply all bt full" is the
+    # useful output and we exit 1 ourselves.
+    exec gdb -q --batch \
+        -ex run \
+        -ex "thread apply all bt full" \
+        -ex "if \$_exitcode >= 0" \
+        -ex "  quit \$_exitcode" \
+        -ex "end" \
+        -ex "quit 1" \
+        --args "$PYTHON" "$fuzz_script" "$@"
+elif command -v lldb >/dev/null 2>&1; then
+    echo "Running under lldb (macOS crash capture)"
+    # --one-line-on-crash: only fires if the target actually stops on a
+    # signal, unlike gdb's approach above - lldb's batch mode otherwise
+    # halts the command queue on any unexpected stop (see the Release
+    # Blocker #8 investigation for why "bt" alone after "continue"
+    # silently produces nothing).
+    #
+    # lldb's own exit code reflects whether *lldb* ran cleanly, not the
+    # inferior's exit status - "Process N exited with status = C" is
+    # only ever printed to its output, so pull the real status from
+    # there instead of trusting $?. No such line at all means the
+    # inferior is still stopped on a real crash signal (the "bt all"
+    # above already captured it) - treat that as a failure.
+    output=$(mktemp)
+    lldb -b \
+        -k "bt all" \
+        -k "quit" \
+        -o "process launch" \
+        -o "continue" \
+        -- "$PYTHON" "$fuzz_script" "$@" 2>&1 | tee "$output"
+    status_line=$(grep -o 'exited with status = [0-9]*' "$output" | tail -1)
+    rm -f "$output"
+    if [ -n "$status_line" ]; then
+        exit "${status_line##* }"
+    fi
+    exit 1
+else
+    echo "No gdb/lldb found - running plain (relies on faulthandler for any Python-level trace)"
+    exec "$PYTHON" "$fuzz_script" "$@"
+fi


### PR DESCRIPTION
Drives Virtaal's real controllers through varied, randomised interaction (navigate, switch mode, edit target, undo, save to a throwaway temp path, close/reopen, resize) via the actual GTK main loop - well beyond what the pytest suite exercises (23 tests, mostly opening one file and asserting on it) - to find more instances of the pattern behind #3381's fix (a live GTK object graph torn down in a way that isn't safe against Python's own garbage collection) before a release does, not just the one instance already root-caused and fixed there.

- `devsupport/testing/fuzz/fuzz_ui.py` - the fuzzer itself. Each action is a real controller method call (the same ones a menu click/keyboard shortcut/treeview click end up calling), not a screen coordinate, so it's resilient to layout changes. Logs every action, flushed immediately, so a native crash still leaves behind the sequence that caused it. `--seed` makes a run exactly reproducible.
- `devsupport/testing/fuzz/run_fuzz.sh` - wraps it under `gdb` (Linux) or `lldb` (macOS) so a crash produces a real backtrace instead of just "the process died". Both extract the wrapped process's real exit status explicitly, since neither debugger propagates it as its own by default - verified against both a clean run and a deliberately-triggered real segfault.
- `.github/workflows/fuzz.yml` - nightly scheduled job, all three platforms, fixed time budget (default 10 minutes, overridable via `workflow_dispatch`). Not a pass/fail gate on every push - a found crash needs its uploaded log/backtrace artifact reviewed manually.

Verified locally: 3000+ iterations across multiple seeds with zero crashes and zero exceptions (that pattern's own dominant driver is already fixed - see #3381). The fuzzer did catch two real bugs in its own first draft (unit-loading gap causing spurious exceptions on `edit_target`/`save_temp`), fixed before landing here.

Deliberately out of scope for now: TM/spellcheck plugin interaction (`main_controller.load_plugins()` does real network downloads and spawns a subprocess - too slow/flaky for a tight fuzz loop) and packaged-build (frozen .exe/.app) driving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)