### PR TITLE
ci: make core-checks actually wait for test/test-windows/test-macos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -768,7 +768,7 @@ jobs:
 
   core-checks:
     name: core checks
-    needs: [pre-commit, docs-and-translations]
+    needs: [pre-commit, docs-and-translations, test, test-windows, test-macos]
     if: always()
     runs-on: ubuntu-24.04
     steps:


### PR DESCRIPTION
The merge queue's ruleset requires exactly one status check: `core checks`. That job only depended on `pre-commit` and `docs-and-translations` - the pytest matrix and both platform test jobs ran and reported results, but a failure in any of them couldn't actually block a merge.

Adds `test`/`test-windows`/`test-macos` to `core-checks`' `needs:`. The build jobs (installer/.app/Flatpak) stay informative-only - packaging correctness, not app correctness, and slower to run on every PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)