### PR TITLE
Fuzzer: fail fast with a stack trace on a hang, instead of running out the clock

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -23,6 +23,11 @@ on:
 jobs:
   fuzz-linux:
     runs-on: ubuntu-24.04
+    # Backstop only - fuzz_ui.py's own watchdog (2x --duration-seconds)
+    # should always fire first and leave a real stack trace; this just
+    # bounds the worst case if that somehow doesn't fire, rather than
+    # running for hours (GitHub's default job timeout).
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v7
         with:
@@ -79,6 +84,8 @@ jobs:
 
   fuzz-macos:
     runs-on: macos-latest
+    # See fuzz-linux's own comment on this - same backstop reasoning.
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v7
         with:
@@ -136,6 +143,8 @@ jobs:
 
   fuzz-windows:
     runs-on: windows-latest
+    # See fuzz-linux's own comment on this - same backstop reasoning.
+    timeout-minutes: 45
     # See test-windows in ci.yml for why gvsbuild/MSVC, not MSYS2.
     env:
       gvsbuild_version: "2026.8.0"

--- a/devsupport/testing/fuzz/fuzz_ui.py
+++ b/devsupport/testing/fuzz/fuzz_ui.py
@@ -229,13 +229,21 @@ def main():
                          help='RNG seed - printed at the start of every run so a crash can be replayed exactly.')
     parser.add_argument('--log', default=None,
                          help='Path to append the action log to (default: a temp file, path printed at startup).')
+    parser.add_argument('--watchdog-seconds', type=int, default=None,
+                         help='Force-exit with a full stack dump if still running after this long '
+                              '(default: 2x --duration-seconds, or 1800 for a fixed --iterations run) - '
+                              'catches a step() that never returns instead of hanging the CI job for hours.')
     args = parser.parse_args()
 
     seed = args.seed if args.seed is not None else random.SystemRandom().randrange(2**32)
     log_path = args.log or os.path.join(tempfile.gettempdir(), 'virtaal-fuzz-%d.log' % (seed))
 
     faulthandler.enable()
-    print('seed=%d log=%s' % (seed, log_path))
+    watchdog_seconds = args.watchdog_seconds
+    if watchdog_seconds is None:
+        watchdog_seconds = args.duration_seconds * 2 if args.duration_seconds else 1800
+    faulthandler.dump_traceback_later(watchdog_seconds, exit=True)
+    print('seed=%d log=%s watchdog_seconds=%d' % (seed, log_path, watchdog_seconds))
 
     fuzzer = Fuzzer(seed=seed, log_path=log_path)
     fuzzer.run(iterations=None if args.duration_seconds else args.iterations,


### PR DESCRIPTION
A workflow_dispatch run of the UI fuzzer (2026-09-04, all three platforms, `--duration-seconds 600`) never completed - each job's `Fuzz` step was still `in_progress` 31+ minutes later, cancelled manually rather than left to run out GitHub's default 360-minute job cap. No native crash and no Python exception was logged, meaning some single `step()` call itself never returned - the run loop's own `duration_seconds` check cannot fire from inside a call that has not returned yet.

Not reproducible locally: 25 different seeds x 300 iterations, plus one seed x 2000 iterations, all completed cleanly - whatever's happening appears tied to the hosted CI runners specifically, not a deterministic action-sequence bug.

Two independent changes, defense in depth for the same problem:
- `fuzz_ui.py` now arms `faulthandler.dump_traceback_later(watchdog_seconds, exit=True)` at 2x `--duration-seconds` (or a flat 1800s for a fixed `--iterations` run) - dumps every thread's current frame and force-exits instead of hanging indefinitely. Verified against an artificially stuck process: fires on schedule, dumps the exact blocked frame, exits nonzero.
- `fuzz.yml`'s three jobs get a 45-minute `timeout-minutes` backstop, in case the watchdog itself somehow does not fire.

Next scheduled/dispatched run should produce a real stack trace pinpointing the actual hang, rather than just running out the clock again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)