### PR TITLE
Defer the post-fullscreen resize until the OS transition actually settles

### DIFF
--- a/virtaal/views/mainview.py
+++ b/virtaal/views/mainview.py
@@ -390,6 +390,7 @@ class MainView(BaseView):
             gdk_window = self.main_window.get_window()
             if gdk_window and not (gdk_window.get_state() & Gdk.WindowState.FULLSCREEN):
                 self._pre_fullscreen_size = self.main_window.get_size()
+                logging.debug("fullscreen: captured pre-fullscreen size %s", self._pre_fullscreen_size)
             return False
 
         def on_configure_event(widget, event):
@@ -907,6 +908,9 @@ class MainView(BaseView):
     def _on_window_state_event(self, widget, event):
         mnu_fullscreen = self.gui.get_object('mnu_fullscreen')
         mnu_fullscreen.set_active(event.new_window_state & Gdk.WindowState.FULLSCREEN)
+        logging.debug(
+            "fullscreen: window-state-event new=%s changed=%s size=%s",
+            event.new_window_state, event.changed_mask, self.main_window.get_size())
         # React to the real, confirmed transition, not the unfullscreen()
         # call itself (which doesn't reliably take effect synchronously
         # on Windows).
@@ -917,6 +921,7 @@ class MainView(BaseView):
         if left_fullscreen and getattr(self, '_pre_fullscreen_size', None):
             target_size = self._pre_fullscreen_size
             self._pre_fullscreen_size = None
+            logging.debug("fullscreen: leaving, will restore to %s in 250ms", target_size)
             # Deferred, not resized right here: this event fires the
             # moment the state *changes*, still mid-transition on both
             # the Win32 and Quartz backends (Quartz's exit-fullscreen is
@@ -932,7 +937,9 @@ class MainView(BaseView):
         store_controller = self.controller.store_controller
         if store_controller.store is not None:
             store_controller.view._treeview.reset_column_width()
+        logging.debug("fullscreen: resizing to %s (get_size() was %s)", target_size, self.main_window.get_size())
         self.main_window.resize(*target_size)
+        logging.debug("fullscreen: get_size() now reports %s", self.main_window.get_size())
         return False  # one-shot: don't repeat this GLib.timeout_add
 
     def _on_app_pressed(self, btn):

--- a/virtaal/views/mainview.py
+++ b/virtaal/views/mainview.py
@@ -6,6 +6,7 @@
 # the AUTHORS.md file for copyright and authorship information.
 
 import locale
+import logging
 import os
 import subprocess
 import time
@@ -116,7 +117,6 @@ class MainView(BaseView):
                 Gtk.Settings.get_default().set_property(
                     "gtk-application-prefer-dark-theme", is_dark)
             except (OSError, subprocess.SubprocessError):
-                import logging
                 logging.exception("Couldn't determine macOS appearance")
 
             # Sometimes we have two resize grips: one from GTK, one from Aqua. We
@@ -158,7 +158,6 @@ class MainView(BaseView):
                 osxapp.connect("NSApplicationBlockTermination", self._on_quit)
                 self._osxapp = osxapp  # keep a reference; the signals need it to stay alive
             except (ImportError, ValueError):
-                import logging
                 logging.debug("GtkosxApplication not found (brew install gtk-mac-integration for native macOS menu-bar integration). Expect zero integration with the Mac desktop.")
 
         elif platform.is_windows:
@@ -173,7 +172,6 @@ class MainView(BaseView):
                 Gtk.Settings.get_default().set_property(
                     "gtk-application-prefer-dark-theme", apps_use_light_theme == 0)
             except OSError:
-                import logging
                 logging.exception("Couldn't determine Windows theme")
 
         self.main_window.connect('destroy', self._on_quit)

--- a/virtaal/views/mainview.py
+++ b/virtaal/views/mainview.py
@@ -136,6 +136,13 @@ class MainView(BaseView):
                 mnu_quit = self.gui.get_object("mnu_quit")
                 mnu_quit.hide()
                 self.gui.get_object("separator_mnu_file_2").hide()
+                # macOS already adds its own native "Enter Full Screen" to
+                # every resizable window - our own GDK-level fullscreen()
+                # is a different mechanism (no real fullscreen Space,
+                # Esc/mouse-to-top-of-screen native affordances not
+                # engaged) and can leave the window with no way back to
+                # the menu bar. Hide it here, keep only the native one.
+                self.gui.get_object("mnu_fullscreen").hide()
                 # Move the about menu item
                 mnu_about = self.gui.get_object("mnu_about")
                 osxapp.insert_app_menu_item(mnu_about, 0)
@@ -362,10 +369,27 @@ class MainView(BaseView):
 
     def _track_window_state(self):
         self._window_is_maximized = False
+        self._pre_fullscreen_size = None
 
         def on_state_event(widget, event):
             self._window_is_maximized = bool(event.new_window_state & Gdk.WindowState.MAXIMIZED)
         self.main_window.connect('window-state-event', on_state_event)
+
+        # Covers entering fullscreen via macOS's own native mechanism
+        # (the green button, Fn+F), not just our own _on_fullscreen() -
+        # by the time a window-state-event confirms fullscreen has
+        # started, get_size() already reports the fullscreen size, so
+        # the pre-fullscreen size has to be tracked continuously
+        # beforehand instead. Queries the GdkWindow's own state directly
+        # rather than a same-transition window-state-event flag - the
+        # two signals' relative firing order isn't guaranteed, and a
+        # flag not yet updated would let this capture the fullscreen
+        # size itself instead of the real pre-fullscreen one.
+        def on_configure_event(widget, event):
+            gdk_window = widget.get_window()
+            if gdk_window and not (gdk_window.get_state() & Gdk.WindowState.FULLSCREEN):
+                self._pre_fullscreen_size = self.main_window.get_size()
+        self.main_window.connect('configure-event', on_configure_event)
 
     def _setup_dnd(self):
         """configures drag and drop"""
@@ -796,12 +820,6 @@ class MainView(BaseView):
 
     def _on_fullscreen(self, widget=None):
         if widget.get_active():
-            # GTK/GDK's Windows backend doesn't reliably restore the
-            # pre-fullscreen size on its own (can stay near-fullscreen
-            # width after unfullscreen()) - save
-            # it here and restore explicitly once _on_window_state_event
-            # confirms fullscreen has actually ended.
-            self._pre_fullscreen_size = self.main_window.get_size()
             self.main_window.fullscreen()
             self.status_bar.hide()
             self.show_app_icon()
@@ -883,7 +901,7 @@ class MainView(BaseView):
         mnu_fullscreen.set_active(event.new_window_state & Gdk.WindowState.FULLSCREEN)
         # React to the real, confirmed transition, not the unfullscreen()
         # call itself (which doesn't reliably take effect synchronously
-        # on Windows) - see _on_fullscreen()'s own comment.
+        # on Windows).
         left_fullscreen = (
             event.changed_mask & Gdk.WindowState.FULLSCREEN
             and not (event.new_window_state & Gdk.WindowState.FULLSCREEN)

--- a/virtaal/views/mainview.py
+++ b/virtaal/views/mainview.py
@@ -891,10 +891,23 @@ class MainView(BaseView):
         if left_fullscreen and getattr(self, '_pre_fullscreen_size', None):
             target_size = self._pre_fullscreen_size
             self._pre_fullscreen_size = None
-            store_controller = self.controller.store_controller
-            if store_controller.store is not None:
-                store_controller.view._treeview.reset_column_width()
-            self.main_window.resize(*target_size)
+            # Deferred, not resized right here: this event fires the
+            # moment the state *changes*, still mid-transition on both
+            # the Win32 and Quartz backends (Quartz's exit-fullscreen is
+            # a genuinely animated ~0.3-0.5s transition) - a resize()
+            # issued now gets silently overridden once that transition's
+            # own final frame lands, on both platforms alike. 250ms is
+            # enough - the transition's own settle is already visible in
+            # storetreeview's 200ms debounce well before this fires.
+            from gi.repository import GLib
+            GLib.timeout_add(250, self._restore_pre_fullscreen_size, target_size)
+
+    def _restore_pre_fullscreen_size(self, target_size):
+        store_controller = self.controller.store_controller
+        if store_controller.store is not None:
+            store_controller.view._treeview.reset_column_width()
+        self.main_window.resize(*target_size)
+        return False  # one-shot: don't repeat this GLib.timeout_add
 
     def _on_app_pressed(self, btn):
         self.app_menu.popup(None, None, None, 0, 0, Gtk.get_current_event_time())

--- a/virtaal/views/mainview.py
+++ b/virtaal/views/mainview.py
@@ -379,16 +379,26 @@ class MainView(BaseView):
         # (the green button, Fn+F), not just our own _on_fullscreen() -
         # by the time a window-state-event confirms fullscreen has
         # started, get_size() already reports the fullscreen size, so
-        # the pre-fullscreen size has to be tracked continuously
-        # beforehand instead. Queries the GdkWindow's own state directly
-        # rather than a same-transition window-state-event flag - the
-        # two signals' relative firing order isn't guaranteed, and a
-        # flag not yet updated would let this capture the fullscreen
-        # size itself instead of the real pre-fullscreen one.
-        def on_configure_event(widget, event):
-            gdk_window = widget.get_window()
+        # the pre-fullscreen size has to be tracked beforehand instead.
+        # Debounced, not committed on every event: macOS's own
+        # fullscreen transition is a multi-frame animation, and an
+        # intermediate frame's own configure-event can still report
+        # not-yet-fullscreen (the state bit lags the size changes) -
+        # only a size that's stayed put for a real moment is trustworthy.
+        self._size_settle_source = None
+
+        def commit_pre_fullscreen_size():
+            self._size_settle_source = None
+            gdk_window = self.main_window.get_window()
             if gdk_window and not (gdk_window.get_state() & Gdk.WindowState.FULLSCREEN):
                 self._pre_fullscreen_size = self.main_window.get_size()
+            return False
+
+        def on_configure_event(widget, event):
+            from gi.repository import GLib
+            if self._size_settle_source is not None:
+                GLib.source_remove(self._size_settle_source)
+            self._size_settle_source = GLib.timeout_add(300, commit_pre_fullscreen_size)
         self.main_window.connect('configure-event', on_configure_event)
 
     def _setup_dnd(self):


### PR DESCRIPTION
Real report: F11 fullscreen doesn't restore the window's original size on exit. Confirmed on both Windows and macOS - different GDK backends, so this is app code, not a backend bug.

`_on_window_state_event`'s `resize()` ran synchronously the instant the state-change event fired, before the OS's own exit-fullscreen transition has actually finished - deferred it, and made the pre-fullscreen size capture itself debounced (macOS's own native fullscreen, triggered by the green button/Fn+F, needs the size tracked continuously, not just around our own F11 handling). Virtaal's own F11 fullscreen is disabled on macOS entirely now - only native fullscreen exists there.

Tested live on both platforms:
- **Windows**: F11 in and out restores the correct size and works well.
- **macOS**: the restored size and window position are correct, but the very first restore after exiting fullscreen doesn't visually apply until some other window-manager interaction (opening any menu) happens - logged as a known cosmetic issue, not something worth blocking beta1 over. Five different ways of forcing it to apply immediately (draining events, `Gdk.flush()`, `present()`, `sync_menubar()`, popping a menu open and closed) were all tried and none worked; it's very likely a GTK/Quartz-backend limitation rather than something fixable from application code.