### PR TITLE
Point Installation docs at the Releases page

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,25 +12,19 @@ References
 
 Installation
 ------------
-The easiest way for most users to install Virtaal is through the provided
-packages, or through the packaging system of their distribution. On the
-Virtaal website there should be packages for Windows and several other systems.
-If you want to install from source code, you will need to ensure you have all
-the dependencies. For more information on building Virtaal to install it
-yourself, please consult the website here:
+Download the latest release (Windows installer, macOS ``.dmg``) from
+the `Releases page <https://github.com/translate/virtaal/releases>`_.
+Linux users can build a Flatpak, or build from source - see
 http://docs.translatehouse.org/projects/virtaal/en/latest/building.html
 
 Note that you will probably already want the Translate Toolkit installed and
-working before you attempt to install Virtaal.
+working before you attempt to install Virtaal from source.
 
 Reporting bugs
 --------------
-Please report bugs by clicking on '*Help->Report bug...*' from within Virtaal
-(this requires a Bugzilla account).  Alternatively report directly using this
-URL: <https://github.com/translate/virtaal/issues/new>
-
-Taking the time to create a bugzilla account will help ensure that you can track
-progress, provide feedback and allows others to see your bug report.
+Please report bugs by clicking on '*Help->Report bug...*' from within Virtaal,
+or directly using this URL: <https://github.com/translate/virtaal/issues/new>
+(requires a GitHub account).
 
 Design principles
 -----------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,17 +38,17 @@ Help menu.
 
 Installation
 ============
-No packaged builds exist yet for this Python 3 + GTK3 release - build
-from source, see :doc:`building`.
+Download the latest release (Windows installer, macOS `.dmg`) from the
+`Releases page <https://github.com/translate/virtaal/releases>`_.
+Linux users can build a `Flatpak
+<https://github.com/translate/virtaal/tree/main/devsupport/packaging/flatpak>`_,
+or build from source - see :doc:`building`.
 
 .. _index#contact:
 
 Contact
 =======
-- Chat in our `channel <https://gitter.im/translate/pootle>`_
 - `Report bugs <https://github.com/translate/virtaal/issues/new>`_
-- Join the `Translate-devel mailing list
-  <https://lists.sourceforge.net/lists/listinfo/translate-devel>`_
 
 .. _index#contributing:
 


### PR DESCRIPTION
`README.rst` and `docs/index.rst` both said no packaged builds exist and pointed only at building from source - stale now that Windows/macOS/Flatpak all build in CI and a real release process exists. Also fixes `README.rst`'s bug-reporting section, which still named Bugzilla; the app itself already opens a GitHub issue.

`docs/index.rst`'s Contact section also listed a gitter channel and a SourceForge mailing list as live contact points - neither is actually active. GitHub issues is the one real, live channel; kept that, dropped the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)