### PR TITLE
Fuzzer: pre-seed translator info to avoid a modal save-time hang

### DIFF
--- a/devsupport/testing/fuzz/fuzz_ui.py
+++ b/devsupport/testing/fuzz/fuzz_ui.py
@@ -59,6 +59,7 @@ import gi
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
 
+from virtaal.common import pan_app
 from virtaal.controllers.maincontroller import MainController
 from virtaal.controllers.storecontroller import StoreController
 from virtaal.controllers.unitcontroller import UnitController
@@ -89,6 +90,11 @@ class Fuzzer:
         self._log_file = open(log_path, 'a', buffering=1)
         self._tempdir = tempfile.mkdtemp(prefix='virtaal-fuzz-')
         self.iteration = 0
+
+        # Avoids StoreModel._update_header()'s modal save-time prompt.
+        pan_app.settings.translator['name'] = 'Fuzzer'
+        pan_app.settings.translator['email'] = 'fuzzer@example.com'
+        pan_app.settings.translator['team'] = 'none'
 
         self._build_controllers()
         self.store_controller.open_file(self.rng.choice(self.testfiles))


### PR DESCRIPTION
Saving a `.po` file with no translator name/email/team configured pops a modal dialog (`StoreModel._update_header()`) - the fuzzer can't dismiss dialogs, so this hung every CI run indefinitely (confirmed via #3392's watchdog stack trace). Empty by default on a fresh CI profile; not on a real user account (name falls back to the OS password database's GECOS field), which is why this never reproduced locally.

Pre-seed all three so `_update_header()` never needs to prompt. Verified directly against a real save with settings cleared/set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)