### PR TITLE
Add a local Windows test harness and UTM VM setup docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,8 @@ assets/
 #vim
 .*.swp
 *~
+
+# devsupport/testing/windows/
+# Ephemeral transcripts from Invoke-VirtaalLocalTestPass.ps1 - run
+# records, not something to commit.
+/devsupport/testing/windows/.local-test-runs/

--- a/devsupport/pseudo-translation/generate_pseudo_translation.py
+++ b/devsupport/pseudo-translation/generate_pseudo_translation.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Generates two synthetic gettext locales from po/virtaal.pot, for
+"""Generates synthetic gettext locales from po/virtaal.pot, for
 exercising every translatable string in the UI without an actual
 translation:
 
@@ -11,11 +11,21 @@ translation:
   text itself readable Latin script (an isolate only sets the base
   direction of the run it wraps, it doesn't reorder or transliterate).
   Bracketed too, since the isolate marks alone are invisible.
+- fa: every string's Unicode glyphs visually flipped (podebug's own
+  "flipped" style) - not a real Farsi translation, just tagged with a
+  real RTL-recognised language code so launching under it (LANG=
+  fa_IR.UTF-8 LANGUAGE=fa) exercises actual whole-window RTL mirroring
+  (menu/toolbar/status-bar placement), which pseudo-bidi's isolate
+  marks alone don't necessarily trigger. Harder to read than
+  pseudo-bidi, deliberately - it's testing Pango's real bidi character
+  reordering, not just that embedded bidi runs don't corrupt layout.
 
-Compiled straight into the active environment's own share/locale/, so
-bin/virtaal --pseudo-translation/--pseudo-translation-bidi work with
-no separate install step.
+Compiled straight into the active environment's own share/locale/ by
+default (so bin/virtaal --pseudo-translation/--pseudo-translation-bidi
+work with no separate install step) - pass --localedir to write
+somewhere else instead, e.g. a frozen build's own share/locale/.
 """
+import argparse
 import os
 import sys
 import tempfile
@@ -44,13 +54,19 @@ podebug.podebug.rewrite_bidi = rewrite_bidi
 LOCALES = {
     "pseudo": "bracket",
     "pseudo-bidi": "bidi",
+    "fa": "flipped",
 }
 
 
 def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--localedir", default=None,
+                         help="Where to write share/locale-style output (default: sys.prefix/share/locale)")
+    args = parser.parse_args()
+
     root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
     potfile = os.path.join(root, "po", "virtaal.pot")
-    localedir = os.path.join(sys.prefix, "share", "locale")
+    localedir = args.localedir or os.path.join(sys.prefix, "share", "locale")
 
     for code, rewritestyle in LOCALES.items():
         with tempfile.NamedTemporaryFile(suffix=".po") as tmp_po:

--- a/devsupport/testfiles/plurals-zero.po
+++ b/devsupport/testfiles/plurals-zero.po
@@ -1,0 +1,50 @@
+# A PO file for the *other* plural edge case from plurals.po: a
+# language with nplurals=1 (no plural distinction in the language at
+# all - Japanese, Chinese, Korean, Vietnamese, ... all real examples).
+#
+# plurals.po (nplurals=3, Polish) exercises unitview.py showing *more*
+# target textboxes than the common two-form case; this exercises the
+# opposite: a msgid_plural unit that should still show only *one*
+# target textbox, not silently break or show a leftover second one.
+# The loop that shows/hides target widgets (unitview.py's
+# _layout_update_units(), right above _layout_update_states()) is
+# bounded by nplurals, driven by the file's own Language header via
+# lang_controller.target_lang.nplurals - not by how many msgstr[]
+# entries the raw file happens to have - so this is a real, distinct
+# code path from plurals.po's, not just the same thing under a
+# different language name.
+#
+# Tagged Language: ja (Japanese, nplurals=1, always plural form 0).
+# msgstr[] content is plain, labelled English (not real Japanese),
+# same reasoning as plurals.po/rtl.po - legible to a non-Japanese-
+# reading developer checking a screenshot.
+# Copyright 2026 Zuza Software Foundation
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: translate-devel@lists.sourceforge.net\n"
+"POT-Creation-Date: 2026-08-25 00:00+0000\n"
+"PO-Revision-Date: 2026-08-25 00:00+0000\n"
+"Last-Translator: Virtaal test suite\n"
+"Language-Team: translate-dev@lists.sourceforge.net\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. Only ONE target textbox should appear for this, despite being a
+#. genuine msgid_plural unit - nplurals=1 means no plural distinction.
+msgid "%d file"
+msgid_plural "%d files"
+msgstr[0] "ONLY FORM (nplurals=1, always form 0): %d file(s)"
+
+#. A second plural unit, same reasoning as plurals.po's second one -
+#. confirms navigating between two nplurals=1 plural units works too.
+msgid "%d new message"
+msgid_plural "%d new messages"
+msgstr[0] "ONLY FORM (nplurals=1, always form 0): %d new message(s)"
+
+#. An ordinary, non-plural unit in the same file too.
+msgid "An ordinary, non-plural string in the same file"
+msgstr "An ordinary, non-plural translation"

--- a/devsupport/testfiles/plurals.po
+++ b/devsupport/testfiles/plurals.po
@@ -1,0 +1,58 @@
+# A PO file with genuine msgid_plural units, for testing Virtaal's
+# plural-form handling (unitview.py's target-widget layout: one target
+# textbox per plural form, all shown simultaneously side by side - see
+# _layout_update_states()/the code right above it, gated on
+# unit.hasplural() and lang_controller.target_lang.nplurals). No other
+# fixture under devsupport/testfiles/ or po/ has a genuine
+# msgid_plural unit, so this code path had never been exercised by
+# this test battery before.
+#
+# Tagged Language: pl (Polish) rather than English deliberately -
+# English's nplurals=2 only ever exercises two target textboxes, the
+# same shape as any ordinary non-plural multi-target case. Polish has
+# a real, common nplurals=3 rule (form 0 for n==1, form 1 for small
+# counts ending 2-4, form 2 for everything else) - genuinely exercises
+# a third target textbox no other fixture in this repo reaches.
+# msgstr[] content is plain, labelled English (not real Polish)
+# deliberately, same reasoning as rtl.po's legible-flipped-glyphs
+# choice: a screenshot is directly checkable without needing Polish
+# literacy to confirm which textbox is which form.
+# Copyright 2026 Zuza Software Foundation
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: translate-devel@lists.sourceforge.net\n"
+"POT-Creation-Date: 2026-08-25 00:00+0000\n"
+"PO-Revision-Date: 2026-08-25 00:00+0000\n"
+"Last-Translator: Virtaal test suite\n"
+"Language-Team: translate-dev@lists.sourceforge.net\n"
+"Language: pl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n"
+"%100<10 || n%100>=20) ? 1 : 2);\n"
+
+#. Simple counting example - three genuinely different target textboxes
+#. should appear (form 0: n==1, form 1: n%10 in 2-4, form 2: everything
+#. else), each independently editable.
+msgid "%d file"
+msgid_plural "%d files"
+msgstr[0] "PLURAL FORM 0 (n==1): %d file"
+msgstr[1] "PLURAL FORM 1 (n%10 in 2..4): %d files"
+msgstr[2] "PLURAL FORM 2 (everything else): %d files"
+
+#. A second plural unit - two genuine plural units in one file so
+#. navigating between them (not just viewing the first one) is also
+#. exercised.
+msgid "%d new message"
+msgid_plural "%d new messages"
+msgstr[0] "PLURAL FORM 0 (n==1): %d new message"
+msgstr[1] "PLURAL FORM 1 (n%10 in 2..4): %d new messages"
+msgstr[2] "PLURAL FORM 2 (everything else): %d new messages"
+
+#. An ordinary, non-plural unit too - confirms plural and non-plural
+#. units can sit in the same file and navigate correctly between each
+#. other (a single target textbox for this one, not three).
+msgid "An ordinary, non-plural string in the same file"
+msgstr "An ordinary, non-plural translation"

--- a/devsupport/testfiles/rtl.po
+++ b/devsupport/testfiles/rtl.po
@@ -1,0 +1,58 @@
+# A PO file with synthetic right-to-left target text, for testing
+# Virtaal's bidi text rendering (text direction, mixed-script layout,
+# cursor behaviour) without needing a real Arabic/Hebrew translation.
+#
+# Generated via translate-toolkit's own podebug tool -
+# `--rewrite=flipped` transposes each source
+# string into visually-flipped Unicode glyphs and wraps it in U+202E
+# (RIGHT-TO-LEFT OVERRIDE), which forces genuine RTL rendering in any
+# bidi-aware text widget, the same mechanism a real RTL language
+# triggers, without depending on this checkout actually having real
+# Arabic/Hebrew content. Deliberately not derived from checks.po (a
+# checks-oriented fixture, not meant for this) - a small, purpose-made
+# source file instead, chosen to stress specific real bidi cases:
+# plain RTL flow, embedded LTR numerals within RTL text (numerals stay
+# visually LTR even inside the flipped/RTL string below - a case naive
+# renderers get wrong), an embedded Latin-script word (mixed-script
+# layout), RTL punctuation mirroring, and line-wrapping under RTL.
+#
+# Regenerate by running podebug against a plain (untranslated) source
+# file with these same 5 msgids and --rewrite=flipped.
+# Copyright 2026 Zuza Software Foundation
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: translate-devel@lists.sourceforge.net\n"
+"POT-Creation-Date: 2026-08-25 00:00+0000\n"
+"PO-Revision-Date: 2026-08-25 00:00+0000\n"
+"Last-Translator: Virtaal test suite\n"
+"Language-Team: translate-dev@lists.sourceforge.net\n"
+"Language: en_GB\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. A plain sentence - baseline RTL text flow and cursor behaviour.
+msgid "A simple sentence for testing right-to-left rendering"
+msgstr "‮∀ sıɯdʅǝ sǝuʇǝuɔǝ ɟoɹ ʇǝsʇıuƃ ɹıƃɥʇ-ʇo-ʅǝɟʇ ɹǝupǝɹıuƃ"
+
+#. Embedded numbers - a real bidi stress case (numerals stay LTR inside
+#. RTL text; a naive renderer often gets this wrong).
+msgid "Item number 42 was ordered on 2026-08-25"
+msgstr "‮Iʇǝɯ unɯqǝɹ 42‮ ʍɐs oɹpǝɹǝp ou 2026-08-25"
+
+#. Embedded Latin-script word - mixed-script layout within one string.
+msgid "Please open the Settings menu to continue"
+msgstr "‮Ԁʅǝɐsǝ odǝu ʇɥǝ Sǝʇʇıuƃs ɯǝun ʇo ɔouʇıunǝ"
+
+#. Punctuation-heavy - RTL punctuation mirroring (parentheses, quotes).
+msgid "Is this correct? (Please check the value: \"42\".)"
+msgstr "‮Is ʇɥıs ɔoɹɹǝɔʇ¿ (Ԁʅǝɐsǝ ɔɥǝɔʞ ʇɥǝ ʌɐʅnǝ: „42‮„˙)"
+
+#. A longer paragraph-style string - wrapping behaviour under RTL.
+msgid "This is a longer piece of text meant to wrap across more than one line, to check how the editor handles line-wrapping and cursor movement in right-to-left text."
+msgstr ""
+"‮⊥ɥıs ıs ɐ ʅouƃǝɹ dıǝɔǝ oɟ ʇǝxʇ ɯǝɐuʇ ʇo ʍɹɐd ɐɔɹoss ɯoɹǝ ʇɥɐu ouǝ ʅıuǝ´ ʇo "
+"ɔɥǝɔʞ ɥoʍ ʇɥǝ ǝpıʇoɹ ɥɐupʅǝs ʅıuǝ-ʍɹɐddıuƃ ɐup ɔnɹsoɹ ɯoʌǝɯǝuʇ ıu ɹıƃɥʇ-ʇo-"
+"ʅǝɟʇ ʇǝxʇ˙"

--- a/devsupport/testing/windows/Enable-VirtaalRtlDebug.ps1
+++ b/devsupport/testing/windows/Enable-VirtaalRtlDebug.ps1
@@ -1,12 +1,13 @@
 <#
 .SYNOPSIS
-Compiles devsupport/testing/rtl-debug.po (a synthetic RTL translation of
-Virtaal's own UI catalog - see that file's own header for what it is and
-why) and installs it into a built/installed virtaal.exe's own directory,
-so the app can be launched under it to check whether the whole UI chrome
-(menus, toolbar, status bar - not just editor text) actually mirrors
-under a right-to-left language. Doesn't launch Virtaal itself - that's
-a manual step, since judging "does this look correctly mirrored" needs
+Generates the synthetic RTL debug catalog (devsupport/pseudo-
+translation/generate_pseudo_translation.py's "fa" locale - see that
+script's own docstring for what it is and why) directly into a
+built/installed virtaal.exe's own directory, so the app can be
+launched under it to check whether the whole UI chrome (menus,
+toolbar, status bar - not just editor text) actually mirrors under a
+right-to-left language. Doesn't launch Virtaal itself - that's a
+manual step, since judging "does this look correctly mirrored" needs
 a human looking at it, not something this battery's usual title-bar/
 log-content checks can verify.
 
@@ -46,30 +47,23 @@ if (-not (Test-Path $ExePath)) {
 }
 
 $exeDir = Split-Path -Parent (Resolve-Path $ExePath)
-$targetDir = Join-Path $exeDir "share\locale\fa\LC_MESSAGES"
-New-Item -ItemType Directory -Path $targetDir -Force | Out-Null
-$targetMo = Join-Path $targetDir "virtaal.mo"
+$localeDir = Join-Path $exeDir "share\locale"
 
-# Same pure-Python compiler setup.py's own mo-compile step uses
-# (translate.tools.pocompile.convertmo) - no external msgfmt.exe needed,
-# guaranteed available anywhere Virtaal itself can run since
-# translate-toolkit is already a hard dependency.
+# Same generator bin/virtaal --pseudo-translation/--pseudo-translation-bidi
+# use for a dev checkout - --localedir points it at the frozen bundle's
+# own directory instead. Also (harmlessly) writes the pseudo/pseudo-bidi
+# locales alongside "fa" - a small bonus, not a cost.
 $py = ".\.venv\Scripts\python.exe"
 if (-not (Test-Path $py)) { $py = "python" }
-& $py -c @"
-from translate.tools.pocompile import convertmo
-with open('devsupport/testing/rtl-debug.po', encoding='utf-8') as inf, open(r'$targetMo', 'w') as outf:
-    convertmo(inf, outf, None)
-print('Compiled', len(open(r'$targetMo', 'rb').read()), 'bytes to', r'$targetMo')
-"@
+& $py devsupport\pseudo-translation\generate_pseudo_translation.py --localedir $localeDir
 if ($LASTEXITCODE -ne 0) {
-    Write-Host "::error::Compiling rtl-debug.po failed - see above"
+    Write-Host "::error::generate_pseudo_translation.py failed - see above"
     exit 1
 }
 
 Write-Host ""
-Write-Host "Installed the synthetic RTL debug catalog at:"
-Write-Host "  $targetMo"
+Write-Host "Installed the synthetic RTL debug catalog under:"
+Write-Host "  $localeDir\fa\LC_MESSAGES\virtaal.mo"
 Write-Host ""
 Write-Host "To actually see it, launch manually (not automated - this needs a human looking at the result):"
 Write-Host "  `$env:LANG = `"fa_IR.UTF-8`""

--- a/devsupport/testing/windows/Enable-VirtaalRtlDebug.ps1
+++ b/devsupport/testing/windows/Enable-VirtaalRtlDebug.ps1
@@ -1,0 +1,79 @@
+<#
+.SYNOPSIS
+Compiles devsupport/testing/rtl-debug.po (a synthetic RTL translation of
+Virtaal's own UI catalog - see that file's own header for what it is and
+why) and installs it into a built/installed virtaal.exe's own directory,
+so the app can be launched under it to check whether the whole UI chrome
+(menus, toolbar, status bar - not just editor text) actually mirrors
+under a right-to-left language. Doesn't launch Virtaal itself - that's
+a manual step, since judging "does this look correctly mirrored" needs
+a human looking at it, not something this battery's usual title-bar/
+log-content checks can verify.
+
+Windows specifically (not macOS/Linux): virtaal/common/pan_app.py only
+calls fix_libintl() - the piece that binds GLib/GTK's own C-level
+gettext lookup to this app's own share/locale directory, which is what
+.ui-file-defined widget translations (and, more importantly here, GTK's
+own RTL direction detection) actually depend on - when
+`os.name == 'nt' and getattr(sys, 'frozen', False)`. A frozen Windows
+build is the only place this mechanism is actually wired up and
+exercised; reproducing this on a raw dev checkout on another platform
+would be fighting unrelated, unexercised complexity.
+
+.PARAMETER ExePath
+Path to an already-built/installed virtaal.exe (e.g.
+.\dist\virtaal\virtaal.exe, or wherever Install-Virtaal put it) whose
+own directory this installs the debug catalog next to.
+
+.EXAMPLE
+.\devsupport\testing\windows\Enable-VirtaalRtlDebug.ps1 -ExePath .\dist\virtaal\virtaal.exe
+# then, manually:
+$env:LANG = "fa_IR.UTF-8"
+$env:LANGUAGE = "fa"
+& .\dist\virtaal\virtaal.exe devsupport\testfiles\checks.po
+#>
+param(
+    [Parameter(Mandatory)][string]$ExePath
+)
+
+$ErrorActionPreference = "Stop"
+$RepoRoot = (git rev-parse --show-toplevel)
+Set-Location $RepoRoot
+
+if (-not (Test-Path $ExePath)) {
+    Write-Host "::error::$ExePath not found - build or install Virtaal first"
+    exit 1
+}
+
+$exeDir = Split-Path -Parent (Resolve-Path $ExePath)
+$targetDir = Join-Path $exeDir "share\locale\fa\LC_MESSAGES"
+New-Item -ItemType Directory -Path $targetDir -Force | Out-Null
+$targetMo = Join-Path $targetDir "virtaal.mo"
+
+# Same pure-Python compiler setup.py's own mo-compile step uses
+# (translate.tools.pocompile.convertmo) - no external msgfmt.exe needed,
+# guaranteed available anywhere Virtaal itself can run since
+# translate-toolkit is already a hard dependency.
+$py = ".\.venv\Scripts\python.exe"
+if (-not (Test-Path $py)) { $py = "python" }
+& $py -c @"
+from translate.tools.pocompile import convertmo
+with open('devsupport/testing/rtl-debug.po', encoding='utf-8') as inf, open(r'$targetMo', 'w') as outf:
+    convertmo(inf, outf, None)
+print('Compiled', len(open(r'$targetMo', 'rb').read()), 'bytes to', r'$targetMo')
+"@
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "::error::Compiling rtl-debug.po failed - see above"
+    exit 1
+}
+
+Write-Host ""
+Write-Host "Installed the synthetic RTL debug catalog at:"
+Write-Host "  $targetMo"
+Write-Host ""
+Write-Host "To actually see it, launch manually (not automated - this needs a human looking at the result):"
+Write-Host "  `$env:LANG = `"fa_IR.UTF-8`""
+Write-Host "  `$env:LANGUAGE = `"fa`""
+Write-Host "  & `"$ExePath`" devsupport\testfiles\checks.po"
+Write-Host ""
+Write-Host "Compare against a normal English launch side by side - does the whole window mirror (menu/toolbar/status-bar placement), not just the visibly-flipped text inside it?"

--- a/devsupport/testing/windows/Invoke-VirtaalLocalTestPass.ps1
+++ b/devsupport/testing/windows/Invoke-VirtaalLocalTestPass.ps1
@@ -1,0 +1,1779 @@
+<#
+.SYNOPSIS
+Runs a full uninstall -> install -> UI regression battery against
+Virtaal's real Inno Setup installer, on a real Windows machine (a VM or
+a physical box) rather than CI's raw PyInstaller bundle. Built
+2026-08-24 per request, to close the gap CI's build-windows-installer
+job deliberately doesn't cover: it builds and tests dist\virtaal\
+virtaal.exe directly, but never actually runs the installer or
+uninstaller it also produces. At least one real report this session -
+"the unsaved marker seems to persist between reinstalls" - was
+specifically about behaviour across an install/uninstall/reinstall
+cycle, which a bundle-only check can't reach at all.
+
+.PARAMETER InstallerPath
+Path to a Virtaal installer .exe. If omitted, auto-discovers the newest
+one under dist\installer (a local devsupport\packaging\windows\
+build_installer.ps1 build) or dist\Virtaal-windows-installer (a
+downloaded CI artifact, e.g. via `gh run download -R
+translate/virtaal -n Virtaal-windows-installer -D dist`).
+
+.PARAMETER SkipInitialUninstall
+Skip uninstalling any existing Virtaal before installing. Default
+behaviour uninstalls first so every run starts from the same clean
+slate - the exact condition the "persists between reinstalls" report
+needs to reproduce reliably, and generally the only way to be sure
+you're testing *this* installer's behaviour rather than a mix of an old
+install plus new files copied over it.
+
+.PARAMETER KeepInstalled
+Don't uninstall Virtaal again at the end of the run. Default tears back
+down to a clean slate so repeated runs stay comparable and don't leave
+a test install cluttering a real machine.
+
+.PARAMETER HumanDelayMs
+Runs at full speed (0, the default) unless set - every dialog, click,
+and keystroke already has its own short, tuned settle delay, and a
+dialog that opens and closes within a few hundred milliseconds is real
+but too fast for a human to actually see. Set this (e.g. 2000 for a
+2-second pause) to watch a run happen instead of only reading its
+transcript afterward - applies uniformly to every interaction, not
+just one check.
+
+.PARAMETER RunTest
+Runs only the given check number(s) instead of the full battery - a
+comma-separated list, e.g. "18,24". Checks are still numbered exactly
+as they would be in a full run (the counter always advances, whether a
+check's body actually runs or not), so a number from a previous full
+run's transcript or the results table always means the same check.
+Install/uninstall still happen as normal around a filtered run - a
+check still needs a real install to test against - so combine with
+-SkipInitialUninstall/-KeepInstalled for a fast repeat-drill-down loop
+on the same install rather than reinstalling every time. Meant for
+drilling into or validating a fix for one or two specific checks;
+omit for a real full pass.
+
+.PARAMETER AppDebugLog
+Launches Virtaal with its own -D/--debug flag and relaxes
+Assert-VirtaalLogsClean's allowlist to match (DEBUG/INFO lines are
+expected noise then, not failures - WARNING/ERROR still fail a check
+same as always). Without this, the app's logging module is never
+configured at all, so every logging.debug()/logging.info() call
+already in the codebase - mode changes, search match counts, which
+unit a match actually selected, and more - is silently discarded
+before it's ever written anywhere, not just hidden. Off by default,
+same reasoning as -HumanDelayMs: a full battery run should stay
+exactly as strict as it's always been. Most useful paired with
+-RunTest when a check's *result* makes sense but you need to see why a
+specific interaction inside it did or didn't happen.
+
+.PARAMETER SkipCommitCheck
+Skips verifying that the installed build's commit (virtaal.exe
+--version, via virtaal.__version__.build_commit - see that module and
+devsupport/packaging/*/build_standalone.*) matches this checkout's own
+`git rev-parse HEAD`. On by default (i.e. the check normally runs) -
+added 2026-08-24 after this exact session spent several rounds testing
+a stale installer built before that session's own fixes existed,
+nothing having ever checked *which commit* was actually installed. A
+mismatch aborts the run (after uninstalling, unless -KeepInstalled) -
+pass this switch only when deliberately testing a build that's not
+expected to match HEAD (e.g. a specific older release).
+
+.EXAMPLE
+.\devsupport\testing\windows\Invoke-VirtaalLocalTestPass.ps1
+
+.EXAMPLE
+.\devsupport\testing\windows\Invoke-VirtaalLocalTestPass.ps1 -InstallerPath C:\Downloads\virtaal-1.0.0-beta1-setup.exe -KeepInstalled
+
+.EXAMPLE
+.\devsupport\testing\windows\Invoke-VirtaalLocalTestPass.ps1 -HumanDelayMs 2000
+
+.EXAMPLE
+.\devsupport\testing\windows\Invoke-VirtaalLocalTestPass.ps1 -RunTest 18,24 -SkipInitialUninstall -KeepInstalled
+
+.EXAMPLE
+.\devsupport\testing\windows\Invoke-VirtaalLocalTestPass.ps1 -RunTest 18 -AppDebugLog -SkipInitialUninstall -KeepInstalled
+#>
+param(
+    [string]$InstallerPath,
+    [switch]$SkipInitialUninstall,
+    [switch]$KeepInstalled,
+    [int]$HumanDelayMs = 0,
+    [string[]]$RunTest,
+    [switch]$AppDebugLog,
+    [switch]$SkipCommitCheck
+)
+
+$ErrorActionPreference = "Stop"
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+. (Join-Path $here "virtaal_install_helpers.ps1")
+. (Join-Path $here "virtaal_ui_test_helpers.ps1")
+if ($HumanDelayMs -gt 0) { Set-VirtaalHumanDelay -Milliseconds $HumanDelayMs }
+if ($AppDebugLog) { Set-VirtaalAppDebugLog; Write-Host "-AppDebugLog: Virtaal launches with --debug, DEBUG/INFO log lines are expected" }
+
+# -RunTest 18,24 -> a lookup set of check numbers to actually run;
+# $null means no filter, i.e. a real full run. [string[]] (not
+# [string]) so PowerShell's own array-literal parsing handles the
+# unquoted form (-RunTest 18,24, which PowerShell hands us as two
+# array elements, "18" and "24", *before* it ever reaches a [string]
+# parameter - binding that straight to [string] instead silently
+# collapses it to the one string "18 24", space-joined, which then
+# fails to parse as a single number). Also split each element on comma
+# so the quoted form (-RunTest "18,24", one array element containing a
+# comma) works too - confirmed live, 2026-08-24: [int[]] alone binds
+# the unquoted form correctly but silently mis-binds a quoted
+# "18,24" as 1824 (PowerShell's string-to-int conversion treats the
+# comma as a thousands separator, no error at all), so this
+# deliberately stays [string[]] + explicit TryParse rather than
+# trusting PowerShell's own numeric coercion. Parsed once up front so
+# a typo (a non-numeric entry) fails fast, before any install/uninstall
+# work, rather than silently matching nothing partway through.
+$script:runTestFilter = $null
+if ($RunTest) {
+    $script:runTestFilter = [System.Collections.Generic.HashSet[int]]::new()
+    foreach ($token in $RunTest) {
+        foreach ($part in $token -split ',') {
+            $part = $part.Trim()
+            if (-not $part) { continue }
+            $n = 0
+            if (-not [int]::TryParse($part, [ref]$n)) {
+                Write-Host "::error::-RunTest entry '$part' is not a check number"
+                exit 1
+            }
+            [void]$script:runTestFilter.Add($n)
+        }
+    }
+    Write-Host "-RunTest: only running check(s) $(($script:runTestFilter | Sort-Object) -join ', ') - every other check is still numbered but skipped"
+}
+
+$results = @()
+$script:checkCount = 0
+function Add-Result([string]$Name, [string]$Status, [string]$Detail = "") {
+    $script:results += [PSCustomObject]@{ Number = $script:currentCheckNumber; Name = $Name; Status = $Status; Detail = $Detail }
+    $marker = switch ($Status) { "Pass" { "[PASS]" }; "Fail" { "[FAIL]" }; default { "[SKIP]" } }
+    Write-Host "$marker #$($script:currentCheckNumber) $Name $(if ($Detail) { "- $Detail" })"
+}
+
+function Invoke-VirtaalCheck {
+    <#
+    .SYNOPSIS
+    Runs one check's $Body, catching any *unexpected* exception as a Fail
+    result instead of letting it abort every check after it and skip
+    Tear down entirely - confirmed live 2026-08-24: an unhandled
+    Start-Process error partway through the battery left Virtaal
+    installed and every later check unrun, with no summary at all. $Body
+    is dot-sourced (not called in a child scope) so it can set $t itself
+    and have this wrapper's own finally still see it for cleanup; $Body
+    is expected to call Add-Result for its own outcome - this wrapper
+    only adds one itself if $Body throws before getting there.
+    #>
+    param([Parameter(Mandatory)][string]$Name, [Parameter(Mandatory)][scriptblock]$Body)
+    # A plain text transcript can't rewrite an earlier line in place, so
+    # this is a second line ([TESTING] now, [PASS]/[FAIL]/[SKIP] later
+    # from Add-Result) rather than an actual in-place update - still
+    # useful for watching a run live, since some checks take many
+    # seconds and there was previously no way to tell what was currently
+    # in flight versus just... nothing happening yet. Numbered
+    # (requested 2026-08-24, after "3rd test has a rendering bug" needed
+    # cross-referencing against the check list by hand) so a live report
+    # can point at an exact check unambiguously.
+    $script:checkCount++
+    $script:currentCheckNumber = $script:checkCount
+    # The counter above always advances, filtered or not, so a check's
+    # number stays identical whether -RunTest is used or not - a number
+    # quoted from a full run always means the same check in a filtered
+    # one.
+    if ($script:runTestFilter -and -not $script:runTestFilter.Contains($script:currentCheckNumber)) {
+        Write-Host "[SKIP] #$($script:currentCheckNumber) $Name - not in -RunTest"
+        return
+    }
+    Write-Host "[TESTING] #$($script:currentCheckNumber) $Name"
+    $t = $null
+    try {
+        . $Body
+    } catch {
+        Add-Result $Name "Fail" "unexpected error: $_"
+    } finally {
+        # Start-VirtaalTest now screenshots every file-argument launch
+        # unconditionally (2026-08-24 - this glitch turned out to be far
+        # more common than its original "rare, hard to reproduce"
+        # characterization, just too fast to see without -HumanDelayMs).
+        # Surfaced here once, for every check, rather than needing each
+        # one to reference $t.OpenScreenshot in its own Add-Result call.
+        if ($t -and $t.OpenScreenshot) { Write-Host "  (open screenshot: $($t.OpenScreenshot))" }
+        if ($t) { Stop-VirtaalTest $t }
+    }
+}
+
+$script:scratchDir = Join-Path $env:TEMP "virtaal-test-scratch"
+function New-VirtaalScratchFile {
+    <#
+    .SYNOPSIS
+    Copies a repo-relative source file (e.g. "po\af.po") out to a
+    disposable scratch directory under %TEMP%, well outside the repo,
+    and returns the copy's full path. Any check that actually saves
+    (Ctrl+S) or otherwise risks writing must use a scratch copy, never a
+    checked-in file directly - so no combination of SendKeys timing,
+    the wrong dialog button, or a real bug can ever leave a git-tracked
+    file modified on disk. Cleaned up in Tear down.
+    #>
+    param([Parameter(Mandatory)][string]$SourceRelativePath, [Parameter(Mandatory)][string]$Suffix)
+    New-Item -ItemType Directory -Path $script:scratchDir -Force | Out-Null
+    $base = [IO.Path]::GetFileNameWithoutExtension($SourceRelativePath)
+    $ext = [IO.Path]::GetExtension($SourceRelativePath)
+    $destPath = Join-Path $script:scratchDir "$base-$Suffix$ext"
+    Copy-Item -Path $SourceRelativePath -Destination $destPath -Force
+    return $destPath
+}
+
+function Set-VirtaalTranslatorInfo {
+    <#
+    .SYNOPSIS
+    Directly writes (or removes) %APPDATA%\Virtaal\virtaal.ini's
+    [translator] section, so a check can force a deterministic "header
+    info already known" or "header info missing" state instead of
+    depending on whatever this VM's config happens to already have from
+    earlier runs. storemodel.py's _update_header() (called on every
+    save of a PO file) prompts for name/email/team individually via
+    maincontroller.py's get_translator_*() whenever
+    pan_app.settings.translator[...] is empty - Settings' own Python-
+    level default already fills "name" from the OS, so on a genuinely
+    untouched profile only email and team are actually missing, but
+    -Missing here removes the whole file for a fully clean state rather
+    than surgically clearing two keys, since that's the more faithful
+    simulation of "this machine has never had Virtaal configured", and
+    simpler to reason about.
+
+    Must be called *before* launching Virtaal - Settings is read once
+    at startup, so changing the file while an instance is already
+    running has no effect on it.
+    #>
+    param([switch]$Missing)
+    $configDir = Join-Path $env:APPDATA "Virtaal"
+    New-Item -ItemType Directory -Path $configDir -Force | Out-Null
+    $iniPath = Join-Path $configDir "virtaal.ini"
+    if ($Missing) {
+        Remove-Item -Path $iniPath -Force -ErrorAction SilentlyContinue
+    } else {
+        Set-Content -Path $iniPath -Value "[translator]`nname = Virtaal Test`nemail = virtaal-test@example.invalid`nteam = Virtaal Test Team`n" -NoNewline
+    }
+}
+
+function Open-VirtaalFileViaDialog {
+    <#
+    .SYNOPSIS
+    Sends Ctrl+O, waits for the file-open dialog, navigates to
+    $FullPath via GTK's Ctrl+L location bar, and presses Enter. Returns
+    the dialog's HWND on success or $null if Ctrl+O never opened one -
+    doesn't verify the resulting title itself, since different callers
+    want different filename checks.
+
+    Takes a *full* path, not a bare filename - see the history below for
+    why. Extracted into one place (was duplicated across three checks)
+    specifically so a reliability fix here benefits all of them at once,
+    and so a future failure has one call site to add more diagnostics
+    to instead of three.
+
+    History: originally typed a bare filename directly into the file
+    list, relying on GTK's interactive/type-ahead search (the same
+    mechanism the run-virtaal skill's macOS driver relies on for its
+    native NSOpenPanel) - reasoned, at the time, to be flaky from a race
+    between the dialog reporting itself foreground and its internal
+    focus settling. That diagnosis was wrong: a saved screenshot from a
+    live failure (2026-08-24) showed the dialog's search UI itself
+    active with "af.po" typed and "No Results Found" - GTK3's file
+    chooser search is a broader, non-recursive-by-default search
+    feature, not a simple filter of the currently-browsed directory's
+    contents, so a bare filename only works if the dialog already
+    happens to be browsing the right folder (recent files, mostly by
+    luck). Ctrl+L's location bar takes an unambiguous full path
+    instead and doesn't depend on whatever directory the dialog opened
+    to.
+    #>
+    param([Parameter(Mandatory)]$Instance, [Parameter(Mandatory)][string]$FullPath, [int]$DialogTimeoutSeconds = 8)
+    Send-VirtaalKeys $Instance "^o"
+    $dlg = Wait-VirtaalPopup $Instance -TimeoutSeconds $DialogTimeoutSeconds
+    if (-not $dlg) { return $null }
+    Start-Sleep -Milliseconds 500
+    Send-VirtaalPopupKeys $dlg "^l"
+    Start-Sleep -Milliseconds 300
+    Send-VirtaalPopupKeys $dlg $FullPath
+    Start-Sleep -Milliseconds 300
+    Send-VirtaalPopupKeys $dlg "{ENTER}"
+    Start-Sleep -Milliseconds 1000
+    return $dlg
+}
+
+function Find-VirtaalUnit {
+    <#
+    .SYNOPSIS
+    Ctrl+F, types $SearchText and presses Enter in one go to jump to the
+    first match (searchmode.py's _on_entry_activate: update_search() +
+    _move_match(0)), then Escape to leave Search mode again (searchmode.py's
+    _on_close_search - see f30dbac7). Used by any check that needs a
+    *specific* unit (a real placeable, a unit that fails a specific
+    quality check, ...) rather than whatever the file's first unit
+    happens to be.
+
+    Two real, distinct bugs previously hid behind the same "doesn't move
+    to unit" symptom here - both confirmed live, not guessed:
+
+    1. searchmode.py's update_search() crashed on *every* search under
+       Python 3.14 (translate-toolkit's GrepFilter.getmatches() ORs in
+       re.LOCALE, invalid for a str pattern - see
+       virtaal/support/pogrep_compat.py, fixed 7bc977aa). That exception
+       aborted _on_entry_activate before it ever reached _move_match(), so
+       Enter looked like it did nothing. Two earlier attempts to fix this
+       function by widening its settle times (800ms/500ms, then
+       2000ms/2000ms) never had a chance of working - the search wasn't
+       failing to catch up, it was throwing before it ever ran. Confirmed
+       both by a live manual repro (Ctrl+F "XML" in checks.po, same
+       traceback from Enter and from clicking Search) and by this
+       function's own log-clean checks going quiet in exactly the runs
+       where this was the cause.
+
+    2. With (1) fixed, the symptom *still* reproduced live. Root cause:
+       Send-VirtaalKeys calls SetForegroundWindow on every single
+       invocation, and this function called it three times back to back
+       (^f, then $SearchText, then {ENTER}) - each a separate window
+       re-activation that can disrupt which GTK widget currently holds
+       keyboard focus in between. If focus isn't still on ent_search by
+       the time {ENTER} is sent, GTK delivers it somewhere else entirely
+       and ent_search's 'activate' signal - the only thing that calls
+       _move_match() and actually moves the selection - never fires. The
+       500ms-debounced live-typing search (_on_search_text_changed) still
+       runs regardless, which is why the search box and highlighting look
+       right even when the unit never changes. Fixed by sending
+       $SearchText and {ENTER} as one combined SendKeys call, so there's
+       no window re-activation between finishing the text and the
+       keystroke meant to land in that same box.
+    #>
+    param([Parameter(Mandatory)]$Instance, [Parameter(Mandatory)][string]$SearchText)
+    Send-VirtaalKeys $Instance "^f"
+    Start-Sleep -Milliseconds 500
+    Send-VirtaalKeys $Instance "$SearchText{ENTER}"
+    Start-Sleep -Milliseconds 1000
+    Send-VirtaalKeys $Instance "{ESC}"
+    Start-Sleep -Milliseconds 800
+}
+
+# Everything below (all Write-Host output, ::error:: lines, and the
+# stdout/stderr log dumps Assert-VirtaalLogsClean/Install-Virtaal print
+# on failure) also goes to a transcript file *inside the repo tree*,
+# not just the console - added 2026-08-24 specifically because this
+# repo checkout is shared from the Windows VM's Z:\ back to a real
+# filesystem path on the host (this is that same host), so a transcript
+# landing under devsupport\testing\windows\.local-test-runs\ can be read
+# directly afterwards without anything needing to be copy-pasted back.
+# Gitignored - these are ephemeral run records, not something to commit.
+$runLogDir = Join-Path $here ".local-test-runs"
+New-Item -ItemType Directory -Path $runLogDir -Force | Out-Null
+$transcriptPath = Join-Path $runLogDir "$(Get-Date -Format 'yyyyMMdd-HHmmss').log"
+try {
+    Start-Transcript -Path $transcriptPath | Out-Null
+} catch {
+    Write-Host "(could not start transcript at $transcriptPath - continuing without one: $_)"
+}
+
+try {
+
+Write-Host "=== 1. Clean slate ==="
+if (-not $SkipInitialUninstall) {
+    if (-not (Uninstall-Virtaal)) {
+        Write-Host "::error::Could not get to a clean uninstalled state - aborting rather than testing on top of a partial install"
+        exit 1
+    }
+} else {
+    Write-Host "Skipped (-SkipInitialUninstall)"
+}
+
+Write-Host "`n=== 2. Install ==="
+$install = Install-Virtaal -InstallerPath $InstallerPath
+if (-not $install) {
+    Write-Host "::error::Install failed - see above"
+    exit 1
+}
+
+if (-not $SkipCommitCheck) {
+    # See virtaal/__version__.py's build_commit docstring and this
+    # param's own help text - this exists specifically because that
+    # exact silent-stale-install mistake happened, more than once, in
+    # the session that added it. --version exits almost immediately
+    # (argparse's own action="version" fires during parse_args(), well
+    # before any GUI/mainloop startup), so -Wait here is safe and fast,
+    # not the "never exits on its own" case every other launch in this
+    # script has to work around. For a packaged Windows build, its
+    # output lands in pan_app's redirected log (see virtaal/common/
+    # pan_app.py), not any console - there is no console for a
+    # windowed-subsystem exe - so read it back from there, not from
+    # Start-Process itself.
+    # Not just `(git ... rev-parse HEAD).Trim()` - confirmed live,
+    # 2026-08-24: git refuses to operate at all ("detected dubious
+    # ownership") against this checkout when it's reached via the
+    # UTM/WebDAV-mounted share path (//localhost@.../DavWWWRoot/virtaal)
+    # rather than a plain local path, printing its error to stdout and
+    # exiting non-zero - .Trim() on that then crashes with a cryptic
+    # "cannot call a method on a null-valued expression" instead of a
+    # useful message. Check $LASTEXITCODE explicitly and fail with git's
+    # own remediation instead.
+    # Confirmed live, 2026-08-24, on the real Windows PowerShell 5.1 this
+    # battery actually runs under (not reproducible with cross-platform
+    # PowerShell 7's git handling, which behaves differently here): with
+    # $ErrorActionPreference = "Stop" in effect (set at the top of this
+    # script), a native command's stderr output - even merged into the
+    # pipeline via 2>&1 - is itself an ErrorRecord, so the *terminating*
+    # dubious-ownership error still aborted this whole script, "2>&1"
+    # notwithstanding. Temporarily relax EAP just for this one call.
+    $prevEAP = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"
+    try {
+        $gitOutput = (git -C $here rev-parse HEAD 2>&1 | Out-String).Trim()
+    } finally {
+        $ErrorActionPreference = $prevEAP
+    }
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "::error::Could not read this checkout's own commit (git -C $here rev-parse HEAD failed):"
+        Write-Host $gitOutput
+        if ($gitOutput -match "safe\.directory") {
+            Write-Host "::error::This looks like git's dubious-ownership check tripping on a network-mounted share path - run the 'git config --global --add safe.directory ...' line above once on this machine, then re-run."
+        }
+        if (-not $KeepInstalled) { Uninstall-Virtaal | Out-Null }
+        exit 1
+    }
+    $expectedCommit = $gitOutput
+    Write-Host "Verifying installed build matches checkout commit $expectedCommit ..."
+    Start-Process -FilePath $install.ExePath -ArgumentList "--version" -Wait | Out-Null
+    Start-Sleep -Milliseconds 500
+    $verLogs = Get-VirtaalLogs
+    $actualCommit = $null
+    foreach ($line in ($verLogs.Stdout + $verLogs.Stderr)) {
+        if ($line -match '\(([0-9a-f]{7,40})\)') { $actualCommit = $Matches[1]; break }
+    }
+    if (-not $actualCommit) {
+        Write-Host "::error::Could not read the installed build's commit from --version output. Either this installer predates build_commit support (rebuild it) or something else is wrong - see the log dump below."
+        Write-VirtaalLogs
+        if (-not $KeepInstalled) { Uninstall-Virtaal | Out-Null }
+        exit 1
+    } elseif (-not $expectedCommit.StartsWith($actualCommit)) {
+        # Confirmed live, 2026-08-25: a commit mismatch alone isn't
+        # necessarily a real problem - a run right after several
+        # PowerShell-only commits (this script itself, read live from
+        # the shared checkout, never baked into the installer at all)
+        # got hard-blocked here even though nothing that actually ships
+        # in the installer had changed. Only the paths that genuinely
+        # get built into it matter for whether a mismatch is real - see
+        # virtaal.spec's own datas/hiddenimports for what that actually
+        # is. Downgrade to a warning (and keep going) when the diff
+        # between the two commits touches none of them; still a hard
+        # Fail when it does, or when the diff itself can't be computed
+        # (fails safe - if in doubt, still requires a rebuild).
+        $appPaths = @("virtaal", "share", "po", "bin", "setup.py", "devsupport/packaging")
+        # Confirmed live, 2026-08-25: same "native stderr treated as
+        # terminating under $ErrorActionPreference = 'Stop'" class of
+        # bug as the git rev-parse HEAD call above (c9673a12) - this
+        # call site was added later and missed the same guard. This
+        # time the actual stderr text was "unable to open loose object
+        # ...: Function not implemented" (a WebDAV-mount quirk reading
+        # a just-pushed object, not the dubious-ownership error the
+        # first guard was written for) - a different underlying cause,
+        # same PowerShell-level symptom, same proven fix: temporarily
+        # relax EAP just for this one call, same as the established
+        # pattern above.
+        $prevEAP = $ErrorActionPreference
+        $ErrorActionPreference = "Continue"
+        try {
+            git diff --quiet $actualCommit $expectedCommit -- $appPaths 2>$null
+        } finally {
+            $ErrorActionPreference = $prevEAP
+        }
+        # Confirmed live, 2026-08-25: the previous version of this check
+        # (`$appPathsChanged = $LASTEXITCODE -ne 0` then a guard that
+        # only cleared it back on a *non*-0/1 exit code) had an inverted
+        # condition - "-ne 1" is also true when the exit code is 0 (the
+        # good, no-diff case), so that guard fired and flipped
+        # $appPathsChanged back to $true on literally every single
+        # no-diff result, hard-blocking a pure test-script-only commit
+        # exactly like the case this whole check exists to allow
+        # through. Never actually exercised end-to-end before landing -
+        # only the bare `git diff --quiet` exit codes were checked
+        # directly, not this script's own control flow around them.
+        # Explicit three-way branch this time, no double-negatives.
+        if ($LASTEXITCODE -eq 0) {
+            $appPathsChanged = $false
+        } elseif ($LASTEXITCODE -eq 1) {
+            $appPathsChanged = $true
+        } else {
+            # git diff --quiet's contract is exit 0 (no diff) or 1 (diff
+            # found) - anything else (128, a bad revision, etc.) means
+            # the check itself failed, not that the paths are clean.
+            $appPathsChanged = $true
+        }
+        if ($appPathsChanged) {
+            Write-Host "::error::Installed build is commit $actualCommit, but this checkout is at $expectedCommit - real app-source changes exist between them, this installer is STALE. Rebuild (build_standalone.ps1 + build_installer.ps1) or download a fresh CI artifact for this commit, or pass -SkipCommitCheck to deliberately test an older build anyway."
+            if (-not $KeepInstalled) { Uninstall-Virtaal | Out-Null }
+            exit 1
+        }
+        Write-Host "Installed build is commit $actualCommit, checkout is at $expectedCommit - different commits, but nothing under virtaal/share/po/bin/setup.py/devsupport/packaging actually differs between them (confirmed via git diff), so this installer is still good to test against - continuing."
+    } else {
+        Write-Host "Confirmed: installed build matches commit $actualCommit"
+    }
+} else {
+    Write-Host "`nSkipped commit verification (-SkipCommitCheck)"
+}
+
+# Confirmed live, 2026-08-25: right after a fresh install, the first
+# one or two checks failed with "Never got a main window handle" -
+# not the mid/late-run cascade already tracked (that one correlated
+# with -AppDebugLog and is a separate, cumulative-load issue) - this
+# one happened at the very *start* of a clean run, before any check
+# had a chance to leave anything stale behind. The commit-verification
+# step above already runs virtaal.exe --version once, but that exits
+# during argparse, well before GTK/Pango/PyGObject/translate-toolkit
+# and the rest of the bundle's DLLs ever get touched - a real antivirus
+# on-access scan of a freshly-written executable's *actual* working set
+# (hundreds of DLLs a full GUI launch loads, not the handful --version
+# does) is a well-known source of exactly this "first real launch is
+# much slower than every later one" pattern. One throwaway warm-up
+# launch+kill here, off the clock before any check's own timing budget
+# starts, should pay that cost once instead of risking check #1 (or #2)
+# eating it under a tight timeout. Cheap even if this theory is wrong -
+# worst case it's a few extra seconds once per run.
+if ($install) {
+    Write-Host "`nWarm-up launch (first real GUI launch after install can be slower - antivirus scanning a freshly-written executable, not a Virtaal problem) ..."
+    $warmup = Start-VirtaalTest -ExePath $install.ExePath -WaitSeconds 15 -HandleTimeoutSeconds 20
+    if ($warmup) {
+        Stop-VirtaalTest $warmup
+        Write-Host "Warm-up launch got a window handle - continuing."
+    } else {
+        Write-Host "::warning::Warm-up launch itself never got a window handle - the underlying slowness may be worse than this warm-up step can absorb."
+    }
+}
+
+Write-Host "`n=== 3. UI regression battery ==="
+
+# Known-good baseline for every check below, not just the two Ctrl+S
+# checks that explicitly re-set it - a check whose failure has nothing
+# to do with saving shouldn't depend on whatever pan_app.settings.
+# translator[...] this VM happens to already have from earlier runs.
+Set-VirtaalTranslatorInfo
+
+Invoke-VirtaalCheck "Launches cleanly" {
+    # Mirrors CI's "Verify the bundle actually runs" step, against the
+    # real installed exe instead of the raw dist\virtaal\ bundle.
+    # Confirmed live, 2026-08-24: this specific launch - the very first
+    # one right after a fresh install, with nothing warm in any OS/AV
+    # file cache yet - can genuinely take longer than Start-VirtaalTest's
+    # CI-tuned defaults (8s + up to 10s more) allow for, especially on a
+    # slower/emulated local VM rather than a GitHub Actions runner; every
+    # later launch in the same run (same exe, same machine) got a window
+    # handle immediately. Give this one specifically a more generous
+    # budget rather than either widening the shared default (which would
+    # slow down every CI check too, where the tighter budget has never
+    # actually been a problem) or risking a false Fail here on a
+    # slow-but-fine cold start.
+    $t = Start-VirtaalTest -ExePath $install.ExePath -Arguments "devsupport\testfiles\checks.po" -WaitSeconds 20 -HandleTimeoutSeconds 20
+    if (-not $t) {
+        Add-Result "Launches cleanly" "Fail" "no window handle - see log above"
+    } else {
+        $logsClean = Assert-VirtaalLogsClean
+        Add-Result "Launches cleanly" $(if ($logsClean) { "Pass" } else { "Fail" }) $(if (-not $logsClean) { "unexpected log output - see above" })
+    }
+}
+
+Invoke-VirtaalCheck "Fresh install: no modified marker on open" {
+    # Directly targets "the unsaved marker seems to persist between
+    # reinstalls" (reported live, 2026-08-24) - a truly clean
+    # uninstall+install cycle followed by opening an untouched file
+    # should never show the "*" modified marker in the title. If this
+    # fails, that's real evidence something is being retained outside
+    # the app itself (e.g. a stray config/state file an uninstall isn't
+    # removing) rather than a code-only bug in this session's
+    # modified-flag fixes.
+    $t = Start-VirtaalTest -ExePath $install.ExePath -Arguments "po\af.po"
+    if (-not $t) {
+        Add-Result "Fresh install: no modified marker on open" "Fail" "app didn't launch"
+    } else {
+        $title = Get-VirtaalTitle $t
+        $isModified = $title.StartsWith("*")
+        Add-Result "Fresh install: no modified marker on open" $(if ($isModified) { "Fail" } else { "Pass" }) "title=`"$title`""
+    }
+}
+
+Invoke-VirtaalCheck "Navigation doesn't grow window" {
+    # Mirrors CI's own check for storetreeview.py's select_index() growth
+    # bug (fixed 7fd21615) - kept here too since this is testing the real
+    # installed build, not just whatever CI happened to build from.
+    #
+    # No longer takes its own screenshot at open - Start-VirtaalTest does
+    # that automatically now for every file-argument launch (see its own
+    # comments: this glitch turned out to be far more common than
+    # originally thought, not specific to this one check).
+    $t = Start-VirtaalTest -ExePath $install.ExePath -Arguments "po\af.po"
+    if (-not $t) {
+        Add-Result "Navigation doesn't grow window" "Fail" "app didn't launch"
+    } else {
+        $widthBefore = Get-VirtaalWidth $t
+        for ($i = 0; $i -lt 25; $i++) { Send-VirtaalKeys $t "{ENTER}" }
+        $widthAfter = Get-VirtaalWidth $t
+        $growth = $widthAfter - $widthBefore
+        Add-Result "Navigation doesn't grow window" $(if ($growth -gt 50) { "Fail" } else { "Pass" }) "grew ${growth}px after 25x Enter"
+    }
+}
+
+Invoke-VirtaalCheck "Type + Ctrl+Z clears modified marker" {
+    # Exercises this session's undo/modified-flag fix chain (4a10f77a,
+    # 10a51457, dfb2a447, 297f0aaa) end-to-end against the real installed
+    # app. Assumes the target text box has default keyboard focus when a
+    # file first opens - if that assumption doesn't hold on a given
+    # machine/GTK theme, typing "x" won't actually modify anything and
+    # the check reports Skip rather than a false Fail, so a focus quirk
+    # doesn't masquerade as a regression.
+    $t = Start-VirtaalTest -ExePath $install.ExePath -Arguments "po\af.po"
+    if (-not $t) {
+        Add-Result "Type + Ctrl+Z clears modified marker" "Fail" "app didn't launch"
+    } else {
+        Send-VirtaalKeys $t "x"
+        $titleAfterType = Get-VirtaalTitle $t
+        if (-not $titleAfterType.StartsWith("*")) {
+            # Confirmed live, 2026-08-25, reproducing consistently (not
+            # VM-load noise - seen on a run confirmed otherwise clean) on
+            # this check and both Ctrl+S checks below, all of which type
+            # immediately after Start-VirtaalTest returns with zero
+            # additional settle. Rather than guess-widen the timing again
+            # (that exact move already failed once this session for a
+            # different check - see Find-VirtaalUnit's own history).
+            # screenshot what's actually on screen at the moment typing
+            # was attempted, so the next occurrence shows real evidence
+            # (is a cell editor even visible/focused?) instead of just
+            # the same "maybe timing, maybe not" guess again.
+            $shot = Save-VirtaalScreenshot $t
+            Add-Result "Type + Ctrl+Z clears modified marker" "Skip" "typing didn't set the modified marker (title=`"$titleAfterType`") - target field may not have had default focus - screenshot: $shot"
+        } else {
+            Send-VirtaalKeys $t "^z"
+            $titleAfterUndo = Get-VirtaalTitle $t
+            $stillModified = $titleAfterUndo.StartsWith("*")
+            Add-Result "Type + Ctrl+Z clears modified marker" $(if ($stillModified) { "Fail" } else { "Pass" }) "title after undo=`"$titleAfterUndo`""
+        }
+    }
+}
+
+Invoke-VirtaalCheck "Keyboard shortcuts don't crash" {
+    # Mirrors CI's own check.
+    $t = Start-VirtaalTest -ExePath $install.ExePath -Arguments "devsupport\testfiles\checks.po"
+    if (-not $t) {
+        Add-Result "Keyboard shortcuts don't crash" "Fail" "app didn't launch"
+    } else {
+        foreach ($keys in @("^z", "^x", "^c", "^v")) { Send-VirtaalKeys $t $keys }
+        Send-VirtaalKeys $t "^o"
+        Send-VirtaalKeys $t "{ESC}"
+        $stillAlive = Get-Process -Id $t.Process.Id -ErrorAction SilentlyContinue
+        Add-Result "Keyboard shortcuts don't crash" $(if ($stillAlive) { "Pass" } else { "Fail" }) $(if (-not $stillAlive) { "process exited" })
+    }
+}
+
+Invoke-VirtaalCheck "Ctrl+C doesn't modify, Ctrl+V does" {
+    # "Keyboard shortcuts don't crash" above only ever checked that
+    # Ctrl+X/C/V don't crash, never that they do the *right* thing to
+    # the modified flag - the same signal-correctness theme as this
+    # session's real bugs (a mutating action failing to mark modified,
+    # or - just as easily, given how many of those bugs were about a
+    # signal firing when it *shouldn't* - a non-mutating one wrongly
+    # marking modified). Select-all + Copy from a clean state must
+    # leave the marker off; pasting straight back over that same
+    # selection must turn it on, since Paste is a real edit regardless
+    # of whether the resulting text happens to match.
+    $t = Start-VirtaalTest -ExePath $install.ExePath -Arguments "po\af.po"
+    if (-not $t) {
+        Add-Result "Ctrl+C doesn't modify, Ctrl+V does" "Fail" "app didn't launch"
+    } else {
+        $titleClean = Get-VirtaalTitle $t
+        if ($titleClean.StartsWith("*")) {
+            Add-Result "Ctrl+C doesn't modify, Ctrl+V does" "Skip" "file already showed modified before any interaction (title=`"$titleClean`")"
+        } else {
+            Send-VirtaalKeys $t "^a"
+            Send-VirtaalKeys $t "^c"
+            $titleAfterCopy = Get-VirtaalTitle $t
+            if ($titleAfterCopy.StartsWith("*")) {
+                Add-Result "Ctrl+C doesn't modify, Ctrl+V does" "Fail" "Ctrl+C alone set the modified marker (title=`"$titleAfterCopy`") - Copy must not mutate"
+            } else {
+                Send-VirtaalKeys $t "^v"
+                $titleAfterPaste = Get-VirtaalTitle $t
+                Add-Result "Ctrl+C doesn't modify, Ctrl+V does" $(if ($titleAfterPaste.StartsWith("*")) { "Pass" } else { "Skip" }) "title after paste=`"$titleAfterPaste`"$(if (-not $titleAfterPaste.StartsWith('*')) { ' - Ctrl+V had no observable effect, possibly nothing was selected to copy' })"
+            }
+        }
+    }
+}
+
+Invoke-VirtaalCheck "Alt+Enter opens Properties and closes cleanly" {
+    # <Virtaal>/File/Properties (propertiesview.py) - same shape as the
+    # existing Ctrl+P Preferences check.
+    $t = Start-VirtaalTest -ExePath $install.ExePath -Arguments "devsupport\testfiles\checks.po"
+    if (-not $t) {
+        Add-Result "Alt+Enter opens Properties and closes cleanly" "Fail" "app didn't launch"
+    } else {
+        Send-VirtaalKeys $t "%{ENTER}"
+        $dlg = Wait-VirtaalPopup $t -TimeoutSeconds 5
+        if (-not $dlg) {
+            # Confirmed live, 2026-08-25 - same "keystroke fired before
+            # the window's own accelerator wiring finished settling"
+            # shape as the "no default focus" checks elsewhere in this
+            # file (Wait-VirtaalPopup already polls for 5s looking for a
+            # dialog, so the issue isn't waiting long enough *after*
+            # sending the keystroke - if Alt+Enter itself never landed,
+            # no amount of waiting afterward would help). Screenshot for
+            # the next occurrence rather than guess-widening timing.
+            $shot = Save-VirtaalScreenshot $t
+            Add-Result "Alt+Enter opens Properties and closes cleanly" "Fail" "no dialog appeared - screenshot: $shot"
+        } else {
+            $dlgTitle = Get-VirtaalWindowText $dlg
+            Close-VirtaalPopup $t $dlg
+            $stillAlive = Get-Process -Id $t.Process.Id -ErrorAction SilentlyContinue
+            $logsClean = if ($stillAlive) { Assert-VirtaalLogsClean } else { $false }
+            Add-Result "Alt+Enter opens Properties and closes cleanly" $(if ($stillAlive -and $logsClean) { "Pass" } else { "Fail" }) "dialog title=`"$dlgTitle`"$(if (-not $stillAlive) { ' - process exited after closing it' } elseif (-not $logsClean) { ' - unexpected log output' })"
+        }
+    }
+}
+
+Invoke-VirtaalCheck "F11 fullscreen restores the original window size" {
+    # mnu_fullscreen / F11 - _on_fullscreen() (mainview.py) is a plain
+    # passthrough to GTK's own main_window.fullscreen()/unfullscreen(),
+    # no custom geometry save/restore logic in Virtaal's own code at
+    # all - so if the size isn't restored correctly, that's GTK/GDK's
+    # Windows backend, not something to fix here directly (though
+    # Virtaal could still work around it by saving/restoring the size
+    # itself, the way this same session's window-growth saga eventually
+    # worked around a different GTK/Windows sizing quirk). Reported
+    # live, 2026-08-24: "F11 returns to a different size" - this used to
+    # only check for a crash; now measures the actual width/height
+    # before fullscreen and after returning from it, so this is a real,
+    # repeatable regression check instead of relying on catching it live
+    # each time. A few pixels of slop is allowed (window-manager/DPI
+    # rounding is a real, benign source of small differences) - the
+    # threshold is deliberately the same 50px this battery already uses
+    # for the navigation-growth check, not a tight pixel-exact match.
+    $t = Start-VirtaalTest -ExePath $install.ExePath -Arguments "devsupport\testfiles\checks.po"
+    if (-not $t) {
+        Add-Result "F11 fullscreen restores the original window size" "Fail" "app didn't launch"
+    } else {
+        $widthBefore = Get-VirtaalWidth $t
+        $heightBefore = Get-VirtaalHeight $t
+        Send-VirtaalKeys $t "{F11}" -SettleMs 500
+        Send-VirtaalKeys $t "{F11}" -SettleMs 500
+        $stillAlive = Get-Process -Id $t.Process.Id -ErrorAction SilentlyContinue
+        if (-not $stillAlive) {
+            Add-Result "F11 fullscreen restores the original window size" "Fail" "process exited"
+        } else {
+            # Confirmed live, 2026-08-24: this used to report just
+            # "unexpected log output" and stop there whenever
+            # storetreeview.py's own diagnostic logging.warning()
+            # (_restore_cursor() - a deliberately-left-in tripwire from
+            # an earlier, since-fixed runaway-resize bug, "investigate
+            # if seen again", not itself a crash) fired - which it does
+            # here. That meant the width/height comparison below,
+            # computed either way, never actually got reported when it
+            # mattered most: we genuinely didn't know whether the
+            # window was overshooting-then-correctly-settling (benign)
+            # or ending up genuinely stuck wide (a real regression) - a
+            # long-standing gap in this exact check. Report both facts every time now, regardless of
+            # which one is the reason for an eventual Fail - the log
+            # warning still fails the check on its own (it's a real
+            # tripwire, not something to blanket-allow), but no longer
+            # at the cost of hiding the size data alongside it.
+            $logsClean = Assert-VirtaalLogsClean
+            $widthAfter = Get-VirtaalWidth $t
+            $heightAfter = Get-VirtaalHeight $t
+            $widthDelta = [Math]::Abs($widthAfter - $widthBefore)
+            $heightDelta = [Math]::Abs($heightAfter - $heightBefore)
+            $sizeRestored = $widthDelta -le 50 -and $heightDelta -le 50
+            $sizeDetail = "before=${widthBefore}x${heightBefore}, after=${widthAfter}x${heightAfter} ($(if ($sizeRestored) { 'restored' } else { 'NOT restored' }))"
+            if (-not $logsClean -or -not $sizeRestored) {
+                $shot = Save-VirtaalScreenshot $t
+                $reason = if (-not $logsClean -and -not $sizeRestored) { "unexpected log output AND size not restored" } elseif (-not $logsClean) { "unexpected log output (size itself was fine)" } else { "size not restored (logs were otherwise clean)" }
+                Add-Result "F11 fullscreen restores the original window size" "Fail" "$reason - $sizeDetail - screenshot: $shot"
+            } else {
+                Add-Result "F11 fullscreen restores the original window size" "Pass" $sizeDetail
+            }
+        }
+    }
+}
+
+Invoke-VirtaalCheck "F11 fullscreen restores size on the Welcome screen too" {
+    # A theory raised live, 2026-08-24, for why the check above might
+    # only show the bug sometimes: welcomescreenview.py's banner image
+    # (welcome_screen_banner*.png) is a real, confirmed 2000x80px -
+    # genuinely wide. If nothing constrains its width, a natural-size
+    # recalculation on unfullscreen() (the same general family as this
+    # session's original resize bug - set_expand(True)'s natural-size
+    # divergence on Windows/gvsbuild GTK3) could plausibly pull the
+    # window out toward something close to that width. The check above
+    # never actually shows the Welcome screen at all (it opens
+    # checks.po directly), so it can't exercise this specific mechanism
+    # either way - this one launches with no file argument instead,
+    # specifically to test the theory.
+    $t = Start-VirtaalTest -ExePath $install.ExePath
+    if (-not $t) {
+        Add-Result "F11 fullscreen restores size on the Welcome screen too" "Fail" "app didn't launch"
+    } else {
+        $widthBefore = Get-VirtaalWidth $t
+        $heightBefore = Get-VirtaalHeight $t
+        Send-VirtaalKeys $t "{F11}" -SettleMs 500
+        Send-VirtaalKeys $t "{F11}" -SettleMs 500
+        $stillAlive = Get-Process -Id $t.Process.Id -ErrorAction SilentlyContinue
+        if (-not $stillAlive) {
+            Add-Result "F11 fullscreen restores size on the Welcome screen too" "Fail" "process exited"
+        } else {
+            $logsClean = Assert-VirtaalLogsClean
+            $widthAfter = Get-VirtaalWidth $t
+            $heightAfter = Get-VirtaalHeight $t
+            $widthDelta = [Math]::Abs($widthAfter - $widthBefore)
+            $heightDelta = [Math]::Abs($heightAfter - $heightBefore)
+            $sizeRestored = $widthDelta -le 50 -and $heightDelta -le 50
+            if (-not $logsClean) {
+                Add-Result "F11 fullscreen restores size on the Welcome screen too" "Fail" "unexpected log output - see above"
+            } elseif (-not $sizeRestored) {
+                $shot = Save-VirtaalScreenshot $t
+                Add-Result "F11 fullscreen restores size on the Welcome screen too" "Fail" "before=${widthBefore}x${heightBefore}, after=${widthAfter}x${heightAfter} - screenshot: $shot"
+            } else {
+                Add-Result "F11 fullscreen restores size on the Welcome screen too" "Pass" "before=${widthBefore}x${heightBefore}, after=${widthAfter}x${heightAfter}"
+            }
+        }
+    }
+}
+
+Invoke-VirtaalCheck "Multi-step undo clears modified marker" {
+    # "Type + Ctrl+Z clears modified marker" above only ever tested a
+    # single edit/undo pair. The actual fix this session made
+    # (UndoModel's clean_index/is_at_clean_position(), 4a10f77a) is
+    # about the undo *stack position* matching where it was at open -
+    # a single-step test can't distinguish "compares against a fixed
+    # start" from "correctly walks back an arbitrary number of steps",
+    # so this exercises two edits and two undos.
+    $t = Start-VirtaalTest -ExePath $install.ExePath -Arguments "po\af.po"
+    if (-not $t) {
+        Add-Result "Multi-step undo clears modified marker" "Fail" "app didn't launch"
+    } else {
+        Send-VirtaalKeys $t "x"
+        Send-VirtaalKeys $t "y"
+        $titleAfterTwoEdits = Get-VirtaalTitle $t
+        if (-not $titleAfterTwoEdits.StartsWith("*")) {
+            # See "Type + Ctrl+Z clears modified marker"'s own comment.
+            $shot = Save-VirtaalScreenshot $t
+            Add-Result "Multi-step undo clears modified marker" "Skip" "typing didn't set the modified marker (title=`"$titleAfterTwoEdits`") - target field may not have had default focus - screenshot: $shot"
+        } else {
+            Send-VirtaalKeys $t "^z"
+            $titleAfterOneUndo = Get-VirtaalTitle $t
+            Send-VirtaalKeys $t "^z"
+            $titleAfterTwoUndos = Get-VirtaalTitle $t
+            $stillModified = $titleAfterTwoUndos.StartsWith("*")
+            Add-Result "Multi-step undo clears modified marker" $(if ($stillModified) { "Fail" } else { "Pass" }) "after 1 undo=`"$titleAfterOneUndo`", after 2 undos=`"$titleAfterTwoUndos`""
+        }
+    }
+}
+
+Invoke-VirtaalCheck "Welcome screen launches cleanly" {
+    # Every other check above passes a file on the command line, which
+    # Virtaal opens synchronously before the event loop even starts
+    # (virtaal/main.py's _open_with_file) - plugin loading (checks, undo,
+    # TM, ...) is deferred to run afterwards via GObject.idle_add. With
+    # no file argument at all, main.py instead takes the
+    # _open_with_welcome path, where *everything* (UnitController,
+    # ModeController, ..., and the same deferred plugin loading) is
+    # queued via the same idle_add mechanism - a genuinely different
+    # startup code path none of the file-argument checks above ever
+    # touch.
+    $t = Start-VirtaalTest -ExePath $install.ExePath
+    if (-not $t) {
+        Add-Result "Welcome screen launches cleanly" "Fail" "app didn't launch"
+    } else {
+        $logsClean = Assert-VirtaalLogsClean
+        Add-Result "Welcome screen launches cleanly" $(if ($logsClean) { "Pass" } else { "Fail" }) $(if (-not $logsClean) { "unexpected log output - see above" })
+    }
+}
+
+Invoke-VirtaalCheck "Menu navigation" {
+    # Opens and closes each top-level menu via its Alt+mnemonic (see
+    # share\virtaal\virtaal.ui's "_File"/"_Edit"/"_View"/"_Navigation"/
+    # "_Help" labels) - a cheap way to exercise menu construction/
+    # rendering for every menu, not just the handful of items the
+    # shortcut checks activate directly.
+    $t = Start-VirtaalTest -ExePath $install.ExePath -Arguments "devsupport\testfiles\checks.po"
+    if (-not $t) {
+        Add-Result "Menu navigation" "Fail" "app didn't launch"
+    } else {
+        foreach ($mnemonic in @("f", "e", "v", "n", "h")) {
+            Send-VirtaalKeys $t "%$mnemonic"
+            Send-VirtaalKeys $t "{ESC}"
+        }
+        $stillAlive = Get-Process -Id $t.Process.Id -ErrorAction SilentlyContinue
+        $logsClean = if ($stillAlive) { Assert-VirtaalLogsClean } else { $false }
+        Add-Result "Menu navigation" $(if ($stillAlive -and $logsClean) { "Pass" } else { "Fail" }) $(if (-not $stillAlive) { "process exited" } elseif (-not $logsClean) { "unexpected log output - see above" })
+    }
+}
+
+Invoke-VirtaalCheck "Welcome screen: open dialog + Recent Files" {
+    # Covers two asks at once (they're the same underlying flow):
+    # opening from the welcome screen via a real file-open dialog (not a
+    # CLI argument), and reopening via File > Recent Files afterwards.
+    # Also the closest thing in this battery to the exact sequence
+    # behind this session's reopen-modified-flag bug family (change,
+    # close, reopen a *different* file) - this variant reopens the
+    # *same* file, so it won't catch that specific bug, but exercises
+    # the same dialog/menu machinery.
+    #
+    # The file-open dialog is a separate top-level window -
+    # Send-VirtaalKeys can't be used once it's open (it always forces
+    # the *main* window foreground first, which would steal focus back
+    # off the dialog); Send-VirtaalPopupKeys targets the dialog's own
+    # HWND instead. Typing a filename with no field explicitly focused
+    # relies on GTK's built-in interactive/type-ahead search in the file
+    # list, the same mechanism the run-virtaal skill's macOS driver
+    # relies on for its native NSOpenPanel.
+    #
+    # History: originally drove File > Recent Files via Alt+F, a "r"
+    # mnemonic jump, Right to open the submenu, Enter to activate its
+    # (assumed) auto-highlighted top entry - failed three separate times
+    # with three different symptoms (no dialog, wrong/no entry selected,
+    # no effect at all landing back on the bare Welcome screen). A saved
+    # screenshot from the third failure showed exactly where that left
+    # things: back on the Welcome screen, which turns out to have its
+    # *own* clickable Recent Files list right on the page
+    # (welcomescreen.py's _get_widgets(): btn_recent1..btn_recent5, real
+    # Gtk.Button widgets with 'clicked' connected) - not the finicky
+    # menu path at all. Clicking btn_recent1 (the most-recent slot, af.po
+    # here given this check's own earlier Ctrl+O) is both simpler and,
+    # per that same reference screenshot's real 848x633 dimensions,
+    # calibrated against an actual observed position rather than a blind
+    # guess - still best-effort without a UI Automation tree, hence the
+    # saved screenshots.
+    $t = Start-VirtaalTest -ExePath $install.ExePath
+    if (-not $t) {
+        Add-Result "Welcome screen: open dialog + Recent Files" "Fail" "app didn't launch"
+    } else {
+        $dlg = Open-VirtaalFileViaDialog $t (Resolve-Path "po\af.po").Path
+        if (-not $dlg) {
+            Add-Result "Welcome screen: open dialog + Recent Files" "Fail" "Ctrl+O never opened a file dialog"
+        } else {
+            $titleAfterOpen = Get-VirtaalTitle $t
+            if ($titleAfterOpen -notmatch "af\.po") {
+                $shot = Save-VirtaalScreenshot $t
+                Add-Result "Welcome screen: open dialog + Recent Files" "Fail" "title after Open dialog=`"$titleAfterOpen`" - expected it to mention af.po - screenshot: $shot"
+            } else {
+                Send-VirtaalKeys $t "^w"
+                Start-Sleep -Milliseconds 500
+                # af.po opened via this exact dialog path (not a CLI
+                # argument) still shows the spurious-modified-on-open bug -
+                # "title after clicking Recent Files=`"*af.po -
+                # Virtaal`"" slipped through as a Pass before this fix,
+                # because the old assertion only checked the filename
+                # appeared, never the leading '*'. A real edit *there*
+                # would also mean this Ctrl+W opens a genuine
+                # unsaved-changes dialog instead of just closing - check
+                # for one defensively rather than blindly clicking
+                # through and risking the click landing on the dialog
+                # instead of the Welcome screen's own Recent Files list.
+                $unexpectedDlg = Wait-VirtaalPopup $t -TimeoutSeconds 2
+                if ($unexpectedDlg) {
+                    $dlgTitle = Get-VirtaalWindowText $unexpectedDlg
+                    $shot = Save-VirtaalScreenshot $t
+                    Add-Result "Welcome screen: open dialog + Recent Files" "Fail" "unexpected dialog after Ctrl+W (title=`"$dlgTitle`") - af.po was likely spuriously marked modified on open - screenshot: $shot"
+                    Close-VirtaalPopup $t $unexpectedDlg
+                } else {
+                    $shotBeforeClick = Save-VirtaalScreenshot $t
+                    Send-VirtaalClick $t -XFraction 0.10 -YFraction 0.436
+                    $titleAfterRecent = Get-VirtaalTitle $t
+                    if ($titleAfterRecent -match "af\.po" -and -not $titleAfterRecent.StartsWith("*")) {
+                        Add-Result "Welcome screen: open dialog + Recent Files" "Pass" "title after clicking Recent Files=`"$titleAfterRecent`""
+                    } else {
+                        $shotAfterClick = Save-VirtaalScreenshot $t
+                        Add-Result "Welcome screen: open dialog + Recent Files" "Fail" "title after clicking Recent Files=`"$titleAfterRecent`" - screenshots: $shotBeforeClick, $shotAfterClick"
+                    }
+                }
+            }
+        }
+    }
+}
+
+Invoke-VirtaalCheck "Ctrl+P opens Preferences" {
+    # Reported live, 2026-08-24: the gallery review for this check only
+    # had the launch-moment screenshot, taken before Ctrl+P was even
+    # sent - couldn't confirm the dialog actually rendered correctly
+    # either way. Preferences is a real separate top-level window, not
+    # part of the main one, so Save-VirtaalScreenshot (which reads
+    # $Instance.Hwnd) needs a lightweight synthetic "instance" wrapping
+    # the dialog's own HWND rather than the main window's.
+    $t = Start-VirtaalTest -ExePath $install.ExePath -Arguments "devsupport\testfiles\checks.po"
+    if (-not $t) {
+        Add-Result "Ctrl+P opens Preferences" "Fail" "app didn't launch"
+    } else {
+        Send-VirtaalKeys $t "^p"
+        $dlg = Wait-VirtaalPopup $t -TimeoutSeconds 5
+        if (-not $dlg) {
+            Add-Result "Ctrl+P opens Preferences" "Fail" "no dialog appeared"
+        } else {
+            $dlgTitle = Get-VirtaalWindowText $dlg
+            $shot = Save-VirtaalScreenshot ([PSCustomObject]@{ Hwnd = $dlg })
+            Close-VirtaalPopup $t $dlg
+            $stillAlive = Get-Process -Id $t.Process.Id -ErrorAction SilentlyContinue
+            $logsClean = if ($stillAlive) { Assert-VirtaalLogsClean } else { $false }
+            Add-Result "Ctrl+P opens Preferences" $(if ($stillAlive -and $logsClean) { "Pass" } else { "Fail" }) "dialog title=`"$dlgTitle`"$(if (-not $stillAlive) { ' - process exited after closing it' } elseif (-not $logsClean) { ' - unexpected log output' }) - screenshot: $shot"
+        }
+    }
+}
+
+Invoke-VirtaalCheck "Ctrl+F search/filter" {
+    # SearchMode ("Includes only units matching the given search string"
+    # - modes\searchmode.py) is Virtaal's filter-by-string feature -
+    # embedded in the main window (a mode swapped in by ModeController),
+    # not a separate dialog, so no Wait-VirtaalPopup needed here.
+    #
+    # Reported live, 2026-08-24: the gallery review for this check only
+    # had the launch-moment screenshot, taken before Ctrl+F was even
+    # sent - couldn't confirm the search bar actually rendered correctly
+    # either way. Screenshots now taken with the search bar actually
+    # active, before Escape closes it again.
+    $t = Start-VirtaalTest -ExePath $install.ExePath -Arguments "devsupport\testfiles\checks.po"
+    if (-not $t) {
+        Add-Result "Ctrl+F search/filter" "Fail" "app didn't launch"
+    } else {
+        Send-VirtaalKeys $t "^f"
+        Send-VirtaalKeys $t "test"
+        $shot = Save-VirtaalScreenshot $t
+        Send-VirtaalKeys $t "{ESC}"
+        $stillAlive = Get-Process -Id $t.Process.Id -ErrorAction SilentlyContinue
+        $logsClean = if ($stillAlive) { Assert-VirtaalLogsClean } else { $false }
+        Add-Result "Ctrl+F search/filter" $(if ($stillAlive -and $logsClean) { "Pass" } else { "Fail" }) "$(if (-not $stillAlive) { 'process exited' } elseif (-not $logsClean) { 'unexpected log output - see above' } else { "screenshot: $shot" })"
+    }
+}
+
+Invoke-VirtaalCheck "F8 quality checks panel" {
+    # Toggles the panel on and off against devsupport\testfiles\
+    # checks.po, a file specifically built to exercise translate-
+    # toolkit's checks - if any single check throws on real data, that's
+    # exactly the kind of thing that lands as a traceback in the app's
+    # own log, which Assert-VirtaalLogsClean would catch (this doesn't
+    # read the checks panel's actual *contents*, no UI Automation tree
+    # available here to do that - just that showing/hiding it and
+    # running checks against a file designed to trigger several of them
+    # doesn't crash or log an error).
+    #
+    # Pointed out live, 2026-08-24: F8 should specifically be tested
+    # where there's actually something to show, same gap as the
+    # placeable check before its own fix - checks.po's *first* unit
+    # ("word", untranslated) may not trigger the same range of checks a
+    # deliberately-broken one would. Every unit in this file is
+    # purpose-built to trigger one specific named check (see its own
+    # comments: "Should trigger 'unchanged'", 'blank', 'short', 'long',
+    # 'escapes', ...), but F8's real value is seeing *more than one*
+    # check flagged on the same unit at once, per a follow-up refinement
+    # - "Just normal sentence case" -> "A Title Case Happy Translator Was
+    # Here" is a good candidate for that: title-case-vs-sentence-case
+    # (its own labelled 'simplecaps' check) and a target more than
+    # double the source's length (plausibly also tripping 'long'), on
+    # one unit. Navigates there via Ctrl+F/Escape, the same pattern
+    # already proven for the placeable check. Still can't read the
+    # panel's actual *contents* without a UI Automation tree - a
+    # screenshot is the real evidence here, same honest bar as the click
+    # checks.
+    $t = Start-VirtaalTest -ExePath $install.ExePath -Arguments "devsupport\testfiles\checks.po"
+    if (-not $t) {
+        Add-Result "F8 quality checks panel" "Fail" "app didn't launch"
+    } else {
+        Find-VirtaalUnit $t "Just normal sentence case"
+        Send-VirtaalKeys $t "{F8}"
+        $shot = Save-VirtaalScreenshot $t
+        Send-VirtaalKeys $t "{F8}"
+        $stillAlive = Get-Process -Id $t.Process.Id -ErrorAction SilentlyContinue
+        $logsClean = if ($stillAlive) { Assert-VirtaalLogsClean } else { $false }
+        Add-Result "F8 quality checks panel" $(if ($stillAlive -and $logsClean) { "Pass" } else { "Fail" }) "$(if (-not $stillAlive) { 'process exited' } elseif (-not $logsClean) { 'unexpected log output - see above' } else { "on a unit with multiple likely failures - screenshot: $shot" })"
+    }
+}
+
+Invoke-VirtaalCheck "Navigation mode switching (Incomplete/Quality Checks/Workflow)" {
+    # The "Navigation:" combo (modeview.py's cmb_modes, a plain
+    # Gtk.ComboBoxText) offers 5 modes: All and Search are already
+    # exercised elsewhere (App launches on All by default; Ctrl+F has
+    # its own dedicated accelerator, tested by the search checks above) -
+    # this is the first coverage anywhere in this battery for the other
+    # three: Incomplete (quicktransmode.py), Quality Checks
+    # (qualitycheckmode.py), Workflow (workflowmode.py).
+    #
+    # First attempt (Alt+A mnemonic focus + type-ahead) confirmed live,
+    # 2026-08-25, to fail identically for all three modes - "Incomplete:
+    # NOT reached; Quality Checks: NOT reached; Workflow: NOT reached",
+    # screenshot showing "Navigation: All" untouched. That's consistent
+    # with the mnemonic focus step itself never landing (if the combo
+    # never gets focus, none of the type-ahead presses that follow do
+    # anything) - not re-guessing at why *that* specific mechanism
+    # failed (no menu-bar equivalent exists to cross-check against
+    # either - confirmed by reading virtaal.ui's own menu_navigation
+    # contents: just Up/Down/Page Up/Page Down, nothing about these
+    # three modes).
+    #
+    # Switched to a mechanism already proven live elsewhere in this
+    # battery instead: a real mouse click (coordinates read directly off
+    # a real saved screenshot of this exact combo, not guessed) to open
+    # the popup, then Home (jump to the first item, "All", removing any
+    # dependency on knowing what was selected before) + Down N times +
+    # Enter to reach the target mode by absolute position - arrow-key
+    # navigation *within an already-open* GTK combo popup is standard,
+    # well-established behaviour, unlike the closed-combo mnemonic/
+    # type-ahead path that just failed. Combo order confirmed by reading
+    # modes/__init__.py's modeclasses list: 0=All, 1=Incomplete,
+    # 2=Search, 3=Quality Checks, 4=Workflow.
+    #
+    # Screenshots the open popup itself for the *first* mode only (not
+    # all three, to keep this check's output manageable) - if this still
+    # doesn't work, that one screenshot tells us directly whether the
+    # click even opened the popup at all, isolating that from whether
+    # the keyboard selection within it worked, rather than having to
+    # guess between two possible failure points again.
+    #
+    # Verified via modecontroller.py's own "Mode selected: %s" INFO log
+    # line (self.current_mode.name, the internal name - QuickTranslate/
+    # QualityCheck/Workflow, not the display name) - -DebugLog on just
+    # this one check (not the whole run's -AppDebugLog) turns Virtaal's
+    # own logging on for this launch only, so this doesn't depend on the
+    # whole battery being run with -AppDebugLog to self-verify.
+    #
+    # Deliberately not going deeper than "the mode was reached without
+    # crashing" here - actually selecting a specific Workflow state (its
+    # own separate "Select States" popup button, opened only once
+    # Workflow mode is active) or confirming Quality Checks/Incomplete
+    # genuinely narrow the visible unit list to the right ones would be
+    # real, valuable follow-ups, not built here - same starting depth this battery used for Search
+    # mode itself, before the placeable-stepping check dug further in.
+    $t = Start-VirtaalTest -ExePath $install.ExePath -Arguments "devsupport\testfiles\checks.po" -DebugLog
+    if (-not $t) {
+        Add-Result "Navigation mode switching (Incomplete/Quality Checks/Workflow)" "Fail" "app didn't launch"
+    } else {
+        # Combo box "Navigation: All" - coordinates read directly off a
+        # real saved screenshot (848x633, this battery's standard
+        # window size), not guessed.
+        $comboX = 0.177
+        $comboY = 0.160
+        $modes = @(
+            @{ DownPresses = 1; DisplayName = 'Incomplete'; InternalName = 'QuickTranslate' },
+            @{ DownPresses = 3; DisplayName = 'Quality Checks'; InternalName = 'QualityCheck' },
+            @{ DownPresses = 4; DisplayName = 'Workflow'; InternalName = 'Workflow' }
+        )
+        $detail = @()
+        $allReached = $true
+        $firstPopupShot = $null
+        foreach ($mode in $modes) {
+            Send-VirtaalClick $t $comboX $comboY
+            Start-Sleep -Milliseconds 500
+            if (-not $firstPopupShot) {
+                $firstPopupShot = Save-VirtaalScreenshot $t
+            }
+            Send-VirtaalKeys $t "{HOME}"
+            Start-Sleep -Milliseconds 300
+            if ($mode.DownPresses -gt 0) {
+                Send-VirtaalKeys $t ("{DOWN}" * $mode.DownPresses)
+                Start-Sleep -Milliseconds 300
+            }
+            Send-VirtaalKeys $t "{ENTER}"
+            Start-Sleep -Milliseconds 800
+            $logs = Get-VirtaalLogs
+            $reached = @($logs.Stdout + $logs.Stderr) | Where-Object { $_ -match "Mode selected: $($mode.InternalName)$" }
+            if ($reached) {
+                $detail += "$($mode.DisplayName): reached"
+            } else {
+                $allReached = $false
+                $detail += "$($mode.DisplayName): NOT reached"
+            }
+        }
+        $shot = Save-VirtaalScreenshot $t
+        # Back to All, tidy state before teardown - same click+Home+Enter
+        # mechanism, no Down presses needed since All is index 0.
+        Send-VirtaalClick $t $comboX $comboY
+        Start-Sleep -Milliseconds 500
+        Send-VirtaalKeys $t "{HOME}"
+        Start-Sleep -Milliseconds 300
+        Send-VirtaalKeys $t "{ENTER}"
+        $stillAlive = Get-Process -Id $t.Process.Id -ErrorAction SilentlyContinue
+        $logsClean = if ($stillAlive) { Assert-VirtaalLogsClean -AllowDebugLog } else { $false }
+        Add-Result "Navigation mode switching (Incomplete/Quality Checks/Workflow)" $(if ($stillAlive -and $logsClean -and $allReached) { "Pass" } else { "Fail" }) "$(if (-not $stillAlive) { 'process exited' } elseif (-not $logsClean) { 'unexpected log output - see above' } else { ($detail -join '; ') + " - popup screenshot: $firstPopupShot - final screenshot: $shot" })"
+    }
+}
+
+Invoke-VirtaalCheck "Plural-form units load cleanly (nplurals=3 and nplurals=1)" {
+    # Neither checks.po, af.po, ar.po, nor anything else this battery
+    # uses has a single genuine msgid_plural unit - confirmed by
+    # grepping every file under devsupport/testfiles and po/af.po,
+    # po/ar.po before writing this - so unitview.py's plural-form
+    # target-widget layout (_layout_update_units(): one target textbox
+    # per plural form, shown/hidden based on
+    # lang_controller.target_lang.nplurals, not by how many msgstr[]
+    # entries the raw file happens to have) had never been exercised by
+    # anything in this test battery until now.
+    #
+    # Two fixtures, two genuinely different code paths, not the same
+    # thing twice: plurals.po (Language: pl, nplurals=3) should show
+    # *three* target textboxes for its plural units; plurals-zero.po
+    # (Language: ja, nplurals=1) should show only *one*, despite being
+    # an equally genuine msgid_plural unit - confirmed via
+    # translate.lang.factory.getlanguage('pl'/'ja').nplurals before
+    # building each file. Both also carry one ordinary non-plural unit,
+    # to confirm plural and non-plural units coexist in the same file
+    # without issue.
+    #
+    # Same "confirm it doesn't crash and nothing unexpected is logged"
+    # baseline depth as this session's other brand-new coverage today
+    # (navigation-mode switching) - actually verifying which/how many
+    # target textboxes are visually present needs a human looking at
+    # the screenshot, no UI Automation tree available here to do that
+    # directly.
+    $allOk = $true
+    $detail = @()
+    foreach ($file in @("devsupport\testfiles\plurals.po", "devsupport\testfiles\plurals-zero.po")) {
+        $t = Start-VirtaalTest -ExePath $install.ExePath -Arguments $file
+        if (-not $t) {
+            $allOk = $false
+            $detail += "$file - app didn't launch"
+            continue
+        }
+        $shot = Save-VirtaalScreenshot $t
+        $stillAlive = Get-Process -Id $t.Process.Id -ErrorAction SilentlyContinue
+        $logsClean = if ($stillAlive) { Assert-VirtaalLogsClean } else { $false }
+        if ($stillAlive -and $logsClean) {
+            $detail += "$file - loaded cleanly, screenshot: $shot"
+        } else {
+            $allOk = $false
+            $detail += "$file - $(if (-not $stillAlive) { 'process exited' } else { 'unexpected log output - see above' })"
+        }
+        Stop-VirtaalTest $t
+    }
+    Add-Result "Plural-form units load cleanly (nplurals=3 and nplurals=1)" $(if ($allOk) { "Pass" } else { "Fail" }) ($detail -join "; ")
+}
+
+Invoke-VirtaalCheck "Placeable navigation/transfer shortcuts" {
+    # <Virtaal>/Edit/Prev Placeable, Next Placeable (Alt+Left/Right -
+    # jump between placeables in the target) and Transfer (Alt+Down -
+    # copies source to an empty target) - see unitview.py's
+    # _setup_key_bindings. Only Alt+Down has an observable effect worth
+    # checking for (copying into an *empty* target sets the modified
+    # marker); like "Type + Ctrl+Z" above, this is Skipped rather than
+    # Failed if the current unit's target already had text (transfer
+    # then does nothing) rather than assuming every test file's first
+    # unit is untranslated.
+    $t = Start-VirtaalTest -ExePath $install.ExePath -Arguments "devsupport\testfiles\checks.po"
+    if (-not $t) {
+        Add-Result "Placeable navigation/transfer shortcuts" "Fail" "app didn't launch"
+    } else {
+        Send-VirtaalKeys $t "%{RIGHT}"
+        Send-VirtaalKeys $t "%{LEFT}"
+        $titleBefore = Get-VirtaalTitle $t
+        Send-VirtaalKeys $t "%{DOWN}"
+        $titleAfter = Get-VirtaalTitle $t
+        $stillAlive = Get-Process -Id $t.Process.Id -ErrorAction SilentlyContinue
+        if (-not $stillAlive) {
+            Add-Result "Placeable navigation/transfer shortcuts" "Fail" "process exited"
+        } elseif ($titleAfter.StartsWith("*") -and -not $titleBefore.StartsWith("*")) {
+            Add-Result "Placeable navigation/transfer shortcuts" "Pass" "Alt+Down transferred source to an empty target"
+        } else {
+            $logsClean = Assert-VirtaalLogsClean
+            Add-Result "Placeable navigation/transfer shortcuts" $(if ($logsClean) { "Skip" } else { "Fail" }) $(if ($logsClean) { "no crash; Alt+Down had no observable effect - target likely wasn't empty" } else { "unexpected log output - see above" })
+        }
+    }
+}
+
+Invoke-VirtaalCheck "Placeable stepping and copy-into-target on a real placeable" {
+    # The check above exercises Alt+Left/Right/Down against whatever
+    # unit happens to be first in checks.po - which has no actual
+    # placeables (an XML tag, a printf %s, ...) to select, so it never
+    # touches unitview.py's real placeable-stepping/insert code path at
+    # all. Pointed out live, 2026-08-24: checks.po line 171
+    # ("XML tags are <b>fun</b>") genuinely has placeables the app
+    # would highlight and let you step between - and, confirmed by
+    # reading copy_original() (unitview.py): when a placeable is
+    # currently selected, Alt+Down takes a completely different branch
+    # than the "transfer whole source" one the existing check exercises
+    # - it inserts *just that placeable* into the target
+    # (textbox.insert_translation(selected_elem)) and auto-advances to
+    # the next one (move_elem_selection(1)) - a real, previously
+    # entirely untested code path.
+    #
+    # Navigates to that unit via Ctrl+F (searchmode.py's
+    # _on_entry_activate selects the first match on Enter) rather than
+    # counting Down-presses to it, so this keeps working regardless of
+    # where the unit sits in the file. No way to verify *which*
+    # placeable ends up selected/highlighted without a UI Automation
+    # tree - screenshots at each step are the only real evidence here,
+    # same honest bar as the click checks.
+    #
+    # {ESC} originally did NOT exit Search mode - confirmed live,
+    # 2026-08-24, via a saved screenshot showing the search bar still
+    # fully active with Alt+Right/Down having had no effect (this check
+    # reported Skip that run instead of Pass/Fail - not a false
+    # negative, a real gap this check hadn't accounted for). Traced to a
+    # genuine, separate accessibility bug rather than a wrong assumption
+    # in this script: there was no Escape binding anywhere in
+    # searchmode.py at all - the only way out of Search mode was the
+    # "Navigation:" mode dropdown, a mouse-only path, against Virtaal's
+    # own keyboard-only-navigation goal. Fixed at the source
+    # (searchmode.py's _on_close_search(), same commit as this comment) -
+    # Escape now calls back into ModeController.select_default_mode()
+    # when Search is the active mode. This check now doubles as that
+    # fix's own regression test.
+    $t = Start-VirtaalTest -ExePath $install.ExePath -Arguments "devsupport\testfiles\checks.po"
+    if (-not $t) {
+        Add-Result "Placeable stepping and copy-into-target on a real placeable" "Fail" "app didn't launch"
+    } else {
+        Find-VirtaalUnit $t "XML tags"
+        $shotAtUnit = Save-VirtaalScreenshot $t
+        Send-VirtaalKeys $t "%{RIGHT}"
+        $shotAfterStep1 = Save-VirtaalScreenshot $t
+        Send-VirtaalKeys $t "%{RIGHT}"
+        $shotAfterStep2 = Save-VirtaalScreenshot $t
+        $titleBeforeInsert = Get-VirtaalTitle $t
+        Send-VirtaalKeys $t "%{DOWN}"
+        $titleAfterInsert = Get-VirtaalTitle $t
+        $stillAlive = Get-Process -Id $t.Process.Id -ErrorAction SilentlyContinue
+        if (-not $stillAlive) {
+            Add-Result "Placeable stepping and copy-into-target on a real placeable" "Fail" "process exited - screenshots: $shotAtUnit, $shotAfterStep1, $shotAfterStep2"
+        } else {
+            $logsClean = Assert-VirtaalLogsClean
+            if (-not $logsClean) {
+                Add-Result "Placeable stepping and copy-into-target on a real placeable" "Fail" "unexpected log output - see above"
+            } elseif ($titleAfterInsert.StartsWith("*") -and -not $titleBeforeInsert.StartsWith("*")) {
+                Add-Result "Placeable stepping and copy-into-target on a real placeable" "Pass" "Alt+Down inserted a placeable - screenshots: $shotAtUnit, $shotAfterStep1, $shotAfterStep2"
+            } else {
+                Add-Result "Placeable stepping and copy-into-target on a real placeable" "Skip" "no crash; no observable modified-marker change from Alt+Down - see screenshots to confirm placeable selection actually happened: $shotAtUnit, $shotAfterStep1, $shotAfterStep2"
+            }
+        }
+    }
+}
+
+Invoke-VirtaalCheck "Click navigation" {
+    # No UI Automation tree is available here to ask "where is row 2",
+    # so this clicks at a guessed position (fractions of the window's
+    # own rect - roughly where the unit-list strip sits, per Virtaal's
+    # general layout: menu/toolbar at top, a compact list of units below
+    # that, the source/target editor filling the rest) and checks for a
+    # plausible *effect* (typing afterwards sets the modified marker,
+    # meaning the click landed in an editable target field) rather than
+    # verifying the click precisely. Screenshots are saved either way,
+    # specifically so a human (or a future Claude session with this same
+    # repo shared back) can look at where the click actually landed and
+    # retune XFraction/YFraction if this keeps Skipping.
+    $t = Start-VirtaalTest -ExePath $install.ExePath -Arguments "po\af.po"
+    if (-not $t) {
+        Add-Result "Click navigation" "Fail" "app didn't launch"
+    } else {
+        $shotBefore = Save-VirtaalScreenshot $t
+        Send-VirtaalClick $t -XFraction 0.5 -YFraction 0.15
+        Send-VirtaalKeys $t "x"
+        $title = Get-VirtaalTitle $t
+        $shotAfter = Save-VirtaalScreenshot $t
+        $stillAlive = Get-Process -Id $t.Process.Id -ErrorAction SilentlyContinue
+        if (-not $stillAlive) {
+            Add-Result "Click navigation" "Fail" "process exited - screenshots: $shotBefore, $shotAfter"
+        } elseif ($title.StartsWith("*")) {
+            Add-Result "Click navigation" "Pass" "click appears to have focused an editable field - screenshots: $shotBefore, $shotAfter"
+        } else {
+            Add-Result "Click navigation" "Skip" "click at (0.5, 0.15) didn't land in an editable field (title=`"$title`") - see $shotBefore / $shotAfter to retune the coordinates"
+        }
+    }
+}
+
+Invoke-VirtaalCheck "Click: check-type (Project Type) selector" {
+    # ChecksProjectView's "Checks: <name>" PopupMenuButton (e.g. GNOME/
+    # Mozilla/OpenOffice style) - checksprojview.py packs it into the
+    # status bar via pack_start, so bottom-*left*, not bottom-right
+    # (that's the language-pair selector below - two different widgets,
+    # only one of them actually on the right). Both are PopupMenuButtons
+    # that open a Gtk.Menu on click rather than a real top-level dialog,
+    # so Wait-VirtaalPopup's GetForegroundWindow() approach isn't used
+    # here (a GTK popup menu doesn't reliably take Win32 foreground focus
+    # the way a real Gtk.Dialog does) - Escape closes it either way
+    # (harmless even if nothing was open), and this only confirms no
+    # crash/log error, the same honest bar as "Click navigation" above.
+    # Coordinates calibrated against a real screenshot, 2026-08-24 (the
+    # original 0.12/0.98 guess was wrong on both axes - confirmed
+    # missing entirely, no popup ever appeared in either the before or
+    # after capture across two separate reviews). "Checks: GNOME" itself
+    # actually sits at roughly x=0.67, y=0.92 of the window - well right
+    # of centre, not near the left edge as pack_start's *code-level*
+    # position among the status bar's children had suggested, and the
+    # status bar's real height means 0.98 was clipping below its visible
+    # text into the window's bottom border/resize-grip area entirely.
+    #
+    # Reported live, 2026-08-24, even after that recalibration: still no
+    # visible menu in either screenshot. Switched to a full-*screen*
+    # capture (Save-VirtaalFullScreenScreenshot), not just the window's
+    # own rect - a GTK popup menu is a separate top-level window that
+    # isn't guaranteed to stay within its parent's bounding box,
+    # especially one anchored this close to a window edge (see that
+    # function's own comments) - if the click is landing correctly (the
+    # coordinates were independently confirmed against the button's real
+    # position in a different screenshot) but the menu still isn't
+    # visible in a full-screen capture, that would be real evidence of
+    # an actual click-mechanism problem rather than a capture-area one.
+    $t = Start-VirtaalTest -ExePath $install.ExePath -Arguments "devsupport\testfiles\checks.po"
+    if (-not $t) {
+        Add-Result "Click: check-type (Project Type) selector" "Fail" "app didn't launch"
+    } else {
+        $shotBefore = Save-VirtaalFullScreenScreenshot
+        Send-VirtaalClick $t -XFraction 0.67 -YFraction 0.92
+        $shotAfter = Save-VirtaalFullScreenScreenshot
+        Send-VirtaalKeys $t "{ESC}"
+        $stillAlive = Get-Process -Id $t.Process.Id -ErrorAction SilentlyContinue
+        $logsClean = if ($stillAlive) { Assert-VirtaalLogsClean } else { $false }
+        Add-Result "Click: check-type (Project Type) selector" $(if ($stillAlive -and $logsClean) { "Pass" } else { "Fail" }) "$(if (-not $stillAlive) { 'process exited' } elseif (-not $logsClean) { 'unexpected log output - see above' } else { 'no crash - see screenshots to confirm the menu actually opened' }) - screenshots: $shotBefore, $shotAfter"
+    }
+}
+
+Invoke-VirtaalCheck "Click: language-pair selector" {
+    # LanguageView's "<source> -> <target>" PopupMenuButton -
+    # langview.py packs it into the status bar via pack_end, so this one
+    # genuinely is bottom-right. Same best-effort approach and caveats as
+    # the check-type selector check above - coordinates likewise
+    # recalibrated, 2026-08-24, against a real screenshot: the label
+    # actually sits at roughly x=0.83, y=0.92, not 0.9/0.98. Also
+    # switched to a full-screen capture, same reasoning as that check.
+    $t = Start-VirtaalTest -ExePath $install.ExePath -Arguments "devsupport\testfiles\checks.po"
+    if (-not $t) {
+        Add-Result "Click: language-pair selector" "Fail" "app didn't launch"
+    } else {
+        $shotBefore = Save-VirtaalFullScreenScreenshot
+        Send-VirtaalClick $t -XFraction 0.83 -YFraction 0.92
+        $shotAfter = Save-VirtaalFullScreenScreenshot
+        Send-VirtaalKeys $t "{ESC}"
+        $stillAlive = Get-Process -Id $t.Process.Id -ErrorAction SilentlyContinue
+        $logsClean = if ($stillAlive) { Assert-VirtaalLogsClean } else { $false }
+        Add-Result "Click: language-pair selector" $(if ($stillAlive -and $logsClean) { "Pass" } else { "Fail" }) "$(if (-not $stillAlive) { 'process exited' } elseif (-not $logsClean) { 'unexpected log output - see above' } else { 'no crash - see screenshots to confirm the menu actually opened' }) - screenshots: $shotBefore, $shotAfter"
+    }
+}
+
+Invoke-VirtaalCheck "Ctrl+S with known translator info saves directly" {
+    # Never tested before this - every earlier check either undoes a
+    # change before closing or never leaves the file dirty at all. Uses
+    # a scratch copy (see New-VirtaalScratchFile) and checks the file's
+    # own LastWriteTime actually changed on disk, not just that the UI
+    # marker cleared - directly relevant given this whole session was
+    # about the modified marker not always reflecting reality.
+    #
+    # Explicitly forces "translator info already known" via
+    # Set-VirtaalTranslatorInfo first - a real live failure here
+    # (2026-08-24) turned out to be storemodel.py's own legitimate
+    # "Header information" prompt (mainview.py's EntryDialog, shown by
+    # _update_header() whenever name/email/team are unset) blocking the
+    # save, not a bug - correct behaviour when that info really is
+    # missing, but this check specifically wants the direct-save path,
+    # so it no longer depends on whatever this VM's config happens to
+    # have from earlier runs. See the next check for the "info is
+    # genuinely missing" path, which the prompt exists for.
+    Set-VirtaalTranslatorInfo
+    $scratch = New-VirtaalScratchFile -SourceRelativePath "po\af.po" -Suffix "save-test"
+    $mtimeBefore = (Get-Item $scratch).LastWriteTimeUtc
+    $t = Start-VirtaalTest -ExePath $install.ExePath -Arguments "`"$scratch`""
+    if (-not $t) {
+        Add-Result "Ctrl+S with known translator info saves directly" "Fail" "app didn't launch"
+    } else {
+        Send-VirtaalKeys $t "x"
+        $titleAfterType = Get-VirtaalTitle $t
+        if (-not $titleAfterType.StartsWith("*")) {
+            # See "Type + Ctrl+Z clears modified marker"'s own comment on
+            # this exact symptom - screenshotting here too rather than
+            # guess-widening the timing again.
+            $shot = Save-VirtaalScreenshot $t
+            Add-Result "Ctrl+S with known translator info saves directly" "Skip" "typing didn't set the modified marker (title=`"$titleAfterType`") - target field may not have had default focus - screenshot: $shot"
+        } else {
+            Send-VirtaalKeys $t "^s" -SettleMs 800
+            # Kept as a safety net even with translator info forced
+            # known above - if it fires now, that's itself worth
+            # knowing (something *else* is blocking the save).
+            $blockingDlg = Wait-VirtaalPopup $t -TimeoutSeconds 2
+            if ($blockingDlg) {
+                $blockingDlgTitle = Get-VirtaalWindowText $blockingDlg
+                $shot = Save-VirtaalScreenshot $t
+                Close-VirtaalPopup $t $blockingDlg
+                Add-Result "Ctrl+S with known translator info saves directly" "Fail" "an unexpected dialog (title=`"$blockingDlgTitle`") blocked the save despite translator info being pre-set - screenshot: $shot"
+            } else {
+                $titleAfterSave = Get-VirtaalTitle $t
+                $mtimeAfter = (Get-Item $scratch).LastWriteTimeUtc
+                $markerCleared = -not $titleAfterSave.StartsWith("*")
+                $fileWritten = $mtimeAfter -gt $mtimeBefore
+                if ($markerCleared -and $fileWritten) {
+                    Add-Result "Ctrl+S with known translator info saves directly" "Pass" "title after save=`"$titleAfterSave`", file written=$fileWritten"
+                } else {
+                    $shot = Save-VirtaalScreenshot $t
+                    Add-Result "Ctrl+S with known translator info saves directly" "Fail" "title after save=`"$titleAfterSave`", file written=$fileWritten - screenshot: $shot"
+                }
+            }
+        }
+    }
+}
+
+Invoke-VirtaalCheck "Ctrl+S with missing translator info prompts, then saves" {
+    # The other half of the case above, requested 2026-08-24: force
+    # translator info to genuinely be missing (Set-VirtaalTranslatorInfo
+    # -Missing), confirm mainview.py's "Header information" EntryDialog
+    # actually appears, drive through it, and confirm the save still
+    # completes afterward. The dialog's own text entry has
+    # set_activates_default(True) with Save as the default response, so
+    # {ENTER} alone submits it - even with an empty entry, since
+    # _update_header() only raises SaveCancelled on an outright Cancel
+    # (None), not an empty string. Settings' own Python-level default
+    # already fills "name" from the OS, so on a genuinely fresh profile
+    # only email and team are actually empty - loops up to 3 times
+    # (name/email/team) rather than assuming exactly 2, so it still
+    # works correctly if that default ever stops applying (e.g. a
+    # locked-down account with no resolvable OS username).
+    Set-VirtaalTranslatorInfo -Missing
+    $scratch = New-VirtaalScratchFile -SourceRelativePath "po\af.po" -Suffix "save-test-missing-header"
+    $mtimeBefore = (Get-Item $scratch).LastWriteTimeUtc
+    # -DebugLog (this check only, not the whole run - see
+    # -AppDebugLog's own cascade finding above) surfaces
+    # storecontroller.py's save_file() trace (92a6ed5d, added
+    # investigating this exact marker-not-clearing bug) so a failure
+    # here finally shows whether set_modified(False) is reached/
+    # succeeds, or something fires after it - no run has captured that
+    # trace for this check yet.
+    $t = Start-VirtaalTest -ExePath $install.ExePath -Arguments "`"$scratch`"" -DebugLog
+    if (-not $t) {
+        Add-Result "Ctrl+S with missing translator info prompts, then saves" "Fail" "app didn't launch"
+    } else {
+        Send-VirtaalKeys $t "x"
+        $titleAfterType = Get-VirtaalTitle $t
+        if (-not $titleAfterType.StartsWith("*")) {
+            # See "Type + Ctrl+Z clears modified marker"'s own comment.
+            $shot = Save-VirtaalScreenshot $t
+            Add-Result "Ctrl+S with missing translator info prompts, then saves" "Skip" "typing didn't set the modified marker (title=`"$titleAfterType`") - target field may not have had default focus - screenshot: $shot"
+        } else {
+            Send-VirtaalKeys $t "^s" -SettleMs 500
+            $promptCount = 0
+            for ($i = 0; $i -lt 3; $i++) {
+                $dlg = Wait-VirtaalPopup $t -TimeoutSeconds 3
+                if (-not $dlg) { break }
+                $dlgTitle = Get-VirtaalWindowText $dlg
+                if ($dlgTitle -ne "Header information") { break }
+                $promptCount++
+                Send-VirtaalPopupKeys $dlg "{ENTER}"
+            }
+            if ($promptCount -eq 0) {
+                Add-Result "Ctrl+S with missing translator info prompts, then saves" "Fail" "no 'Header information' prompt appeared despite translator info being cleared - Set-VirtaalTranslatorInfo -Missing may not have taken effect"
+            } else {
+                $titleAfterSave = Get-VirtaalTitle $t
+                $mtimeAfter = (Get-Item $scratch).LastWriteTimeUtc
+                $markerCleared = -not $titleAfterSave.StartsWith("*")
+                $fileWritten = $mtimeAfter -gt $mtimeBefore
+                if ($markerCleared -and $fileWritten) {
+                    Add-Result "Ctrl+S with missing translator info prompts, then saves" "Pass" "$promptCount prompt(s) answered, title after save=`"$titleAfterSave`", file written=$fileWritten"
+                } else {
+                    $shot = Save-VirtaalScreenshot $t
+                    # This check doesn't otherwise call Assert-VirtaalLogsClean
+                    # (it fails on title/mtime state, not log content), so
+                    # -AppDebugLog's instrumentation (searchmode.py/
+                    # unitcontroller.py/storecontroller.py's signal-chain
+                    # tracing, added investigating this exact marker-not-
+                    # clearing bug) was never actually surfaced here before -
+                    # confirmed live, 2026-08-25: a real run with -AppDebugLog
+                    # active reproduced this exact failure with zero debug
+                    # lines visible anywhere in the transcript. Dump the logs
+                    # unconditionally on failure now so the trace is actually
+                    # readable, not just known to exist somewhere on the VM.
+                    Write-VirtaalLogs
+                    Add-Result "Ctrl+S with missing translator info prompts, then saves" "Fail" "$promptCount prompt(s) answered, title after save=`"$titleAfterSave`", file written=$fileWritten - screenshot: $shot"
+                }
+            }
+        }
+    }
+    # Restore known-good state for hygiene, so this doesn't affect
+    # whatever check runs next.
+    Set-VirtaalTranslatorInfo
+}
+
+Invoke-VirtaalCheck "Real unsaved-changes dialog appears and Discard works" {
+    # Never tested before this either - every earlier check that closes
+    # a file either isn't actually dirty, or already undid its change
+    # first. mainview.py's confirm_dialog has three buttons (Save/
+    # _Discard/Cancel, Save is the *default* response) - explicitly
+    # activating Discard via its own Alt+D mnemonic rather than
+    # Enter/the default button, since accidentally hitting Save here
+    # would write real content (mitigated anyway by using a scratch
+    # copy, but there's no reason to rely on that as the only
+    # safeguard). Confirms the scratch file's mtime is untouched
+    # afterward - proof Discard genuinely discarded rather than saving.
+    $scratch = New-VirtaalScratchFile -SourceRelativePath "po\af.po" -Suffix "discard-test"
+    $mtimeBefore = (Get-Item $scratch).LastWriteTimeUtc
+    $t = Start-VirtaalTest -ExePath $install.ExePath -Arguments "`"$scratch`""
+    if (-not $t) {
+        Add-Result "Real unsaved-changes dialog appears and Discard works" "Fail" "app didn't launch"
+    } else {
+        Send-VirtaalKeys $t "x"
+        $titleAfterType = Get-VirtaalTitle $t
+        if (-not $titleAfterType.StartsWith("*")) {
+            # See "Type + Ctrl+Z clears modified marker"'s own comment.
+            $shot = Save-VirtaalScreenshot $t
+            Add-Result "Real unsaved-changes dialog appears and Discard works" "Skip" "typing didn't set the modified marker (title=`"$titleAfterType`") - target field may not have had default focus - screenshot: $shot"
+        } else {
+            Send-VirtaalKeys $t "^w"
+            $dlg = Wait-VirtaalPopup $t -TimeoutSeconds 5
+            if (-not $dlg) {
+                Add-Result "Real unsaved-changes dialog appears and Discard works" "Fail" "no confirm dialog appeared despite a real unsaved change"
+            } else {
+                Send-VirtaalPopupKeys $dlg "%d"
+                Start-Sleep -Milliseconds 500
+                $stillAlive = Get-Process -Id $t.Process.Id -ErrorAction SilentlyContinue
+                $mtimeAfter = if (Test-Path $scratch) { (Get-Item $scratch).LastWriteTimeUtc } else { $null }
+                $fileUntouched = $mtimeAfter -eq $mtimeBefore
+                Add-Result "Real unsaved-changes dialog appears and Discard works" $(if ($stillAlive -and $fileUntouched) { "Pass" } else { "Fail" }) "$(if (-not $stillAlive) { 'process exited after Discard' } elseif (-not $fileUntouched) { 'file was modified on disk - Discard may have actually saved' } else { 'file untouched, process alive' })"
+            }
+        }
+    }
+}
+
+Invoke-VirtaalCheck "Change file A, discard, open different file B: no spurious modified" {
+    # The actual shape of this session's headline bug (reported live:
+    # change file A, close/discard, open a *different* file B - B showed
+    # modified with nothing changed there yet - fixed across 10a51457,
+    # dfb2a447, 297f0aaa). "Welcome screen: open dialog + Recent Files"
+    # above reopens the *same* file, which doesn't exercise this at all
+    # - this check is the real regression test for that bug family.
+    # Open-VirtaalFileViaDialog navigates straight to B's full scratch
+    # path via the dialog's own Ctrl+L location bar, so it doesn't
+    # matter which directory the dialog happens to be browsing.
+    $scratchA = New-VirtaalScratchFile -SourceRelativePath "po\af.po" -Suffix "reopen-A"
+    $scratchB = New-VirtaalScratchFile -SourceRelativePath "po\ar.po" -Suffix "reopen-B"
+    $scratchBName = Split-Path -Leaf $scratchB
+    $t = Start-VirtaalTest -ExePath $install.ExePath -Arguments "`"$scratchA`""
+    if (-not $t) {
+        Add-Result "Change file A, discard, open different file B: no spurious modified" "Fail" "app didn't launch"
+    } else {
+        Send-VirtaalKeys $t "x"
+        $titleAfterType = Get-VirtaalTitle $t
+        if (-not $titleAfterType.StartsWith("*")) {
+            # See "Type + Ctrl+Z clears modified marker"'s own comment.
+            $shot = Save-VirtaalScreenshot $t
+            Add-Result "Change file A, discard, open different file B: no spurious modified" "Skip" "typing didn't set the modified marker on A (title=`"$titleAfterType`") - target field may not have had default focus - screenshot: $shot"
+        } else {
+            Send-VirtaalKeys $t "^w"
+            $dlg = Wait-VirtaalPopup $t -TimeoutSeconds 5
+            if (-not $dlg) {
+                Add-Result "Change file A, discard, open different file B: no spurious modified" "Fail" "no confirm dialog appeared for A despite a real unsaved change"
+            } else {
+                Send-VirtaalPopupKeys $dlg "%d"
+                Start-Sleep -Milliseconds 500
+                $openDlg = Open-VirtaalFileViaDialog $t $scratchB
+                if (-not $openDlg) {
+                    Add-Result "Change file A, discard, open different file B: no spurious modified" "Fail" "Ctrl+O never opened a file dialog after discarding A"
+                } else {
+                    $titleAfterOpenB = Get-VirtaalTitle $t
+                    $bOpened = $titleAfterOpenB -match [regex]::Escape($scratchBName)
+                    $bModified = $titleAfterOpenB.StartsWith("*")
+                    if ($bOpened -and -not $bModified) {
+                        Add-Result "Change file A, discard, open different file B: no spurious modified" "Pass" "title after opening B=`"$titleAfterOpenB`""
+                    } else {
+                        $shot = Save-VirtaalScreenshot $t
+                        # Same reasoning as the missing-translator-info check
+                        # above: this check doesn't otherwise call
+                        # Assert-VirtaalLogsClean, so -AppDebugLog's
+                        # signal-chain tracing (added investigating this
+                        # exact spurious-modified-marker bug) was never
+                        # actually surfaced here before. Dump unconditionally
+                        # on failure so it's readable when -AppDebugLog is
+                        # active for the run, not just present somewhere on
+                        # the VM's own disk.
+                        Write-VirtaalLogs
+                        Add-Result "Change file A, discard, open different file B: no spurious modified" "Fail" "title after opening B=`"$titleAfterOpenB`" - screenshot: $shot"
+                    }
+                }
+            }
+        }
+    }
+}
+
+Invoke-VirtaalCheck "First open: no visual glitch (manual) or modified marker (auto)" {
+    # Not a pass/fail check - "widgets overlapping near the top of the
+    # window on first opening a file" is a known, still-open render
+    # glitch (see storeview.py's show()) that has never reproduced
+    # locally on macOS despite direct attempts. There's no way to
+    # detect "widgets are overlapping" from window geometry/title
+    # alone - this just takes a screenshot at the exact moment the
+    # reported repro describes (fresh launch, Ctrl+O, type-ahead
+    # select, Enter) so there's always something to look at, not just
+    # when someone happens to notice it live.
+    $t = Start-VirtaalTest -ExePath $install.ExePath
+    if (-not $t) {
+        Add-Result "First open: no visual glitch (manual) or modified marker (auto)" "Fail" "app didn't launch"
+    } else {
+        Send-VirtaalKeys $t "^o"
+        $dlg = Wait-VirtaalPopup $t -TimeoutSeconds 8
+        if (-not $dlg) {
+            Add-Result "First open: no visual glitch (manual) or modified marker (auto)" "Fail" "Ctrl+O never opened a file dialog"
+        } else {
+            # Deliberately not using Open-VirtaalFileViaDialog here - its
+            # settle delay after Enter (1s) is tuned for reliable
+            # navigation, but this check specifically wants a screenshot
+            # as soon as possible after opening, before the glitch (if
+            # present) potentially clears on its own. Ctrl+L + full path,
+            # not a bare filename typed into the file list - see
+            # Open-VirtaalFileViaDialog's own history notes for why a
+            # bare filename isn't reliable (GTK3's file-chooser search is
+            # a broader search feature, not a same-directory filter, and
+            # returned "No Results Found" against this exact sequence in
+            # a saved screenshot from a live run, 2026-08-24).
+            Start-Sleep -Milliseconds 500
+            Send-VirtaalPopupKeys $dlg "^l"
+            Start-Sleep -Milliseconds 300
+            Send-VirtaalPopupKeys $dlg (Resolve-Path "po\af.po").Path
+            Start-Sleep -Milliseconds 300
+            Send-VirtaalPopupKeys $dlg "{ENTER}"
+            Start-Sleep -Milliseconds 300
+            $shot = Save-VirtaalScreenshot $t
+            # Confirmed live, 2026-08-24: this exact screenshot once
+            # showed *no* visible overlap at all, but did show the
+            # modified marker set on af.po despite zero interaction with
+            # the document (no typing anywhere in this check) - a
+            # different symptom than the visual glitch this check was
+            # built to catch, but plausibly the same root cause (the
+            # original theory here has always been select_index(0)'s
+            # first cell-editor racing with the treeview column's
+            # placeholder sizing - a race like that could as easily
+            # produce a stray "changed" signal as a visual glitch). Now a
+            # real assertion, not just a diagnostic Skip - the screenshot
+            # stays purely informational for the *visual* glitch (still
+            # no way to auto-detect "widgets are overlapping" from window
+            # geometry alone), but the modified-marker check doesn't need
+            # a human's eyes.
+            $title = Get-VirtaalTitle $t
+            if ($title.StartsWith("*")) {
+                # Same reasoning as the other two spurious-modified-marker
+                # checks: this one doesn't otherwise call
+                # Assert-VirtaalLogsClean, so -AppDebugLog's signal-chain
+                # tracing was never actually surfaced here before. Dump
+                # unconditionally on failure so it's readable when
+                # -AppDebugLog is active, not just present on the VM's disk.
+                Write-VirtaalLogs
+                Add-Result "First open: no visual glitch (manual) or modified marker (auto)" "Fail" "title=`"$title`" - modified marker set despite no interaction with the document - screenshot: $shot"
+            } else {
+                Add-Result "First open: no visual glitch (manual) or modified marker (auto)" "Skip" "modified marker correctly unset (title=`"$title`") - visual glitch itself not auto-verified, inspect $shot"
+            }
+        }
+    }
+}
+
+Write-Host "`n=== 4. Tear down ==="
+if (Test-Path $script:scratchDir) {
+    Remove-Item -Path $script:scratchDir -Recurse -Force -ErrorAction SilentlyContinue
+}
+if (-not $KeepInstalled) {
+    Uninstall-Virtaal | Out-Null
+} else {
+    Write-Host "Skipped (-KeepInstalled) - Virtaal remains installed at $($install.ExePath)"
+}
+
+Write-Host "`n=== Summary ==="
+$results | Format-Table -AutoSize | Out-String | Write-Host
+$failed = @($results | Where-Object { $_.Status -eq "Fail" })
+if ($failed) {
+    Write-Host "::error::$($failed.Count) check(s) failed"
+    exit 1
+}
+Write-Host "All checks passed (or were skipped with a stated reason)."
+exit 0
+
+} finally {
+    try { Stop-Transcript | Out-Null } catch { }
+}

--- a/devsupport/testing/windows/README.md
+++ b/devsupport/testing/windows/README.md
@@ -1,0 +1,265 @@
+# Windows testing recipes
+
+Two layers of Windows-side testing exist for Virtaal, covering different
+things:
+
+- **CI** (`.github/workflows/ci.yml`'s `build-windows-installer` job)
+  builds and UI-tests the raw PyInstaller bundle (`dist\virtaal\
+  virtaal.exe`) directly, then packages it into an installer as a final
+  step - it never actually *runs* that installer or its uninstaller.
+  Good for catching regressions in the app itself on every push, fast.
+- **This directory**, run by hand on a real Windows machine (VM or
+  physical box), tests the actual install/uninstall/reinstall cycle a
+  real user goes through - something CI's bundle-only checks can't
+  reach at all. At least one real report ("the unsaved marker seems to
+  persist between reinstalls") was specifically about behaviour across
+  that cycle.
+
+## Files
+
+- `virtaal_ui_test_helpers.ps1` - drives a running `virtaal.exe`
+  (launch, read window geometry/title via Win32, send keystrokes, read
+  the frozen build's log files, clean up). Used by both CI and the
+  local recipe below.
+- `virtaal_install_helpers.ps1` - installs/uninstalls Virtaal's real
+  Inno Setup package silently and idempotently, via the Windows
+  uninstall registry (works whether the install was per-user or
+  machine-wide - doesn't assume a fixed path).
+- `Invoke-VirtaalLocalTestPass.ps1` - orchestrates both: uninstall ->
+  install -> a battery of UI regression checks against the real
+  installed app -> uninstall again, with a pass/fail summary and a
+  process exit code.
+
+## Running a local test pass
+
+Windows' default PowerShell execution policy (`Restricted`) blocks
+running any local `.ps1` file at all, including this one - if you hit
+`... cannot be loaded because running scripts is disabled on this
+system`, allow it for just the current window (reverts automatically
+when you close it, no permanent/system-wide change):
+
+```powershell
+Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force
+```
+
+From the repo root, in PowerShell, on Windows:
+
+```powershell
+# Auto-discovers the newest installer under dist\installer or
+# dist\Virtaal-windows-installer
+.\devsupport\testing\windows\Invoke-VirtaalLocalTestPass.ps1
+```
+
+To test a specific installer (e.g. one downloaded from a CI run):
+
+```powershell
+gh run download <run-id> -R translate/virtaal -n Virtaal-windows-installer -D dist
+.\devsupport\testing\windows\Invoke-VirtaalLocalTestPass.ps1
+```
+
+That extracts the `.exe` flat into `dist\` (not into a
+`dist\Virtaal-windows-installer\` subfolder, despite the artifact's
+name - `gh run download -n <name> -D <dir>` uses `<dir>` as-is, it
+doesn't nest by artifact name) - auto-discovery checks a flat
+`dist\*.exe` too, alongside `dist\installer\` and
+`dist\Virtaal-windows-installer\`, so this just works either way.
+
+Or point at one directly:
+
+```powershell
+.\devsupport\testing\windows\Invoke-VirtaalLocalTestPass.ps1 -InstallerPath C:\Downloads\virtaal-1.0.0-beta1-setup.exe
+```
+
+Right after installing, the script runs `virtaal.exe --version` and
+checks the commit it reports (embedded at build time - see
+`virtaal/__version__.py`'s `build_commit`) against this checkout's own
+`git rev-parse HEAD`, aborting on a mismatch rather than silently
+testing a stale build. Pass `-SkipCommitCheck` to deliberately test a
+build that isn't expected to match HEAD (e.g. a specific old release).
+
+Useful switches:
+
+- `-SkipInitialUninstall` - test installing *on top of* whatever's
+  already there, instead of starting from a clean slate (the default).
+  Use this to specifically test an upgrade path.
+- `-KeepInstalled` - leave Virtaal installed afterwards instead of
+  tearing back down to a clean slate. Useful when you want to keep
+  poking at it by hand right after the automated battery finishes.
+- `-HumanDelayMs <n>` - runs at full speed by default; some dialogs
+  open and close within a few hundred milliseconds, real but too fast
+  to actually watch. `-HumanDelayMs 2000` adds a pause after every
+  interaction (keystroke, click, dialog appearing) uniformly, so you
+  can follow a run happening live instead of only reading its
+  transcript afterward.
+- `-RunTest <n,n,...>` - runs only the given check number(s), e.g.
+  `-RunTest 18,24`, instead of the full battery. Every check keeps the
+  same number it would have in a full run (the counter still advances
+  for skipped checks, it just doesn't run their bodies), so a number
+  from an earlier transcript or results table always points at the
+  same check. For drilling into or validating a fix for one or two
+  checks without waiting on a full pass - combine with
+  `-SkipInitialUninstall -KeepInstalled` to also skip reinstalling
+  between repeats:
+  ```powershell
+  .\devsupport\testing\windows\Invoke-VirtaalLocalTestPass.ps1 -RunTest 18,24 -SkipInitialUninstall -KeepInstalled
+  ```
+- `-AppDebugLog` - launches Virtaal with its own `-D`/`--debug` flag and
+  relaxes the log-content check to match, so the app's existing
+  `logging.debug()`/`logging.info()` calls (mode changes, search match
+  counts, which unit a match actually selected, ...) actually show up
+  in the transcript instead of being silently discarded (the logging
+  module is never configured at all without `-D`). `WARNING`/`ERROR`/
+  tracebacks still fail a check exactly as before - this only adds
+  tolerance for the expected extra detail. Most useful paired with
+  `-RunTest` when a check's pass/fail result makes sense but you need
+  to see *why* a specific interaction inside it did or didn't happen:
+  ```powershell
+  .\devsupport\testing\windows\Invoke-VirtaalLocalTestPass.ps1 -RunTest 18 -AppDebugLog -SkipInitialUninstall -KeepInstalled
+  ```
+
+The script exits 0 if every check passed, 1 otherwise - safe to use as
+a gate in a self-hosted Windows CI runner later, not just interactively.
+
+Every run's full console output is also written to a transcript under
+`.local-test-runs\<timestamp>.log` (gitignored) next to this README -
+if this repo checkout is itself a shared folder (e.g. a UTM share from
+a macOS host into a Windows VM), that transcript is readable directly
+from the host side afterwards without anything needing to be
+copy-pasted out of the Windows terminal. The app's own stdout/stderr
+logs (`%APPDATA%\Virtaal\std{out,err}_virtaal.log`) and the installer's
+log (`%TEMP%\virtaal-install-*.log`) live outside the repo tree and
+aren't captured this way on their own - but their content gets printed
+to the console (and so into the transcript too) automatically whenever
+a check that reads them fails. The click-navigation check also saves
+before/after screenshots to the same `.local-test-runs\` directory
+regardless of outcome, for the same reason - readable from the host
+side without anything needing to be copied out by hand.
+
+### What the battery covers
+
+- App launches cleanly (both with a file argument and from a bare
+  welcome screen - genuinely different startup code paths, see
+  `virtaal/main.py`'s `_open_with_file` vs `_open_with_welcome`).
+- A fresh install shows no modified marker on an untouched file.
+- Repeated navigation doesn't grow the window.
+- Type + Ctrl+Z clears the modified marker.
+- Common shortcuts (Ctrl+Z/X/C/V/O) don't crash.
+- Menu navigation (every top-level menu opens/closes cleanly).
+- Welcome screen -> a real File > Open dialog (not a CLI argument) ->
+  File > Recent Files reopens the same file.
+- Ctrl+P opens Preferences and it closes cleanly.
+- Ctrl+F's search/filter (`modes/searchmode.py`) doesn't crash.
+- F8's quality-checks panel doesn't crash or log an error against a
+  file built to exercise several checks.
+- Navigation-mode switching (`modes/`) to Incomplete, Quality Checks, and
+  Workflow - the "Navigation:" combo's other three modes (`All` and
+  `Search` are already covered by other checks) - verified via
+  `modecontroller.py`'s own log line that each mode was actually
+  reached, not just a screenshot. Doesn't yet verify a mode actually
+  narrows the visible unit list, or Workflow's own state-selector popup
+  - a real follow-up, not built here.
+- Plural-form units (`msgid_plural`) load cleanly, in both an
+  nplurals=3 file (`plurals.po`, Polish) and an nplurals=1 file
+  (`plurals-zero.po`, Japanese) - genuinely different code paths in
+  `unitview.py`'s target-widget layout, not the same case twice.
+  Doesn't yet verify the right *number* of target
+  textboxes actually renders - needs a human looking at the screenshot.
+- Placeable navigation/transfer (Alt+Left/Right/Down) - Alt+Down
+  specifically verified to copy source into an empty target.
+- Click navigation, and clicking the two status-bar `PopupMenuButton`s
+  (check-type/"Project Type" bottom-left, language-pair bottom-right) -
+  all three best-effort (see `Send-VirtaalClick`'s own comments for why
+  these are inherently a guess without a UI Automation tree available).
+- Ctrl+S actually saves and clears the modified marker - verified
+  against the file's own on-disk write time, not just the UI marker.
+- The real Save/Discard/Cancel dialog (not exercised by any other
+  check) appears on a genuine unsaved change, and Discard genuinely
+  discards - verified the file's on-disk write time is untouched
+  afterward.
+- Change file A, discard, open a *different* file B: B shows no
+  spurious modified marker - a different, harder-to-hit shape of the
+  reopen-modified-flag bug than a same-file reopen.
+- A diagnostic (not auto-verified) screenshot of the still-open
+  "widgets overlapping on first File>Open" layout glitch, taken at
+  the exact moment it would appear.
+- Ctrl+C from a clean state doesn't set the modified marker; Ctrl+V
+  right after does - Copy/Paste were previously only checked for "don't
+  crash", never that they get the modified flag right.
+- Alt+Enter opens Properties and closes cleanly (same shape as Ctrl+P).
+- F11 fullscreen returns the window to its original size afterward
+  (reported live to differ, 2026-08-24 - `_on_fullscreen()` is a plain
+  passthrough to GTK's own fullscreen()/unfullscreen(), so this is
+  measuring a GTK/GDK Windows-backend quirk, not app code).
+- Multi-step undo (two edits, two Ctrl+Z) clears the modified marker -
+  the existing single-step check can't distinguish "compares against a
+  fixed start" from "correctly walks back an arbitrary number of
+  steps".
+
+The three checks above that risk an actual save (Ctrl+S, and anything
+that could hit the confirm dialog's default Save button by mistake) all
+run against a disposable scratch copy under `%TEMP%\virtaal-test-
+scratch\` (`New-VirtaalScratchFile`, cleaned up in Tear down) - never
+`po\af.po`/`po\ar.po` directly - so no combination of SendKeys timing,
+the wrong dialog response, or a real bug can leave a git-tracked file
+modified on disk.
+
+None of this reaches into a check's *content* (e.g. what the checks
+panel actually lists, or whether the "right" recent file reopened
+beyond its filename appearing in the title) - there's no UI Automation
+tree wired up here, just Win32 window geometry/title/foreground-window
+plus SendKeys and a plain Win32 mouse click. That's enough to catch
+crashes, hangs, and the specific modified-flag/resize regressions this
+session was about; deeper content assertions would need a real
+Automation-tree library (e.g. FlaUI) wired in as a bigger follow-up.
+
+## Using the pieces separately
+
+Both helper files are meant to be dot-sourced and driven directly too,
+e.g. for a quick manual check or a one-off repro:
+
+```powershell
+. .\devsupport\testing\windows\virtaal_install_helpers.ps1
+. .\devsupport\testing\windows\virtaal_ui_test_helpers.ps1
+
+Uninstall-Virtaal | Out-Null
+$install = Install-Virtaal -InstallerPath C:\Downloads\virtaal-1.0.0-beta1-setup.exe
+$t = Start-VirtaalTest -ExePath $install.ExePath -Arguments "po\af.po"
+Get-VirtaalTitle $t          # e.g. "af.po - Virtaal"
+Send-VirtaalKeys $t "x"
+Get-VirtaalTitle $t          # e.g. "*af.po - Virtaal"
+Send-VirtaalKeys $t "^z"
+Get-VirtaalTitle $t          # back to "af.po - Virtaal"
+Stop-VirtaalTest $t
+Uninstall-Virtaal | Out-Null
+```
+
+`Get-VirtaalInstallInfo` (in `virtaal_install_helpers.ps1`) is a
+read-only status check - "is Virtaal currently installed, from where,
+what version" - with no side effects, useful before deciding whether to
+touch anything.
+
+## Future work: macOS and Linux
+
+None of this is reusable on macOS or Linux as-is - it's Windows
+technology throughout (Win32 P/Invoke, .NET `SendKeys`, Inno Setup's
+install/uninstall mechanics). The *list of what to test* (modified-flag
+correctness, undo behaviour, menu/dialog coverage, an install/uninstall
+cycle) is portable; the implementation isn't.
+
+- **macOS** already has a parallel, but much more limited: the
+  `run-virtaal` skill's `driver.sh` (launch + screenshot verification
+  only). Its own notes rule out AppleScript/System Events UI-scripting
+  as unreliable on this app (windows/processes it tries to address
+  intermittently don't resolve, or report 0 windows for one plainly on
+  screen) - there's no macOS equivalent yet of "click a button, type
+  text, read a dialog title back". Building one would need real
+  Accessibility API driving instead (e.g. via `atomac`/`ApplicationServices`
+  directly, not AppleScript's System Events layer).
+- **Linux** has no equivalent at all - CI's Linux job runs `pytest`
+  under Xvfb (headless unit/GUI tests), not an interactive UI battery.
+  Something similar here would need `xdotool`/`wmctrl` for a SendKeys-
+  equivalent, or AT-SPI accessibility driving for something closer to
+  real UI Automation.
+
+Neither is a small lift - not started, just noted here so it isn't
+lost.

--- a/devsupport/testing/windows/virtaal_install_helpers.ps1
+++ b/devsupport/testing/windows/virtaal_install_helpers.ps1
@@ -1,0 +1,210 @@
+# Reusable PowerShell helpers for installing and uninstalling Virtaal's
+# real Inno Setup package (dist\installer\*.exe / a downloaded
+# Virtaal-windows-installer artifact) on a Windows box - as opposed to
+# devsupport\testing\windows\virtaal_ui_test_helpers.ps1, which drives
+# the raw, unpacked PyInstaller bundle (dist\virtaal\virtaal.exe) that
+# CI's build-windows-installer job tests directly. Neither CI nor that
+# helpers file ever exercises the actual installer/uninstaller - which
+# matters, because at least one real report ("the unsaved marker seems
+# to persist between reinstalls") was specifically about behaviour
+# across an install/uninstall/reinstall cycle, something a bundle-only
+# check structurally cannot catch. Built so that cycle can be driven
+# reliably and repeatably on a real Windows machine instead of by hand
+# each time.
+#
+# Usage: dot-source this file, then call the functions below.
+#   . .\devsupport\testing\windows\virtaal_install_helpers.ps1
+#   Uninstall-Virtaal | Out-Null                      # clean slate, idempotent
+#   $install = Install-Virtaal                         # auto-discovers dist\installer\*.exe
+#   if (-not $install) { exit 1 }                       # already logged why
+#   # ... drive $install.ExePath with virtaal_ui_test_helpers.ps1 ...
+#   Uninstall-Virtaal | Out-Null                        # tear down again
+
+# Must match virtaal.iss's [Setup] AppId exactly (with the outer {{ }}
+# un-escaped back to a single pair of braces - Inno's .iss syntax uses
+# {{ to write a literal { into AppId, so the GUID Inno actually writes
+# into the registry key name is just {B3B6...}, not {{B3B6...}}).
+$script:VirtaalAppId = '{B3B6E6A0-6E8B-4B6C-9C7E-3C6F6E6E6E6E}'
+
+function Find-VirtaalUninstallEntry {
+    <#
+    .SYNOPSIS
+    Looks up Virtaal's Inno Setup uninstall registry entry by AppId,
+    checking both the per-user location (PrivilegesRequired=lowest in
+    virtaal.iss means a plain install lands in HKCU, not HKLM) and the
+    machine-wide locations (in case the installer's "install for all
+    users" option was used instead) - rather than assuming one location,
+    so this works regardless of which the tester chose. Returns $null if
+    Virtaal isn't currently installed at all.
+    #>
+    $keyName = "$($script:VirtaalAppId)_is1"
+    $candidates = @(
+        "HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\$keyName",
+        "HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\$keyName",
+        "HKLM:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\$keyName"
+    )
+    foreach ($path in $candidates) {
+        if (Test-Path $path) {
+            $props = Get-ItemProperty -Path $path -ErrorAction SilentlyContinue
+            if ($props -and $props.UninstallString) {
+                return [PSCustomObject]@{
+                    RegistryPath    = $path
+                    UninstallString = $props.UninstallString
+                    InstallLocation = $props.InstallLocation
+                    DisplayVersion  = $props.DisplayVersion
+                }
+            }
+        }
+    }
+    return $null
+}
+
+function Get-VirtaalInstallInfo {
+    <#
+    .SYNOPSIS
+    Read-only status check: is Virtaal currently installed, from where,
+    and what version - without side effects. Thin wrapper so callers
+    don't need to know the registry-lookup details of
+    Find-VirtaalUninstallEntry.
+    #>
+    $entry = Find-VirtaalUninstallEntry
+    if (-not $entry) {
+        return [PSCustomObject]@{ Installed = $false }
+    }
+    return [PSCustomObject]@{
+        Installed       = $true
+        ExePath         = Join-Path $entry.InstallLocation "virtaal.exe"
+        InstallLocation = $entry.InstallLocation
+        Version         = $entry.DisplayVersion
+    }
+}
+
+function Uninstall-Virtaal {
+    <#
+    .SYNOPSIS
+    Silently and idempotently uninstalls Virtaal. Returns $true if
+    Virtaal ends up not installed (whether or not it was installed to
+    begin with) and $false if an uninstall was attempted but didn't
+    complete within the timeout - callers should treat that as a hard
+    failure, not proceed to install on top of a half-removed copy.
+    #>
+    param([int]$TimeoutSeconds = 60)
+
+    $entry = Find-VirtaalUninstallEntry
+    if (-not $entry) {
+        Write-Host "Virtaal is not currently installed - nothing to uninstall."
+        return $true
+    }
+
+    # An uninstall can't remove a locked virtaal.exe, and /VERYSILENT
+    # would otherwise just fail quietly rather than prompt to close it.
+    Get-Process -Name virtaal -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+
+    $uninstExe = $entry.UninstallString.Trim('"')
+    if (-not (Test-Path $uninstExe)) {
+        Write-Host "::error::Uninstall registry entry points at a missing file: $uninstExe (a previous uninstall may have been interrupted). Remove $($entry.RegistryPath) by hand and retry."
+        return $false
+    }
+
+    Write-Host "Uninstalling Virtaal $($entry.DisplayVersion) via $uninstExe ..."
+    Start-Process -FilePath $uninstExe -ArgumentList "/VERYSILENT /SUPPRESSMSGBOXES /NORESTART" -Wait -ErrorAction SilentlyContinue
+
+    # Inno Setup's uninstaller relaunches a copy of itself out of a temp
+    # dir so it can delete the original unins000.exe, then exits - so the
+    # process -Wait above returns before that copy has necessarily
+    # finished deleting files and removing the registry key. Poll for the
+    # registry key's actual removal (the last thing Inno's uninstaller
+    # does) instead of trusting -Wait alone.
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    while ((Get-Date) -lt $deadline) {
+        if (-not (Find-VirtaalUninstallEntry)) {
+            Write-Host "Uninstall confirmed (registry entry gone)."
+            return $true
+        }
+        Start-Sleep -Milliseconds 500
+    }
+
+    Write-Host "::error::Uninstall did not complete within ${TimeoutSeconds}s - registry entry still present at $($entry.RegistryPath)"
+    return $false
+}
+
+function Install-Virtaal {
+    <#
+    .SYNOPSIS
+    Silently installs Virtaal from an Inno Setup installer .exe. With no
+    -InstallerPath, auto-discovers the newest .exe under dist\installer
+    (devsupport\packaging\windows\build_installer.ps1's own output dir),
+    dist\Virtaal-windows-installer (only if you deliberately downloaded a
+    CI artifact into a same-named subfolder), or a flat dist\*.exe -
+    `gh run download <run> -n Virtaal-windows-installer -D dist` (the
+    README's own documented example) doesn't create a
+    Virtaal-windows-installer subfolder at all, it extracts straight
+    into dist\ - the artifact's upload path was
+    dist\installer\*.exe on the CI side, but actions/upload-artifact
+    doesn't preserve that directory structure, so gh run download's -D
+    is the *only* directory involved, not -D plus the artifact name.
+    Both patterns are kept (rather than fixing just the flat one) so a
+    deliberately-organised download into a same-named subfolder still
+    works too. Defaults -Tasks to disabling both optional installer
+    tasks (desktop icon, file associations) so repeated test-cycle
+    installs don't spam a real desktop or overwrite real file
+    associations on a tester's own machine - pass an explicit -Tasks to
+    opt back in.
+
+    Returns $null (with an ::error:: already written) on any failure, or
+    a PSCustomObject with ExePath/InstallLocation/Version/LogPath on
+    success - pass .ExePath straight to virtaal_ui_test_helpers.ps1's
+    Start-VirtaalTest -ExePath.
+    #>
+    param(
+        [string]$InstallerPath,
+        [string]$Tasks = "!desktopicon,!fileassoc",
+        [int]$TimeoutSeconds = 120
+    )
+
+    if (-not $InstallerPath) {
+        $candidates = @(Get-ChildItem -Path "dist\installer\*.exe", "dist\Virtaal-windows-installer\*.exe", "dist\*.exe" -ErrorAction SilentlyContinue) |
+            Sort-Object LastWriteTime -Descending
+        if (-not $candidates) {
+            Write-Host "::error::No installer .exe found under dist\installer, dist\Virtaal-windows-installer, or flat under dist - build one (devsupport\packaging\windows\build_installer.ps1) or download a Virtaal-windows-installer CI artifact first (gh run download <run> -n Virtaal-windows-installer -D dist), or pass -InstallerPath explicitly."
+            return $null
+        }
+        $InstallerPath = $candidates[0].FullName
+    }
+    if (-not (Test-Path $InstallerPath)) {
+        Write-Host "::error::Installer not found at $InstallerPath"
+        return $null
+    }
+
+    $logPath = Join-Path $env:TEMP "virtaal-install-$(Get-Date -Format 'yyyyMMddHHmmss').log"
+    Write-Host "Installing $InstallerPath (log: $logPath) ..."
+    $proc = Start-Process -FilePath $InstallerPath `
+        -ArgumentList "/VERYSILENT", "/SUPPRESSMSGBOXES", "/NORESTART", "/SP-", "/TASKS=`"$Tasks`"", "/LOG=`"$logPath`"" `
+        -PassThru -Wait
+
+    if ($proc.ExitCode -ne 0) {
+        Write-Host "::error::Installer exited with code $($proc.ExitCode)"
+        if (Test-Path $logPath) { Get-Content $logPath }
+        return $null
+    }
+
+    $entry = Find-VirtaalUninstallEntry
+    if (-not $entry) {
+        Write-Host "::error::Installer reported success (exit 0) but no uninstall registry entry was found afterwards"
+        if (Test-Path $logPath) { Get-Content $logPath }
+        return $null
+    }
+    $exePath = Join-Path $entry.InstallLocation "virtaal.exe"
+    if (-not (Test-Path $exePath)) {
+        Write-Host "::error::virtaal.exe not found at expected install location $exePath"
+        return $null
+    }
+
+    Write-Host "Installed Virtaal $($entry.DisplayVersion) at $exePath"
+    return [PSCustomObject]@{
+        ExePath         = $exePath
+        InstallLocation = $entry.InstallLocation
+        Version         = $entry.DisplayVersion
+        LogPath         = $logPath
+    }
+}

--- a/devsupport/testing/windows/virtaal_install_helpers.ps1
+++ b/devsupport/testing/windows/virtaal_install_helpers.ps1
@@ -24,7 +24,7 @@
 # un-escaped back to a single pair of braces - Inno's .iss syntax uses
 # {{ to write a literal { into AppId, so the GUID Inno actually writes
 # into the registry key name is just {B3B6...}, not {{B3B6...}}).
-$script:VirtaalAppId = '{B3B6E6A0-6E8B-4B6C-9C7E-3C6F6E6E6E6E}'
+$script:VirtaalAppId = '{6249E57B-4B71-4E69-8174-F261A0DD9DAE}'
 
 function Find-VirtaalUninstallEntry {
     <#
@@ -184,14 +184,18 @@ function Install-Virtaal {
 
     if ($proc.ExitCode -ne 0) {
         Write-Host "::error::Installer exited with code $($proc.ExitCode)"
-        if (Test-Path $logPath) { Get-Content $logPath }
+        # Write-Host, not bare Get-Content - its output would
+        # otherwise join this function's own return value.
+        if (Test-Path $logPath) { Get-Content $logPath | ForEach-Object { Write-Host $_ } }
         return $null
     }
 
     $entry = Find-VirtaalUninstallEntry
     if (-not $entry) {
         Write-Host "::error::Installer reported success (exit 0) but no uninstall registry entry was found afterwards"
-        if (Test-Path $logPath) { Get-Content $logPath }
+        # Write-Host, not bare Get-Content - its output would
+        # otherwise join this function's own return value.
+        if (Test-Path $logPath) { Get-Content $logPath | ForEach-Object { Write-Host $_ } }
         return $null
     }
     $exePath = Join-Path $entry.InstallLocation "virtaal.exe"

--- a/devsupport/testing/windows/virtaal_install_helpers.ps1
+++ b/devsupport/testing/windows/virtaal_install_helpers.ps1
@@ -20,11 +20,19 @@
 #   # ... drive $install.ExePath with virtaal_ui_test_helpers.ps1 ...
 #   Uninstall-Virtaal | Out-Null                        # tear down again
 
-# Must match virtaal.iss's [Setup] AppId exactly (with the outer {{ }}
-# un-escaped back to a single pair of braces - Inno's .iss syntax uses
-# {{ to write a literal { into AppId, so the GUID Inno actually writes
-# into the registry key name is just {B3B6...}, not {{B3B6...}}).
-$script:VirtaalAppId = '{6249E57B-4B71-4E69-8174-F261A0DD9DAE}'
+# Read straight from virtaal.iss rather than hardcoding a copy that can
+# drift out of sync - Inno's .iss syntax writes a literal { via {{, so
+# strip one leading brace to get the GUID Inno actually writes into the
+# registry key name.
+$script:VirtaalIssPath = Join-Path $PSScriptRoot '..\..\packaging\windows\virtaal.iss'
+function Get-VirtaalAppId {
+    $line = Select-String -Path $script:VirtaalIssPath -Pattern '^AppId=\{\{(.+)\}$'
+    if (-not $line) {
+        throw "Could not find AppId= in $script:VirtaalIssPath"
+    }
+    return '{' + $line.Matches[0].Groups[1].Value + '}'
+}
+$script:VirtaalAppId = Get-VirtaalAppId
 
 function Find-VirtaalUninstallEntry {
     <#

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -52,7 +52,7 @@ coverage.
 Pseudo-Translation
 ===================
 
-Generate and run against two synthetic locales, covering every
+Generate and run against synthetic locales, covering every
 translatable string without needing a real translation::
 
   python devsupport/pseudo-translation/generate_pseudo_translation.py
@@ -61,9 +61,20 @@ translatable string without needing a real translation::
 
 ``--pseudo-translation`` wraps every string in brackets (``[Save]``) -
 useful for spotting hardcoded strings and layout truncation.
-``--pseudo-translation-bidi`` additionally mirrors the whole UI
-layout, simulating a right-to-left translation while keeping the text
-itself readable Latin script.
+``--pseudo-translation-bidi`` wraps every string in Unicode RTL
+isolate marks too, simulating a right-to-left translation's text runs
+while keeping the text itself readable Latin script.
+
+The same script also writes a third, ``fa``-tagged locale with every
+string's glyphs visually flipped (not a real Farsi translation - a
+real RTL-recognised language code, for exercising actual whole-window
+RTL mirroring under a genuine locale rather than just isolate-wrapped
+text)::
+
+  LANG=fa_IR.UTF-8 LANGUAGE=fa virtaal devsupport/testfiles/checks.po
+
+See ``devsupport/testing/windows/Enable-VirtaalRtlDebug.ps1`` for
+installing this into a frozen build instead of a dev checkout.
 
 .. _testing#windows_ci:
 

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -88,5 +88,111 @@ a real bug found this way (the main window growing wider on every
 Enter-to-advance during translation - see
 ``virtaal/views/widgets/storetreeview.py``'s ``select_index()``).
 
-This is CI-only tooling, not a local test harness - there's no
-hands-on driver for a real Windows session.
+This is CI-only tooling - see below for a local, hands-on Windows
+test harness.
+
+.. _testing#windows_local:
+
+Local Windows Testing
+======================
+
+CI's checks above run headless against a raw PyInstaller bundle, not
+the actual installer/uninstaller a real user goes through - at least
+one real report ("the unsaved marker seems to persist between
+reinstalls") was specifically about behaviour across that cycle,
+something CI's bundle-only checks can't reach at all. It's also worth
+actually watching Virtaal run on a real Windows desktop rather than
+only trusting a headless pass.
+
+``devsupport/testing/windows/`` has the pieces for this:
+
+* ``virtaal_install_helpers.ps1`` - installs/uninstalls Virtaal's real
+  Inno Setup package silently and idempotently.
+* ``Invoke-VirtaalLocalTestPass.ps1`` - orchestrates a full pass:
+  uninstall, install, a battery of UI regression checks against the
+  real installed app, uninstall again, with a pass/fail summary and a
+  process exit code.
+* ``Enable-VirtaalRtlDebug.ps1`` - installs a synthetic right-to-left
+  UI catalog for manually checking that the app's whole chrome (menus,
+  toolbar, status bar), not just editor text, mirrors correctly under
+  an RTL language.
+
+Run from the repo root, in PowerShell, on Windows::
+
+  .\devsupport\testing\windows\Invoke-VirtaalLocalTestPass.ps1
+
+See ``devsupport/testing/windows/README.md`` for the full detail -
+useful switches, what the battery covers, and using the helper
+functions directly for a one-off manual check.
+
+Getting a real Windows 11 desktop
+-----------------------------------
+
+On an Apple Silicon Mac, `UTM <https://mac.getutm.app>`_ (free) runs
+Windows 11 ARM64 natively via Apple's own virtualization framework -
+fast, no CPU emulation involved.
+
+1. Install UTM from `mac.getutm.app <https://mac.getutm.app>`_ (or the
+   Mac App Store).
+2. Get a Windows 11 ARM64 installer ISO. Easiest: install
+   `CrystalFetch <https://apps.apple.com/app/crystalfetch/id6461174912>`_
+   (free, App Store) - it downloads the current official build directly
+   from Microsoft. Alternatively, UTM's own guide links a direct
+   `Windows 11 for Apple Silicon Macs <https://docs.getutm.app/guides/windows/>`_
+   ISO download if you'd rather not install another app. Either way, you
+   need a real Windows license to activate it - a VM doesn't get you
+   around that.
+3. In UTM: **+** -> **Virtualize** -> **Windows** -> pick RAM/CPU (4GB/2
+   cores minimum; more if your Mac has the headroom) -> Continue -> make
+   sure **"Install Windows 10 or higher"** and **"Install drivers and
+   SPICE tools"** are both checked -> Browse to the ISO -> Continue -> give
+   it at least 64GB of disk -> Continue -> Save.
+4. Boot it, press any key when prompted to boot from the ISO. Newer UTM
+   versions handle Secure Boot/TPM automatically; if Windows Setup
+   refuses with "This PC can't run Windows 11," see
+   `UTM's troubleshooting section <https://docs.getutm.app/guides/windows/>`_
+   for the ``LabConfig`` registry bypass.
+5. To skip the Microsoft-account requirement and set up a local account
+   instead: at the network-connection screen during Setup, press
+   **Shift+F10** for a command prompt and run ``start ms-cxh:localonly``
+   (the older ``OOBE\BYPASSNRO`` trick is now blocked by Microsoft on
+   current builds).
+6. Known UTM gotcha on Windows 11 24H2: the installer can go to a black
+   screen because of the bundled guest-tools graphics driver. If that
+   happens, eject the guest-tools ISO from UTM's CD menu, finish
+   Windows Setup without it, then remount the tools ISO afterward and
+   run "Install Windows Guest Tools" - you may need to reset the VM once
+   more for the drivers to load cleanly.
+7. Install the SPICE guest tools if they didn't run automatically (needed
+   for working networking - without them Windows may insist there's no
+   internet connection even once you're on the desktop).
+
+Match what ``test-windows`` in ``.github/workflows/ci.yml`` actually
+installs inside the VM, rather than improvising a different setup:
+
+1. Install `Git for Windows <https://git-scm.com/download/win>`_ and a
+   current Python (matching what ``windows-latest`` runs) from
+   `python.org <https://www.python.org/downloads/windows/>`_ - ARM64
+   builds are available directly.
+2. Install `Visual Studio Build Tools <https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio>`_
+   with the "Desktop development with C++" workload - this gives you
+   ``cl.exe`` (needed to build PyGObject) and, usefully for debugging,
+   ``cdb.exe``/WinDbg under ``Windows Kits\10\Debuggers\``.
+3. Download the same ``gvsbuild`` GTK3 build CI uses (check
+   ``gvsbuild_version`` in ``ci.yml`` for the current pinned version) from
+   `wingtk/gvsbuild releases <https://github.com/wingtk/gvsbuild/releases>`_
+   and extract to ``C:\gtk``.
+4. Clone the repo, then in a Developer PowerShell for VS (so ``cl.exe`` is
+   on ``PATH``), set the same environment variables ``ci.yml``'s Windows job
+   sets - ``PKG_CONFIG_PATH``, ``GI_TYPELIB_PATH``, ``INCLUDE``/``LIB`` pointing
+   at ``C:\gtk``, and add ``C:\gtk\bin`` to ``PATH`` - before
+   ``pip install --no-build-isolation .[test]``. Read through the
+   ``test-windows`` job's steps directly for the exact current values and
+   ordering (some of them, like ``PKG_CONFIG_PATH``, get silently
+   overwritten by other tools if set in the wrong order - see that
+   job's own comments for why).
+
+This is also the most useful environment for chasing a Windows-only
+native crash - no 30-minute ``tmate`` session time limit, real WinDbg
+instead of just ``cdb.exe``'s command-line interface, and a real GUI
+to actually watch what happens.

--- a/virtaal/controllers/placeablescontroller.py
+++ b/virtaal/controllers/placeablescontroller.py
@@ -236,11 +236,24 @@ class PlaceablesController(BaseController):
     def _on_style_set(self, widget, prev_style=None):
         textbox = None
 
-        # Refresh text boxes' colours
+        # textbox.refresh() (textbox.py) redisplays a textbox's current
+        # content and unconditionally emits 'changed' regardless of
+        # whether any text actually changed - main_window's
+        # 'style-set'/'style-updated' signals can fire from unrelated
+        # GTK operations (a widget being shown/hidden as part of mode
+        # switching, for one), well outside load_unit()'s own
+        # disable_signals() window. Confirmed live: this fired while a
+        # freshly-opened file's unit was loading, its 'changed' reached
+        # UnitView._on_target_changed unguarded, and got misreported as
+        # a real edit on the new file. Reuse load_unit()'s own guard -
+        # this is a pure style/colour redisplay, never a real edit.
         unitview = self.main_controller.unit_controller.view
+        unitview.disable_signals(['modified', 'insert-text', 'delete-text'])
+        # Refresh text boxes' colours
         for textbox in unitview.sources + unitview.targets:
             if textbox.props.visible:
                 textbox.refresh()
+        unitview.enable_signals(['modified', 'insert-text', 'delete-text'])
 
         if textbox:
             placeablesguiinfo.update_style(textbox)

--- a/virtaal/controllers/undocontroller.py
+++ b/virtaal/controllers/undocontroller.py
@@ -195,6 +195,19 @@ class UndoController(BaseController):
         if self.model.is_at_clean_position():
             self.main_controller.store_controller.set_modified(False)
 
+        # Reported live (Dwayne): undoing a change back to an empty
+        # target left the unit's workflow state stuck at "Translated".
+        # _perform_undo() deliberately disables unit signals around the
+        # text-reverting action (to avoid re-marking the document
+        # modified), so the normal typing-triggered state timer
+        # (_unit_modified -> _start_state_timer -> _state_timer_expired)
+        # never runs for an undo. Re-run its own EMPTY<->UNREVIEWED
+        # check directly - never overrides a deliberate user pick
+        # (_state_sticky).
+        current_unit = self.unit_controller.current_unit
+        if current_unit is not None and current_unit.STATE and not getattr(current_unit, '_state_sticky', False):
+            self.unit_controller._correct_empty_state(current_unit)
+
     @if_enabled
     def _on_unit_delete_text(self, unit_controller, unit, deleted, parent, offset, cursor_pos, elem, target_num):
         def undo_action(unit):

--- a/virtaal/controllers/unitcontroller.py
+++ b/virtaal/controllers/unitcontroller.py
@@ -175,6 +175,13 @@ class UnitController(BaseController):
         self._state_timer_active = False
         if unit is not self.current_unit:
             return
+        self._correct_empty_state(unit)
+
+    def _correct_empty_state(self, unit):
+        """Move a unit between EMPTY and UNREVIEWED based on its
+        actual target content right now - the automatic half of
+        workflow-state tracking, as opposed to a deliberate user pick
+        (see set_current_state()'s own from_user/_state_sticky)."""
         if unit.hasplural():
             target_len = min([len(s) for s in unit.target.strings])
         else:

--- a/virtaal/views/mainview.py
+++ b/virtaal/views/mainview.py
@@ -19,6 +19,7 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 import locale
+import logging
 import os
 import subprocess
 import sys
@@ -909,8 +910,12 @@ class MainView(BaseView):
             and not (event.new_window_state & Gdk.WindowState.FULLSCREEN)
         )
         if left_fullscreen and getattr(self, '_pre_fullscreen_size', None):
-            self.main_window.resize(*self._pre_fullscreen_size)
+            target_size = self._pre_fullscreen_size
             self._pre_fullscreen_size = None
+            store_controller = self.controller.store_controller
+            if store_controller.store is not None:
+                store_controller.view._treeview.reset_column_width()
+            self.main_window.resize(*target_size)
 
     def _on_app_pressed(self, btn):
         self.app_menu.popup(None, None, None, 0, 0, Gtk.get_current_event_time())

--- a/virtaal/views/mainview.py
+++ b/virtaal/views/mainview.py
@@ -817,6 +817,12 @@ class MainView(BaseView):
 
     def _on_fullscreen(self, widget=None):
         if widget.get_active():
+            # GTK/GDK's Windows backend doesn't reliably restore the
+            # pre-fullscreen size on its own (confirmed live: window
+            # stayed near-fullscreen width after unfullscreen()) - save
+            # it here and restore explicitly once _on_window_state_event
+            # confirms fullscreen has actually ended.
+            self._pre_fullscreen_size = self.main_window.get_size()
             self.main_window.fullscreen()
             self.status_bar.hide()
             self.show_app_icon()
@@ -895,6 +901,16 @@ class MainView(BaseView):
     def _on_window_state_event(self, widget, event):
         mnu_fullscreen = self.gui.get_object('mnu_fullscreen')
         mnu_fullscreen.set_active(event.new_window_state & Gdk.WindowState.FULLSCREEN)
+        # React to the real, confirmed transition, not the unfullscreen()
+        # call itself (which doesn't reliably take effect synchronously
+        # on Windows) - see _on_fullscreen()'s own comment.
+        left_fullscreen = (
+            event.changed_mask & Gdk.WindowState.FULLSCREEN
+            and not (event.new_window_state & Gdk.WindowState.FULLSCREEN)
+        )
+        if left_fullscreen and getattr(self, '_pre_fullscreen_size', None):
+            self.main_window.resize(*self._pre_fullscreen_size)
+            self._pre_fullscreen_size = None
 
     def _on_app_pressed(self, btn):
         self.app_menu.popup(None, None, None, 0, 0, Gtk.get_current_event_time())

--- a/virtaal/views/storeview.py
+++ b/virtaal/views/storeview.py
@@ -97,6 +97,14 @@ class StoreView(BaseView):
     def hide(self):
         self.parent_widget.props.visible = False
         self.load_store(None)
+        # The treeview's FIXED-width column (storetreeview.py's
+        # _on_size_allocate) holds whatever width the window was at
+        # when this file was open - hiding it here doesn't reset that,
+        # so it silently becomes the *next* file's window's effective
+        # minimum size once its treeview is shown again (same
+        # mechanism as mainview.py's F11 fix). Relax it now, while
+        # nothing is displayed, rather than leaving it to bite later.
+        self._treeview.reset_column_width()
 
     def load_store(self, store):
         self.store = store

--- a/virtaal/views/unitview.py
+++ b/virtaal/views/unitview.py
@@ -289,7 +289,6 @@ class UnitView(Gtk.EventBox, GObjectWrapper, Gtk.CellEditable, BaseView):
 
     def modified(self):
         self._modified = True
-        #logging.debug('emit("modified")')
         self.emit('modified')
 
     def show(self):

--- a/virtaal/views/widgets/storecellrenderer.py
+++ b/virtaal/views/widgets/storecellrenderer.py
@@ -178,6 +178,7 @@ class StoreCellRenderer(Gtk.CellRenderer):
         width = widget.get_toplevel().get_allocation().width - 32
         if width < -1:
             width = -1
+        treeview = self.view._treeview
         if self.editable:
             # compute_optimal_height() below does real Pango text-layout
             # measurement across every textview in the editor (source,
@@ -193,7 +194,6 @@ class StoreCellRenderer(Gtk.CellRenderer):
             # forces that via queue_resize()). Never skipped for a
             # genuine content edit - _set_unit() clears this on every
             # row change, and edits don't happen mid-resize.
-            treeview = self.view._treeview
             if treeview.is_resizing and self._cached_height is not None:
                 height = self._cached_height
             else:
@@ -212,7 +212,17 @@ class StoreCellRenderer(Gtk.CellRenderer):
                 height += self.ROW_PADDING
                 self._cached_height = height
         else:
-            height = self.compute_cell_height(widget, width)
+            # Same reasoning as the editable branch above - real Pango
+            # measurement (two fresh layouts, source and target) on
+            # every size-allocate, but this branch runs for *every*
+            # visible non-editable row, not just one - the bulk of the
+            # real cost during a live resize, not the editable row
+            # alone.
+            if treeview.is_resizing and self._cached_height is not None:
+                height = self._cached_height
+            else:
+                height = self.compute_cell_height(widget, width)
+                self._cached_height = height
         #height = min(height, 600)
         y_offset = self.ROW_PADDING / 2
         return 0, y_offset, width, height

--- a/virtaal/views/widgets/storecellrenderer.py
+++ b/virtaal/views/widgets/storecellrenderer.py
@@ -145,6 +145,10 @@ class StoreCellRenderer(Gtk.CellRenderer):
         self.editable = False
         self.source_layout = None
         self.target_layout = None
+        # See do_get_size()'s own comment - a real Pango-measurement
+        # cache, only ever consulted mid-resize, invalidated below on
+        # any unit change so it can never leak between rows.
+        self._cached_height = None
 
 
     # ACCESSORS #
@@ -158,6 +162,7 @@ class StoreCellRenderer(Gtk.CellRenderer):
         else:
             self.props.cell_background_set = False
         self.__unit = value
+        self._cached_height = None
 
     unit = property(_get_unit, _set_unit, None, None)
 
@@ -170,24 +175,42 @@ class StoreCellRenderer(Gtk.CellRenderer):
         return getattr(self, pspec.name)
 
     def do_get_size(self, widget, _cell_area):
-        #TODO: store last unitid and computed dimensions
         width = widget.get_toplevel().get_allocation().width - 32
         if width < -1:
             width = -1
         if self.editable:
-            editor = self.view.get_unit_celleditor(self.unit)
-            editor.set_size_request(width, -1)
-            editor.show()
-            # fixme: this will make vbox_editor width too large
-            compute_optimal_height(editor, width)
-            parent_height = widget.get_allocation().height
-            if parent_height < -1:
-                parent_height = widget.size_request()[1]
-            if parent_height > 0:
-                self.check_editor_height(editor, width, parent_height)
-            size_request = editor.size_request()
-            height = size_request.height
-            height += self.ROW_PADDING
+            # compute_optimal_height() below does real Pango text-layout
+            # measurement across every textview in the editor (source,
+            # target, notes, ...) - genuinely expensive, and GTK calls
+            # this on every size-allocate. During a live window resize
+            # that's many calls per second for no visual benefit (word-
+            # wrap barely changes between two nearly-identical widths) -
+            # confirmed live as the cause of very slow, unresponsive
+            # horizontal window dragging. Reuse storetreeview.py's
+            # existing configure-event debounce: skip the expensive
+            # recompute while a resize is still in progress, do one real
+            # one once it settles (StoreTreeView._on_configure_settled
+            # forces that via queue_resize()). Never skipped for a
+            # genuine content edit - _set_unit() clears this on every
+            # row change, and edits don't happen mid-resize.
+            treeview = self.view._treeview
+            if treeview.is_resizing and self._cached_height is not None:
+                height = self._cached_height
+            else:
+                editor = self.view.get_unit_celleditor(self.unit)
+                editor.set_size_request(width, -1)
+                editor.show()
+                # fixme: this will make vbox_editor width too large
+                compute_optimal_height(editor, width)
+                parent_height = widget.get_allocation().height
+                if parent_height < -1:
+                    parent_height = widget.size_request()[1]
+                if parent_height > 0:
+                    self.check_editor_height(editor, width, parent_height)
+                size_request = editor.size_request()
+                height = size_request.height
+                height += self.ROW_PADDING
+                self._cached_height = height
         else:
             height = self.compute_cell_height(widget, width)
         #height = min(height, 600)

--- a/virtaal/views/widgets/storetreeview.py
+++ b/virtaal/views/widgets/storetreeview.py
@@ -64,6 +64,12 @@ class StoreTreeView(Gtk.TreeView):
         # on_configure_event() action - see that method for why.
         self._configure_timeout_id = None
 
+        # See StoreCellRenderer.do_get_size()'s own comment - True for
+        # the duration of a live resize (first configure-event to
+        # debounce-settled), used there to skip expensive per-allocate
+        # editor-height remeasurement until the resize actually stops.
+        self.is_resizing = False
+
     def _enable_tooltips(self):
         if hasattr(self, "set_tooltip_column"):
             self.set_tooltip_column(COLUMN_NOTE)
@@ -243,6 +249,7 @@ class StoreTreeView(Gtk.TreeView):
         # itself is fixed at the source (_make_column()); this is just
         # settle-then-restore-cursor housekeeping.
         logging.debug("storetreeview: configure-event %dx%d", event.width, event.height)
+        self.is_resizing = True
         if self._configure_timeout_id is not None:
             GLib.source_remove(self._configure_timeout_id)
         self._configure_timeout_id = GLib.timeout_add(200, self._on_configure_settled)
@@ -250,7 +257,13 @@ class StoreTreeView(Gtk.TreeView):
 
     def _on_configure_settled(self):
         self._configure_timeout_id = None
+        self.is_resizing = False
         logging.debug("storetreeview: debounce settled, window=%s", self._window_size())
+        # do_get_size() was skipping real height recomputation while
+        # is_resizing was True (see its own comment) - ask GTK to
+        # re-request sizes now that it's settled, so the row(s) it
+        # skipped get one real, correct measurement at the final width.
+        self.queue_resize()
         self._restore_cursor()
         return False  # one-shot: don't repeat this GLib.timeout_add
 

--- a/virtaal/views/widgets/storetreeview.py
+++ b/virtaal/views/widgets/storetreeview.py
@@ -116,6 +116,20 @@ class StoreTreeView(Gtk.TreeView):
         if column.get_fixed_width() != new_width:
             column.set_fixed_width(new_width)
 
+    def reset_column_width(self):
+        """Relax the FIXED-width column back to its placeholder size
+        (see _make_column()), letting the next size-allocate correct
+        it for real. A FIXED-width column's current width becomes part
+        of the toplevel window's own effective minimum size - confirmed
+        live: main_window.resize() to a smaller size was silently
+        clamped back up, unchanged, while this column still held its
+        fullscreen-era width. Called right before a resize() that needs
+        to shrink the window past whatever width this column is
+        currently holding (F11 fullscreen exit is the real case)."""
+        column = self.get_columns()[0] if self.get_columns() else None
+        if column:
+            column.set_fixed_width(1)
+
 
     # METHODS #
     def select_index(self, index):


### PR DESCRIPTION
Brings up the local Windows testing tooling this project has been using informally, deferred while the main port/fix PR sequence landed - a real, hands-on test harness (install cycle + UI regression battery + RTL debug catalog) and a documented path to a real Windows 11 desktop for any contributor, not just CI.

**The harness itself:**
- `devsupport/testfiles/rtl.po` - a synthetic RTL bidi-content fixture, and `devsupport/pseudo-translation/generate_pseudo_translation.py` gains a third locale (`fa`, flipped glyphs, a real RTL-recognised language code) for exercising whole-window RTL chrome mirroring - generated on the fly from `po/virtaal.pot` like the existing `pseudo`/`pseudo-bidi` locales, not committed as a static file.
- `devsupport/testfiles/plurals.po`/`plurals-zero.po` - genuine `msgid_plural` fixtures (nplurals=3 and nplurals=1) the harness's own plural-form check already depended on.
- `devsupport/testing/windows/{virtaal_install_helpers,Invoke-VirtaalLocalTestPass,Enable-VirtaalRtlDebug}.ps1` + `README.md` - a real install/uninstall cycle harness plus a UI regression battery against the actual installed app. `virtaal_ui_test_helpers.ps1` (already merged, drives the raw PyInstaller bundle for CI) is untouched.
- `docs/testing.rst` - documents the harness and a full walkthrough for getting a real Windows 11 desktop via UTM on Apple Silicon.
- `.gitignore` - excludes the harness's own run transcripts/screenshots.

**Real app bugs found by actually running this on Windows, and fixed:**
- `virtaal_install_helpers.ps1`'s AppId didn't match `virtaal.iss`'s real one - every install/uninstall check searched a registry key that could never exist. Now read directly from `virtaal.iss` instead of duplicated.
- A spurious "modified" marker on file open, Recent-Files reopen, and post-save: `PlaceablesController._on_style_set` refreshes every visible textbox's colours on a GTK `style-set`/`style-updated` signal (which can fire from unrelated operations like a widget being shown/hidden during mode switching), and that refresh unconditionally re-emits `changed`, misreported as a real edit. Fixed by reusing `load_unit()`'s own signal-suppression window for this refresh too.
- Opening a file after closing another could silently inherit the previous file's window width: the store treeview's `FIXED`-width column holds whatever width the window was at while a file was open, and `StoreView.hide()`/`show()` never reset it. Fixed by relaxing it in `hide()`.
- Undo back to an empty target left the unit's workflow state stuck at "Translated" - undo deliberately bypasses the normal typing-triggered state-timer signal chain (to avoid re-marking the document modified from its own text manipulation), so nothing ever re-checked whether the target went back to empty. Fixed by re-running that same check directly after undo.
- Dragging the window to resize it is slow/unresponsive, particularly shrinking: `StoreCellRenderer.do_get_size()` does real Pango text-layout measurement for every visible row on every size-allocate (confirmed directly: 1,043 calls for one single `resize()` on a 523-unit file). Mitigated by skipping the recompute for the duration of a live resize and doing one real pass once it settles.

**F11 fullscreen doesn't restore the original window size - investigated, not resolved from the app side.** After the fixes above, GDK's own `get_size()` settles at the correct height and a much-improved width following `resize()` - but the real on-screen window doesn't follow, confirmed with a live `get_size()` trace at several delays after the call. That gap is below what application code controls; this looks like a genuine GDK-Win32 backend issue, not something more `resize()` tuning will fix. The app-level save/restore logic is kept (it's the correct approach and may work on other platforms/GDK versions) but doesn't close the loop on this specific symptom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)