### PR TITLE
Hide dev-only plugins from a frozen build

### DIFF
--- a/virtaal/controllers/plugincontroller.py
+++ b/virtaal/controllers/plugincontroller.py
@@ -224,6 +224,10 @@ class PluginController(BaseController):
             for _finder, name, _ispkg in pkgutil.iter_modules(package.__path__):
                 if self._is_wrong_plugin_name(name):
                     continue
+                # Don't show dev-only plugins (_helloworld, _python_console,
+                # ...) on frozen builds, regardless of DEBUG's value here.
+                if getattr(sys, 'frozen', False) and name[0] == u'_':
+                    continue
                 if pan_app.DEBUG or name[0] != u'_':
                     plugin_names.append(name)
 


### PR DESCRIPTION
Real Windows test: Preferences listed \`_helloworld\` alongside real plugins in a packaged build. \`_find_plugin_names()\`'s underscore-prefix exclusion only applied when \`pan_app.DEBUG\` was false - relying on that left room for ordering/edge cases to leak dev-only plugins into a real user's Preferences list.

Gate on \`sys.frozen\` directly as well - a packaged build should never show these regardless of \`DEBUG\`'s exact state. Confirmed directly: \`_helloworld\`/\`_python_console\`/\`_ipython_console\` excluded when frozen, present otherwise; real plugins unaffected. Full test suite passes.