### PR TITLE
Build macOS releases for both Apple Silicon and Intel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -569,13 +569,30 @@ jobs:
         run: virtaal --help
 
   build-macos-app:
-    runs-on: macos-latest
     needs: test-macos
     # Separate job from test-macos, not extra steps tacked onto it:
     # PyInstaller has to trace and copy the whole dependency tree, which
     # is genuinely slow, and this only needs to run once the fast pytest
     # job has already confirmed the app itself works - no point spending
     # the extra time building a bundle around a broken app.
+    #
+    # Two-leg matrix, not a single macos-latest job: PyInstaller builds
+    # a single-architecture bundle matching the host it runs on, and
+    # Homebrew doesn't ship universal2 GTK3 bottles, so an arm64-only
+    # build won't run on an Intel Mac at all (Rosetta 2 only
+    # translates x86_64 -> arm64, not the reverse). A real universal2
+    # bundle isn't attempted - every dependency would need to be built
+    # as a fat binary from source, which Homebrew doesn't support -
+    # building both architectures separately is the practical fix.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-latest
+            arch: arm64
+          - runner: macos-26-intel
+            arch: x86_64
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -660,7 +677,7 @@ jobs:
 
       - uses: actions/upload-artifact@v7
         with:
-          name: Virtaal-macos-app
+          name: Virtaal-macos-app-${{ matrix.arch }}
           path: dist/Virtaal-macos-app.zip
           if-no-files-found: error
 
@@ -682,7 +699,7 @@ jobs:
 
       - uses: actions/upload-artifact@v7
         with:
-          name: Virtaal-macos-dmg
+          name: Virtaal-macos-dmg-${{ matrix.arch }}
           path: dist/Virtaal.dmg
           if-no-files-found: error
 

--- a/docs/building.rst
+++ b/docs/building.rst
@@ -171,3 +171,13 @@ into ``dist/Virtaal.dmg`` (settings in
 ``devsupport/packaging/macos/dmgbuild-settings.py``). CI's
 ``build-macos-app`` job runs these same two scripts and uploads the
 results as workflow artifacts on every push.
+
+This produces a single-architecture build matching whatever
+Python/Homebrew it's built with - Homebrew doesn't ship universal2
+GTK3 bottles, so there's no ``lipo``-style fat binary available here.
+An arm64-only build won't run on an Intel Mac at all (Rosetta 2 only
+translates x86_64 -> arm64, never the reverse), so CI builds both
+architectures separately (a matrix job - see ``build-macos-app`` in
+``ci.yml`` for the current runner labels) and uploads them as
+separate artifacts (``Virtaal-macos-app-arm64``/``-x86_64`` and the
+``.dmg`` equivalents) rather than one universal bundle.


### PR DESCRIPTION
`build-macos-app`'s PyInstaller bundle was arm64-only - confirmed by downloading a real CI artifact and checking it directly (`lipo -info`: "Non-fat file ... arm64" for the launcher and every bundled GTK/PyGObject library). Root cause: `macos-latest` is an Apple Silicon runner, Homebrew's GTK3/PyGObject bottles are architecture-specific (no universal2 available at all), and `virtaal.spec` sets no `target_arch` override, so PyInstaller defaults to matching the host.

Since Rosetta 2 only translates x86_64 -> arm64, never the reverse, that build simply **cannot launch at all on an Intel Mac** - not a degraded experience, a hard failure with no workaround available to the user. This was undocumented anywhere (checked `docs/building.rst` and the existing release-blockers tracking).

**Fix**: `build-macos-app` is now a two-leg matrix (`macos-latest` for arm64, `macos-26-intel` for x86_64 - GitHub's current Intel-hosted macOS runner label), each producing and uploading its own `.app`/`.dmg` under an architecture-suffixed artifact name (`Virtaal-macos-app-arm64`/`-x86_64`, same for the `.dmg`). Verified: workflow YAML validates and passes `actionlint` cleanly, `docs/building.rst`'s update builds clean under Sphinx.

A true universal2 bundle isn't attempted here - it would need every dependency (GTK3, PyGObject, cairo, gettext, enchant, gtkspell3) built as a fat binary from source, since Homebrew doesn't support universal2 at all. Building and shipping both architectures separately is the tractable fix for a project this size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
