### PR TITLE
Fix plugin discovery finding nothing in a frozen build

### DIFF
--- a/virtaal/controllers/plugincontroller.py
+++ b/virtaal/controllers/plugincontroller.py
@@ -194,30 +194,35 @@ class PluginController(BaseController):
         return plugin_class
 
     def _find_plugin_names(self):
-        """Look in C{self.PLUGIN_DIRS} for importable Python modules.
+        """Look in each of C{self.PLUGIN_MODULES}'s packages for importable
+            submodules, via C{pkgutil.iter_modules()} rather than scanning
+            C{self.PLUGIN_DIRS} on the filesystem directly - the latter
+            always found nothing in a frozen (PyInstaller) build, since
+            pure-Python modules are bundled into an archive there, not laid
+            out as loose files on disk, so the "plugins" directory simply
+            doesn't exist to list. pkgutil.iter_modules() works against a
+            package's __path__ either way, frozen or not.
             @note: Hidden files/directories are ignored.
             @note: If a plug-in is in a directory, it's C{self.PLUGIN_CLASSNAME}
                 class should be exposed in the plug-in's __init__.py file.
             @returns: A list of module names, assumed to be plug-ins."""
+        import importlib
+        import pkgutil
+
         plugin_names = []
 
-        for dir in self.PLUGIN_DIRS:
-            if not os.path.isdir(dir):
+        for plugin_module in self.PLUGIN_MODULES:
+            try:
+                package = importlib.import_module(plugin_module)
+            except ImportError:
                 continue
-            for name in os.listdir(dir):
+            if not hasattr(package, '__path__'):
+                continue
+            for _finder, name, _ispkg in pkgutil.iter_modules(package.__path__):
                 if self._is_wrong_plugin_name(name):
                     continue
-                fullpath = os.path.join(dir, name)
-                if os.path.isdir(fullpath):
-                    # XXX: The plug-in system assumes that a plug-in in a directory makes the Plugin class accessible via it's __init__.py
-                    if pan_app.DEBUG or name[0] != u'_':
-                        plugin_names.append(name)
-                elif os.path.isfile(fullpath) and not name.startswith(u'__init__.py'):
-                    if u'.py' not in name:
-                        continue
-                    plugname = u'.'.join(name.split(os.extsep)[:-1]) # Effectively removes extension, preserving other .'s in the name
-                    if pan_app.DEBUG or plugname[0] != u'_':
-                        plugin_names.append(plugname)
+                if pan_app.DEBUG or name[0] != u'_':
+                    plugin_names.append(name)
 
         plugin_names = list(set(plugin_names))
         #logging.debug('Found plugins: %s' % (', '.join(plugin_names)))


### PR DESCRIPTION
Real Windows test: Preferences showed a completely blank plugin list, and no terminology backend (Pontoon included) ever loaded - not a crash, just silent non-discovery.

\`_find_plugin_names()\` scanned \`self.PLUGIN_DIRS\` via \`os.listdir()\` against a real filesystem path derived from \`__file__\`. PyInstaller bundles pure-Python modules into an archive, not as loose files on disk, so that directory never exists in a frozen build and the scan always returned nothing - not Pontoon-specific, every plugin was affected, and every nested plugin_controller (terminology/tm/lookup models, which reconfigure \`PLUGIN_DIRS\`/\`PLUGIN_MODULES\` the same way) too.

Switched to \`pkgutil.iter_modules()\` against each of \`self.PLUGIN_MODULES\`'s already-imported packages instead - it enumerates a package's \`__path__\` correctly whether frozen or not, and every existing \`PLUGIN_MODULES\` reconfiguration (\`termcontroller.py\`/\`tmcontroller.py\`/\`lookupcontroller.py\`) already sets that list correctly, so this needed no changes anywhere but this one method.

Confirmed directly (not just reasoned about): finds \`pontoon\`/\`autoterm\`/\`localfile\` via the same nested-reconfiguration path those controllers use, and \`spellchecker\`/\`terminology\`/\`tm\`/\`lookup\`/etc. at the top level. Full test suite passes (42 passed).

\`PLUGIN_DIRS\` itself (and the three controllers' own reconfiguration of it) becomes dead code as a result - left in place rather than swept out in the same change; a smaller follow-up, not blocking this fix.