### PR TITLE
spellchecker: disable gracefully when GtkSpell/enchant is missing

### DIFF
--- a/virtaal/plugins/spellchecker.py
+++ b/virtaal/plugins/spellchecker.py
@@ -62,11 +62,18 @@ class Plugin(BasePlugin):
             except UnicodeEncodeError:
                 raise PluginUnsupported("Spell checking is not supported with non-ascii username")
 
-        # If these imports fail, the plugin is automatically disabled
-        import gi
-        gi.require_version('GtkSpell', '3.0')
-        from gi.repository import GtkSpell as gtkspell
-        import enchant
+        # If these imports fail, the plugin is automatically disabled -
+        # gi.require_version() raises ValueError (not ImportError) when
+        # the typelib itself is simply missing (true for this project's
+        # gvsbuild GTK3 build, which doesn't ship GtkSpell/enchant at
+        # all), so both need catching here, not just ImportError.
+        try:
+            import gi
+            gi.require_version('GtkSpell', '3.0')
+            from gi.repository import GtkSpell as gtkspell
+            import enchant
+        except (ImportError, ValueError) as e:
+            raise PluginUnsupported(str(e))
         self.gtkspell = gtkspell
         self.enchant = enchant
         # languages that we've handled before:


### PR DESCRIPTION
Direct fallout of the plugin-discovery fix (#3407): spellchecker was never actually attempted before (discovery found nothing), so this exact path was never exercised in a frozen build. Now that plugins are discovered correctly, \`gi.require_version\` raised a raw \`ValueError\` on Windows (\`Namespace GtkSpell not available\`) and a raw \`ModuleNotFoundError\` on macOS (\`No module named 'enchant'\`) - both this project's gvsbuild/no-enchant builds, confirmed via real CI runs on both platforms - neither caught, so \`enable_plugin()\`'s generic \`except Exception\` logged a full ERROR-level traceback instead of the quiet, one-line disablement the class's own comment already claims happens.

Wrapped in \`try/except (ImportError, ValueError)\`, raising \`PluginUnsupported\` - the same graceful-disablement path already used two lines above for the non-ascii-username case.

**Re-landing this**: it was pushed as a second commit onto #3407 but the merge queue evaluated a stale snapshot from before that push landed, so only the first commit actually made it to \`main\` - same failure mode as the \`Assert-VirtaalLogsClean\` commit dropped from #3401 earlier. Recovering the same way: a fresh PR against current \`main\`.