### PR TITLE
Fix missing translate.storage submodules and log truncation in frozen builds

### DIFF
--- a/devsupport/packaging/macos/virtaal.spec
+++ b/devsupport/packaging/macos/virtaal.spec
@@ -14,6 +14,10 @@
 # across the whole virtaal package (not just .plugins) is the simplest way
 # to not have to enumerate either by hand, at negligible cost for a
 # pure-Python package this size.
+#
+# Same reasoning covers translate.storage: factory.getobject() imports
+# a format's backend module by a runtime-computed string, invisible to
+# PyInstaller unless collected explicitly too.
 import os
 import sys
 from pathlib import Path
@@ -69,7 +73,7 @@ a = Analysis(  # noqa: F821
         (str(ROOT / "devsupport" / "mac-bundle" / "VirtaalDocument.icns"), "."),
     ]
     + mo_files,
-    hiddenimports=collect_submodules("virtaal"),
+    hiddenimports=collect_submodules("virtaal") + collect_submodules("translate.storage"),
     hooksconfig={
         "gi": {
             "module-versions": {

--- a/devsupport/packaging/windows/virtaal.spec
+++ b/devsupport/packaging/windows/virtaal.spec
@@ -12,6 +12,10 @@
 # reached via bin/virtaal's own runpy-based "--run-module" dispatch -
 # see localtm.py.
 #
+# Same reasoning covers translate.storage: factory.getobject() imports
+# a format's backend module by a runtime-computed string, invisible to
+# PyInstaller unless collected explicitly too.
+#
 # --onedir (not --onefile): translate.misc.file_discovery's frozen-mode
 # data lookup (os.path.dirname(sys.executable), confirmed by reading the
 # installed package directly) assumes a flat, same-directory-as-
@@ -130,7 +134,7 @@ a = Analysis(  # noqa: F821
         (str(TRANSLATE_SHARE), "share"),
     ]
     + mo_files,
-    hiddenimports=collect_submodules("virtaal"),
+    hiddenimports=collect_submodules("virtaal") + collect_submodules("translate.storage"),
     hooksconfig={
         "gi": {
             "module-versions": {

--- a/devsupport/testing/windows/virtaal_ui_test_helpers.ps1
+++ b/devsupport/testing/windows/virtaal_ui_test_helpers.ps1
@@ -452,10 +452,13 @@ function Assert-VirtaalLogsClean {
     Same allowlist-of-lines shape as the "Verify the bundle actually
     runs" step in ci.yml: fails (writes ::error:: and returns $false) if
     either log file contains a line not covered by $AllowlistPatterns
-    (an array of regex strings). Starts with no allowlist by default -
-    the known-clean baseline for this frozen build is empty logs.
+    (an array of regex strings). The baseline always allows pan_app.py's
+    own launch-separator line (written unconditionally on every start,
+    now that the logs are appended to rather than truncated) - anything
+    past that is real unexpected output.
     #>
     param([string[]]$AllowlistPatterns = @(), [switch]$AllowDebugLog)
+    $AllowlistPatterns = $AllowlistPatterns + '^=== launch \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} ===$'
     if ($script:VirtaalAppDebugLog -or $AllowDebugLog) {
         # bin\virtaal's -D/--debug format is '%(levelname)7s
         # %(module)s...' - levelname right-justified to 7 chars, so

--- a/virtaal/common/pan_app.py
+++ b/virtaal/common/pan_app.py
@@ -51,9 +51,17 @@ def get_config_dir():
 # subsystem executable has no console, so this is the only way to get
 # error messages out of it.
 if os.name == 'nt' and getattr(sys, 'frozen', False):
+    import time
     filename_template = os.path.join(get_config_dir(), '%s_virtaal.log')
-    sys.stdout = open(filename_template % ('stdout'), 'w', buffering=1)
-    sys.stderr = open(filename_template % ('stderr'), 'w', buffering=1)
+    # Append, not overwrite - a crash's own log was otherwise wiped the
+    # moment the app was relaunched to look at it. A separator line
+    # marks where each launch's own output starts, since a single file
+    # can now span several runs.
+    sys.stdout = open(filename_template % ('stdout'), 'a', buffering=1)
+    sys.stderr = open(filename_template % ('stderr'), 'a', buffering=1)
+    _launch_marker = '=== launch %s ===\n' % (time.strftime('%Y-%m-%d %H:%M:%S'))
+    sys.stdout.write(_launch_marker)
+    sys.stderr.write(_launch_marker)
 
 
 # Ok, now we can continue with what we actually wanted to do


### PR DESCRIPTION
Real Windows test of the frozen installer found two bugs.

**Opening `.qph`/`.ftl`/`.xliff` failed with `"No module named 'translate.storage.qph'"`** (and similarly for the others). `translate.storage.factory` - the single entry point virtaal always goes through to open any file - resolves a file's format to its actual backend module via `importlib.import_module()` on a string computed at runtime, invisible to PyInstaller's static analysis. Formats virtaal happens to also import directly somewhere (`.po`, `.mo`, `.ts`) worked by accident; everything only reached through `factory` didn't. Reproduced directly: blocking these three modules from import and calling `factory.getobject()` raises the exact same error text reported on Windows. `collect_submodules("translate.storage")` added on both platforms - not Windows-specific, macOS's spec has the identical gap.

**stdout/stderr logs were truncated on every launch**, wiping a crash's own log the moment the app was relaunched to look at it. Append instead, with a launch-separator line since one file can now span several runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
