### PR TITLE
Fix Pontoon terminology downloads 404ing for regional locale codes

### DIFF
--- a/virtaal/plugins/terminology/models/pontoon.py
+++ b/virtaal/plugins/terminology/models/pontoon.py
@@ -190,7 +190,10 @@ class TerminologyModel(BaseTerminologyModel):
         if os.path.isfile(localfile) and localfile in self.config:
             etag = self.config[os.path.abspath(localfile)]
 
-        url = self._l10n_URL % {'srclang': srclang, 'tgtlang': tgtlang}
+        url = self._l10n_URL % {
+            'srclang': _pontoon_locale_code(srclang),
+            'tgtlang': _pontoon_locale_code(tgtlang),
+        }
 
         if not os.path.isfile(localfile):
             localfile = None
@@ -292,6 +295,23 @@ def _is_english(langcode):
         only, see TerminologyModel's own docstring."""
     normalized = normalize_code(langcode)
     return bool(normalized) and normalized.split('-')[0] == 'en'
+
+
+def _pontoon_locale_code(langcode):
+    """Convert a Virtaal-style language code (e.g. "en_GB") to the exact
+        form Pontoon's own static file naming expects. Two things
+        normalize_code() alone doesn't get right for this specific server:
+        it lowercases the whole code (Pontoon's server is case-sensitive
+        and serves "en-GB.tbx", not "en-gb.tbx" - confirmed live, the
+        lowercase form 404s), and Virtaal's own codes use an underscore
+        separator where Pontoon's file names use a hyphen. Language
+        subtag lowercase, region subtag uppercase - the standard BCP 47
+        casing convention, not something Pontoon invented."""
+    normalized = normalize_code(langcode)
+    parts = normalized.split('-')
+    if len(parts) > 1:
+        parts[1] = parts[1].upper()
+    return '-'.join(parts)
 
 
 # TBX-Basic dialect (ISO 30042:ed-2) namespace - what Pontoon actually


### PR DESCRIPTION
Real Windows test: downloading \`en_GB\` terminology from Pontoon failed. Pontoon's server is case-sensitive and serves files as e.g. \`en-GB.tbx\` - confirmed live via a real fetch: the exact underscore form Virtaal's own language codes use (\`en_GB\`) and even the all-lowercase hyphenated form (\`en-gb\`, what \`normalize_code()\` alone produces) both 404; only the properly-cased \`en-GB\` (language lowercase, region uppercase - standard BCP 47 casing) actually returns content.

Added \`_pontoon_locale_code()\` to fix the casing after \`normalize_code()\` does the underscore-to-hyphen conversion, used for both \`srclang\`/\`tgtlang\` when building the download URL. Confirmed directly against a battery of codes (\`en_GB\`, \`en-GB\`, \`pt_BR\`, \`en\`, \`fr\`, \`en_US\`). Full test suite passes.