### PR TITLE
Notify frozen builds of a newer release

### DIFF
--- a/virtaal/main.py
+++ b/virtaal/main.py
@@ -26,6 +26,8 @@
 # after the GUI is already showing.
 
 
+import sys
+
 from gi.repository import GLib
 
 
@@ -155,6 +157,18 @@ class Virtaal(object):
         defer(PreferencesController, main_controller)
         defer(PropertiesController, main_controller)
         defer(main_controller.load_plugins)
+
+        # Only bundled builds (macOS .app, Windows installer) can't
+        # already control their own updates the way a checkout/pip
+        # install can.
+        if getattr(sys, 'frozen', False):
+            defer(self._check_for_update)
+
+    def _check_for_update(self):
+        from virtaal.__version__ import ver
+        from virtaal.support.update_check import UpdateChecker
+
+        UpdateChecker(ver, self.main_controller.view.show_update_notice).check()
 
 
     # METHODS #

--- a/virtaal/support/test_update_check.py
+++ b/virtaal/support/test_update_check.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2026 Zuza Software Foundation
+#
+# This file is part of Virtaal.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for update_check's pure version-comparison logic - the one
+part of the update check that's cheaply, deterministically testable
+without a real network call."""
+
+import pytest
+
+from virtaal.support.update_check import is_newer
+
+
+@pytest.mark.parametrize("remote,local,expected", [
+    # Same core version, different beta numbers - the main case that
+    # matters while every published release is still a prerelease.
+    ("v1.0.0-beta2", "1.0.0-beta1", True),
+    ("v1.0.0-beta1", "1.0.0-beta2", False),
+    ("v1.0.0-beta1", "1.0.0-beta1", False),
+    # A stable release outranks any prerelease of the same core version.
+    ("v1.0.0", "1.0.0-beta5", True),
+    ("v1.0.0-rc1", "1.0.0", False),
+    # alpha < beta < rc for the same core version.
+    ("v1.0.0-rc1", "1.0.0-beta9", True),
+    ("v1.0.0-beta1", "1.0.0-alpha9", True),
+    # Plain core-version ordering.
+    ("v1.1.0", "1.0.0", True),
+    ("v2.0.0", "1.9.9", True),
+    ("v1.0.0", "1.0.1", False),
+    # A leading "v" on either side shouldn't matter.
+    ("1.0.1", "v1.0.0", True),
+])
+def test_is_newer(remote, local, expected):
+    assert is_newer(remote, local) is expected
+
+
+def test_is_newer_unparseable_fails_closed():
+    """Malformed input never claims an update exists - fail closed,
+        not guess."""
+    assert is_newer("not-a-version", "1.0.0") is False
+    assert is_newer("v1.0.0", "not-a-version") is False
+    assert is_newer("", "1.0.0") is False

--- a/virtaal/support/update_check.py
+++ b/virtaal/support/update_check.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2026 Zuza Software Foundation
+#
+# This file is part of Virtaal.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+
+"""Checks GitHub for a newer release than the one currently running.
+
+Uses the plural /releases list endpoint (newest first), not the
+singular /releases/latest one - GitHub defines "latest" as the newest
+non-prerelease release, which returns nothing at all while every
+published release is still beta/rc-flagged. The whole point of this
+check right now is surfacing newer *prereleases* to beta testers.
+"""
+
+import json
+import logging
+import re
+
+from virtaal.support.httpclient import HTTPClient
+
+RELEASES_API_URL = 'https://api.github.com/repos/translate/virtaal/releases'
+
+_VERSION_RE = re.compile(
+    r'^v?(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)'
+    r'(?:-(?P<pretype>alpha|beta|rc)(?P<prenum>\d*))?$'
+)
+_PRE_ORDER = {'alpha': 0, 'beta': 1, 'rc': 2}
+
+
+def _parse_version(version_string):
+    """Parse a plain vMAJOR.MINOR.PATCH[-alpha|beta|rcN] string into a
+        tuple that sorts correctly - a release with no pre-release
+        suffix always sorts after any pre-release of the same core
+        version (pre-rank 99), and alpha < beta < rc for same-numbered
+        pre-releases. Raises ValueError on anything else, rather than
+        guessing - see is_newer()'s own fail-closed handling of that."""
+    match = _VERSION_RE.match(version_string.strip())
+    if not match:
+        raise ValueError('unrecognised version string: %r' % (version_string,))
+    core = (int(match.group('major')), int(match.group('minor')), int(match.group('patch')))
+    pretype = match.group('pretype')
+    if pretype is None:
+        return core + (99, 0)
+    prenum = int(match.group('prenum') or 0)
+    return core + (_PRE_ORDER[pretype], prenum)
+
+
+def is_newer(remote_version, local_version):
+    """Whether remote_version is a newer release than local_version."""
+    try:
+        return _parse_version(remote_version) > _parse_version(local_version)
+    except ValueError:
+        # Either string didn't match this project's own version scheme -
+        # fail closed rather than guess, never claim an update exists
+        # from data we can't actually parse.
+        return False
+
+
+class UpdateChecker:
+    """Checks once, asynchronously, whether a newer release exists than
+        local_version - calling on_update_available(tag_name, html_url)
+        if so. Silent (just logs) on any failure: network errors must
+        never surface as an application error to the user."""
+
+    def __init__(self, local_version, on_update_available):
+        self.local_version = local_version
+        self.on_update_available = on_update_available
+        self._client = HTTPClient()
+
+    def check(self):
+        self._client.set_virtaal_useragent()
+        self._client.get(RELEASES_API_URL, self._on_success, error_callback=self._on_error)
+
+    def _on_success(self, _request, result):
+        try:
+            releases = json.loads(result.decode('utf-8'))
+            latest = releases[0]
+            tag_name = latest['tag_name']
+            html_url = latest['html_url']
+        except (ValueError, KeyError, IndexError, UnicodeDecodeError) as e:
+            # ValueError covers both json.loads() and int() failures;
+            # IndexError is an empty releases list (nothing published
+            # yet) - all equally "nothing to report", not errors worth
+            # surfacing to the user.
+            logging.debug('update check: could not use response: %s' % (e,))
+            return
+        if is_newer(tag_name, self.local_version):
+            self.on_update_available(tag_name, html_url)
+
+    def _on_error(self, _request, status):
+        logging.debug('update check: request failed, status=%r' % (status,))

--- a/virtaal/views/mainview.py
+++ b/virtaal/views/mainview.py
@@ -791,6 +791,31 @@ class MainView(BaseView):
         from virtaal.support import openmailto
         openmailto.open("http://translate.sourceforge.net/wiki/virtaal/index")
 
+    def show_update_notice(self, tag_name, html_url):
+        """Called at most once per session, from a frozen build only,
+            if virtaal.support.update_check finds a newer release than
+            this one."""
+        from virtaal.__version__ import ver
+
+        infobar = Gtk.InfoBar()
+        infobar.set_message_type(Gtk.MessageType.INFO)
+        infobar.set_show_close_button(True)
+        label = Gtk.Label(label=_('Virtaal %s is available (you have %s)') % (tag_name, ver))
+        infobar.get_content_area().pack_start(label, True, True, 0)
+        infobar.add_button(_('Download'), Gtk.ResponseType.OK)
+
+        def on_response(infobar, response_id):
+            if response_id == Gtk.ResponseType.OK:
+                from virtaal.support import openmailto
+                openmailto.open(html_url)
+            infobar.destroy()
+        infobar.connect('response', on_response)
+
+        infobar.show_all()
+        vbox_main = self.gui.get_object('vbox_main')
+        vbox_main.pack_start(infobar, False, False, 0)
+        vbox_main.reorder_child(infobar, 1)  # directly below the menu bar
+
     def _on_file_open(self, _widget):
         self.open_file()
 


### PR DESCRIPTION
Checks GitHub's releases API once at startup (frozen builds only - checkout/pip installs already control their own updates) and shows a dismissible `Gtk.InfoBar` if a newer one exists.

Uses the plural `/releases` list endpoint (newest first), not the singular `/releases/latest` one - GitHub defines "latest" as the newest non-prerelease release, which returns nothing while every published release is still beta/rc-flagged. Version comparison is prerelease-aware for the same reason: a naive tuple compare would treat `1.0.0-beta1` and `1.0.0-beta2` as equal (same core version), silently never notifying the beta-to-beta upgrades that matter most right now.

Reuses the existing non-blocking `HTTPClient` (same pattern the TM/terminology plugins already use) rather than adding a new threading mechanism, and the app's own existing deferred-startup mechanism (`_Deferer`) rather than a separate timer. Fails silently on any network error - never surfaces as an application error.

Verified directly, not just unit-tested: a live `MainController`/`MainView` instance builds and packs the InfoBar correctly with the right text; a real request against `translate/virtaal`'s actual (currently empty) releases API completes cleanly with no callback fired; a request against a nonexistent repo (404) also fails silently as required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)