### PR TITLE
Fix Alt+Down transfer-from-source corrupting a later unit

### DIFF
--- a/virtaal/test/test_unitcontroller.py
+++ b/virtaal/test/test_unitcontroller.py
@@ -18,7 +18,11 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
+from gi.repository import GLib
+
 from test_scaffolding import TestScaffolding
+
+from virtaal.controllers.placeablescontroller import PlaceablesController
 
 
 class TestUnitController(TestScaffolding):
@@ -40,3 +44,43 @@ class TestUnitController(TestScaffolding):
 
         self.unit_controller.set_unit_target(0, [u'Test',])
         assert str(self.unit_controller.view.targets[0].elem) == u'Test'
+
+    def test_stale_alt_down_does_not_corrupt_a_later_unit(self):
+        """Alt+Down ('transfer from source') defers its copy via
+        GLib.idle_add(). If the loaded unit changes before that runs,
+        it must skip rather than overwrite the new unit with the old
+        one's source text."""
+        if not getattr(self.main_controller, 'placeables_controller', None):
+            PlaceablesController(self.main_controller)
+
+        units = self.trans_store.getunits()
+        unit_a, unit_b = units[1], units[2]
+
+        self.unit_controller.load_unit(unit_a)
+        view = self.unit_controller.view
+        textbox = view.targets[0]
+
+        original_b_target = str(unit_b.target)
+
+        # Intercept GLib.idle_add() rather than pumping the real main
+        # loop - main-loop pumping has hung CI elsewhere in this
+        # codebase. Invoking the captured callback directly tests the
+        # real closure with no main-loop involvement at all.
+        scheduled = []
+        real_idle_add = GLib.idle_add
+        GLib.idle_add = lambda callback, *a, **kw: scheduled.append(callback)
+        try:
+            # Real Alt+Down keypress on unit A.
+            textbox.emit('key-pressed', None, 'alt-down')
+        finally:
+            GLib.idle_add = real_idle_add
+        assert scheduled, 'Alt+Down should have scheduled a deferred copy'
+
+        # Navigate to a different unit before that callback runs.
+        self.unit_controller.load_unit(unit_b)
+        self.store_controller.set_modified(False)
+
+        scheduled[0]()  # run the now-stale callback
+
+        assert str(unit_b.target) == original_b_target
+        assert not self.store_controller.is_modified()

--- a/virtaal/views/unitview.py
+++ b/virtaal/views/unitview.py
@@ -407,7 +407,16 @@ class UnitView(Gtk.EventBox, GObjectWrapper, Gtk.CellEditable, BaseView):
 
             # Alt-Down
             elif eventname == 'alt-down':
-                GLib.idle_add(self.copy_original, textbox)
+                # Guard against the unit changing before this deferred
+                # call runs - copy_original() reads self.unit and
+                # writes into textbox unconditionally, so a stale call
+                # would silently overwrite whatever unit is now loaded.
+                scheduled_unit = self.unit
+                def do_copy_original():
+                    if self.unit is scheduled_unit:
+                        self.copy_original(textbox)
+                    return False
+                GLib.idle_add(do_copy_original)
                 return True
 
             # Shift-Tab


### PR DESCRIPTION
Investigating the spurious modified-marker bug (opening or reopening a file sometimes shows unsaved changes with none made) turned up a concrete, previously-unguarded instance of the same class of bug, but worse than cosmetic.

`GLib.idle_add(self.copy_original, textbox)` (Alt+Down, "transfer from source") had no guard against the loaded unit changing before that deferred callback ran - unlike every other deferred `UnitView` callback already fixed for this bug (`select_index()`'s `change_cursor`, undo's deferred refresh, close's model teardown). `copy_original()` reads `self.unit` and writes into `textbox` unconditionally, so a stale callback silently **overwrites whatever unit is now loaded with the previous unit's source text** and marks it modified - not just a stray marker, real content corruption.

**Reproduced deterministically** (100% across repeated runs): press Alt+Down, navigate to a different unit before the idle callback runs, then let it run - the new unit's target gets overwritten with the old unit's source text.

Fixed by capturing the unit the keypress was scheduled against and skipping the deferred copy if it's since changed, the same pattern already used for the other fixes in this area.

Also fixed something the investigation surfaced along the way, unrelated to the bug itself: the regression test originally used `while Gtk.events_pending(): Gtk.main_iteration()` to drain the idle queue, which hung the full test suite (though not in isolation) - exactly the pumping pattern already proven to hang CI elsewhere in this codebase. Replaced with intercepting and directly invoking the scheduled callback, no main-loop involvement at all - verified hang-free across 5 repeated full-suite runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)