### PR TITLE
Ignore .venv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@
 *.pyc
 __pycache__/
 
+# venv
+.venv
+
 # gh-pages branch
 _site
 _layouts


### PR DESCRIPTION
Currently unignored except by luck - newer Python's venv module auto-generates a .gitignore inside the venv itself, but that's not guaranteed for every contributor's toolchain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)