### PR TITLE
Rename CI workflow from "Tests" to "CI"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: CI
 
 on:
   push:


### PR DESCRIPTION
It only ran the test suite when first named - now also builds Windows/macOS/Flatpak packages and cuts GitHub Releases, so "Tests" undersells what it does. No badge or other reference to the old name exists anywhere in the repo (checked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)