### PR TITLE
Windows test harness: allow the launch-separator line in log checks

### DIFF
--- a/devsupport/testing/windows/virtaal_ui_test_helpers.ps1
+++ b/devsupport/testing/windows/virtaal_ui_test_helpers.ps1
@@ -452,10 +452,13 @@ function Assert-VirtaalLogsClean {
     Same allowlist-of-lines shape as the "Verify the bundle actually
     runs" step in ci.yml: fails (writes ::error:: and returns $false) if
     either log file contains a line not covered by $AllowlistPatterns
-    (an array of regex strings). Starts with no allowlist by default -
-    the known-clean baseline for this frozen build is empty logs.
+    (an array of regex strings). The baseline always allows pan_app.py's
+    own launch-separator line (written unconditionally on every start,
+    now that the logs are appended to rather than truncated) - anything
+    past that is real unexpected output.
     #>
     param([string[]]$AllowlistPatterns = @(), [switch]$AllowDebugLog)
+    $AllowlistPatterns = $AllowlistPatterns + '^=== launch \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} ===$'
     if ($script:VirtaalAppDebugLog -or $AllowDebugLog) {
         # bin\virtaal's -D/--debug format is '%(levelname)7s
         # %(module)s...' - levelname right-justified to 7 chars, so


### PR DESCRIPTION
Re-landing a commit that was dropped from #3401: it was one of that PR's three commits, but the merge queue evaluated a stale snapshot from before this specific commit was pushed, so only the other two landed on \`main\`. Confirmed directly against \`upstream/main\`'s current file content - the fix was genuinely absent.

Net effect: every Windows PR's "Verify the bundle actually runs" CI step has been failing since #3401 merged (\`pan_app.py\` now writes a launch-separator line on every start instead of leaving the log empty, and \`Assert-VirtaalLogsClean\`'s baseline never got updated to allow for that). This is the fix - added the separator line to the permanent allowlist rather than the opt-in debug one, since it's always expected now.