### PR TITLE
version: embed the build commit so a build's provenance is checkable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -393,6 +393,12 @@ jobs:
 
       - name: Build self-contained bundle
         shell: pwsh
+        env:
+          # actions/checkout on a pull_request event checks out GitHub's
+          # own ephemeral preview-merge commit, not the PR branch's real
+          # head - pass the real head SHA so the embedded build_commit
+          # is one a human can actually compare against their checkout.
+          VIRTAAL_BUILD_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
         run: devsupport\packaging\windows\build_standalone.ps1
 
       - name: Verify the bundle actually runs
@@ -625,6 +631,12 @@ jobs:
         run: pip install --no-build-isolation .
 
       - name: Build self-contained .app bundle
+        env:
+          # actions/checkout on a pull_request event checks out GitHub's
+          # own ephemeral preview-merge commit, not the PR branch's real
+          # head - pass the real head SHA so the embedded build_commit
+          # is one a human can actually compare against their checkout.
+          VIRTAAL_BUILD_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
         run: devsupport/packaging/macos/build_standalone.sh
 
       - name: Verify the bundle launches cleanly

--- a/bin/virtaal
+++ b/bin/virtaal
@@ -107,7 +107,16 @@ def main(argv):
         # - without this, its generated chrome stays untranslated.
         argparse._ = _
         parser = argparse.ArgumentParser()
-        parser.add_argument("-v", "--version", action="version", version=__version__.ver)
+        # See virtaal.__version__.build_commit's own docstring. Short
+        # (7-char) since a human's the one reading this, matching
+        # `git rev-parse --short`. Note for a packaged Windows build:
+        # pan_app's stdout/stderr redirection runs at import time,
+        # before this ever executes, so this text lands in
+        # %APPDATA%\Virtaal\stdout_virtaal.log, not a caller's console.
+        version_string = __version__.ver
+        if __version__.build_commit:
+            version_string += " (%s)" % __version__.build_commit[:7]
+        parser.add_argument("-v", "--version", action="version", version=version_string)
         parser.add_argument("-l", "--log", dest="log", metavar=_("LOG"),
                              help=_("turn on logging, storing the result to the supplied filename."))
         parser.add_argument("-c", "--config", dest="config", metavar=_("CONFIG"),

--- a/devsupport/packaging/macos/build_standalone.sh
+++ b/devsupport/packaging/macos/build_standalone.sh
@@ -37,7 +37,13 @@ rm -rf build/virtaal dist/Virtaal.app
 # sys.path.insert(0, ROOT) (repo root first) means this local-tree file
 # wins over any installed site-packages copy of virtaal when
 # collect_submodules("virtaal") picks it up below.
-commit="$(git rev-parse HEAD)"
+#
+# $VIRTAAL_BUILD_COMMIT lets CI override this: `git rev-parse HEAD` on
+# a pull_request-triggered runner is GitHub's own ephemeral
+# preview-merge commit, not the branch's real head - fetchable nowhere,
+# so useless for a human comparing a downloaded build against their own
+# checkout. CI passes the real head SHA explicitly instead.
+commit="${VIRTAAL_BUILD_COMMIT:-$(git rev-parse HEAD)}"
 echo "commit = \"$commit\"" > virtaal/_build_info.py
 echo "Building from commit $commit"
 

--- a/devsupport/packaging/windows/build_standalone.ps1
+++ b/devsupport/packaging/windows/build_standalone.ps1
@@ -44,7 +44,17 @@ Remove-Item -Recurse -Force -ErrorAction SilentlyContinue build\virtaal, dist\vi
 # sys.path.insert(0, ROOT) (repo root first) means this local-tree file
 # wins over any installed site-packages copy of virtaal when
 # collect_submodules("virtaal") picks it up below.
-$commit = (git rev-parse HEAD).Trim()
+#
+# $env:VIRTAAL_BUILD_COMMIT lets CI override this: `git rev-parse HEAD`
+# on a pull_request-triggered runner is GitHub's own ephemeral
+# preview-merge commit, not the branch's real head - fetchable nowhere,
+# so useless for a human comparing a downloaded build against their own
+# checkout. CI passes the real head SHA explicitly instead.
+if ($env:VIRTAAL_BUILD_COMMIT) {
+    $commit = $env:VIRTAAL_BUILD_COMMIT
+} else {
+    $commit = (git rev-parse HEAD).Trim()
+}
 "commit = `"$commit`"" | Set-Content -Path virtaal\_build_info.py -Encoding utf8
 Write-Host "Building from commit $commit"
 

--- a/virtaal/__version__.py
+++ b/virtaal/__version__.py
@@ -20,3 +20,40 @@
 
 """This file contains the version."""
 ver = "1.0.0-beta1"
+
+
+def _get_build_commit():
+    """The git commit this build was made from, or None if that's not
+    knowable.
+
+    Two sources, tried in order:
+
+    1. virtaal._build_info, a plain "commit = '<sha>'" file the
+       packaging scripts (devsupport/packaging/*/build_standalone.*)
+       generate fresh just before running PyInstaller - not checked
+       into git (see .gitignore). The only source that works in a
+       frozen build, which has no .git directory or git binary.
+    2. A live `git rev-parse HEAD`, for everything else (running from
+       a checkout directly, e.g. bin/virtaal or the run-virtaal
+       skill).
+    """
+    try:
+        from virtaal._build_info import commit
+        return commit
+    except ImportError:
+        pass
+    try:
+        import subprocess
+        from os import path
+        repo_root = path.dirname(path.dirname(path.abspath(__file__)))
+        result = subprocess.run(
+            ['git', 'rev-parse', 'HEAD'], cwd=repo_root,
+            capture_output=True, text=True, timeout=2)
+        if result.returncode == 0:
+            return result.stdout.strip()
+    except Exception:
+        pass
+    return None
+
+
+build_commit = _get_build_commit()


### PR DESCRIPTION
A plain marketing version string alone can't answer "is this actually the build that was supposed to be tested" - not the filename, not the app itself. `virtaal.__version__.build_commit` closes that gap.

Two sources, tried in order: a generated `virtaal/_build_info.py` (not checked in - the packaging scripts already write it fresh right before a PyInstaller build, on both Windows and macOS). This is the only source that works in a frozen build, which has no `.git` directory or git binary. Falls back to a live `git rev-parse HEAD` for everything else (running from a checkout directly).

`bin/virtaal`'s `--version` now includes the short commit when known, e.g. `1.0.0-beta1 (5bb637f)`.

This closes a gap that already existed: both platforms' `build_standalone` scripts generate `virtaal/_build_info.py` and `.gitignore` already excludes it, but nothing ever read it back - this PR adds the read side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)