### PR TITLE
Fix Pontoon terminology plugin failing to load: GType name collision

### DIFF
--- a/virtaal/plugins/terminology/models/pontoon.py
+++ b/virtaal/plugins/terminology/models/pontoon.py
@@ -56,7 +56,7 @@ class TerminologyModel(BaseTerminologyModel):
         extending translate-toolkit's own TBX support.
         """
 
-    __gtype_name__ = 'AutoTermTerminology'
+    __gtype_name__ = 'PontoonTerminology'
     display_name = _('Mozilla Pontoon')
     description = _('Community localization terminology from Mozilla Pontoon')
 


### PR DESCRIPTION
Real local run failed with:

\`\`\`
RuntimeError: could not create new GType: AutoTermTerminology (subclass of virtaal+plugins+terminology+models+basetermmodel+BaseTerminologyModel)
\`\`\`

\`pontoon.py\`'s \`TerminologyModel\` was copied from \`autoterm.py\` and kept its exact \`__gtype_name__\` (\`'AutoTermTerminology'\`) - GObject registers GType names process-wide, so loading both plugins collided as soon as \`pontoon.py\`'s class definition ran.

Renamed to its own \`PontoonTerminology\`. Checked the rest of the codebase for other \`__gtype_name__\` collisions - none found.