### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,77 @@
+name: Bug report
+description: Something in Virtaal isn't working as expected
+labels: ["bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: What did you do, what did you expect to happen, and what actually happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: The exact sequence of actions that triggers it, as precisely as you can.
+      placeholder: |
+        1. Open checks.po
+        2. ...
+    validations:
+      required: false
+
+  - type: input
+    id: version
+    attributes:
+      label: Virtaal version
+      description: Run `virtaal --version` (or Help → About), and paste the full output here.
+      placeholder: 1.0.0-beta1 (5bb637f)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: install-method
+    attributes:
+      label: How did you install Virtaal?
+      options:
+        - Windows installer
+        - macOS .dmg
+        - Flatpak
+        - pip install / from source checkout
+        - Linux distro package
+        - Other (please describe below)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - Windows
+        - macOS
+        - Linux
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: os-version
+    attributes:
+      label: OS version
+      placeholder: e.g. Windows 11 23H2, macOS 15.1, Ubuntu 24.04
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Log output (if relevant)
+      description: >
+        On Windows/macOS frozen builds, `stdout_virtaal.log`/`stderr_virtaal.log`
+        live next to your Virtaal config directory. Paste anything relevant -
+        a real crash/traceback is far more useful here than a description of one.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,19 @@
+name: Feature request
+description: Suggest something Virtaal doesn't do yet
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem would this solve?
+      description: What are you trying to do today that Virtaal doesn't support, or makes awkward?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What would you like to see?
+      description: Your idea for how this could work - a rough sketch is fine, it doesn't need to be a full design.
+    validations:
+      required: false


### PR DESCRIPTION
No bug-report/feature-request structure existed at all - a new issue got GitHub's completely blank default form (confirmed via the API, `community/profile` showed `issue_template: null`). Worth having before a real beta starts collecting reports: asks for the exact version string (`--version`, which already embeds the build commit), how it was installed, and OS - the details every platform-specific bug report in this project's own history has needed.

`config.yml` just keeps blank issues enabled (not forcing template use) - dropped the contact links it originally had (a gitter channel and a SourceForge mailing list, neither actually active - same fix as #3397).

🤖 Generated with [Claude Code](https://claude.com/claude-code)