### PR TITLE
Fix PluginUnsupported handler crashing on Python 3

### DIFF
--- a/virtaal/controllers/plugincontroller.py
+++ b/virtaal/controllers/plugincontroller.py
@@ -109,7 +109,10 @@ class PluginController(BaseController):
             try:
                 self.plugins[name] = plugin_class(name, self.controller)
             except PluginUnsupported as pu:
-                logging.info(pu.message)
+                # Exception.message was a Python 2-only attribute -
+                # PluginUnsupported (controllers/baseplugin.py) is a bare
+                # Exception subclass with no such attribute in Python 3.
+                logging.info(str(pu))
                 return None
             self.emit('plugin-enabled', self.plugins[name])
             logging.info('    - ' + getattr(self.plugins[name], self.PLUGIN_NAME_ATTRIB, name))


### PR DESCRIPTION
Real CI failure on both Windows and macOS, right after #3408's fix: \`enable_plugin()\`'s \`except PluginUnsupported\` handler read \`pu.message\` - a Python 2-only \`Exception\` attribute. \`PluginUnsupported\` (\`baseplugin.py\`) is a bare \`Exception\` subclass with no such attribute in Python 3, so the handler itself raised \`AttributeError\` instead of the clean, one-line disablement it was meant to produce.

Pre-existing bug, not introduced by #3408 - the only previous \`PluginUnsupported\` call site (spellchecker.py's non-ascii-username case) was apparently never actually exercised in CI before now. \`str(pu)\` instead of \`pu.message\`. Confirmed directly.

**Re-landing this**: pushed as a second commit onto #3408, but that PR merged with only the first commit before it landed - same pattern as #3401 and #3407. Root cause identified this time, not just timing: \`translate/virtaal\`'s merge ruleset only requires \`"core checks"\` (a ~5s job) to pass - \`build-windows-installer\`/\`build-macos-app\` aren't required checks at all, so a merge can go through before those slower jobs even finish.