### PR TITLE
Windows: disable curl's schannel certificate-revocation check

### DIFF
--- a/virtaal/support/httpclient.py
+++ b/virtaal/support/httpclient.py
@@ -18,6 +18,7 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 import logging
+import os
 from io import BytesIO
 
 import pycurl
@@ -69,6 +70,13 @@ class HTTPRequest(GObjectWrapper):
         # We want to use gzip and deflate if possible:
         self.curl.setopt(pycurl.ENCODING, "") # use all available encodings
         self.curl.setopt(pycurl.URL, self.url)
+
+        if os.name == 'nt':
+            # curl's schannel (Windows-native TLS) backend treats being
+            # unable to reach the CA's own revocation-check servers as
+            # a hard failure. SSLOPT_NO_REVOKE disables that check;
+            # curl only defines it for schannel, so it's a no-op elsewhere.
+            self.curl.setopt(pycurl.SSL_OPTIONS, pycurl.SSLOPT_NO_REVOKE)
 
         # let's set the HTTP request method
         if method == 'GET':


### PR DESCRIPTION
Real Windows test: every HTTPS request failed with "schannel: next InitializeSecurityContext failed: CRYPT_E_REVOKED - The certificate is revoked." - curl's schannel (Windows-native TLS) backend treats being unable to reach the CA's own revocation-check servers as a hard failure by default, distinct from reaching the actual request's own server (which worked fine). `SSLOPT_NO_REVOKE` disables that check; curl only defines it for schannel, so it's a no-op everywhere else.

Retested directly against pycurl (not just curl.exe, which uses a different bundled libcurl) on the same VM, hitting the three real HTTPS hosts Virtaal actually calls (GitHub API, Pontoon, GitHub releases): all three succeed whether the revocation check is on or off - the CA-revocation-server-unreachable condition this fix targets is inherently intermittent (depends on reachability of the revocation infrastructure at that moment, not the target host), so it can't be force-reproduced on demand. Also found and fixed a real confound in the original 460-failure count: that VM's `plugins.ini` had `disabled_models = ` (empty) for the terminology plugin, from before `autoterm` (whose default endpoint, terminology.locamotion.org, is fully dead) became disabled by default - so a chunk of that noise was an unrelated dead HTTP endpoint, not schannel at all.

Minimal, Windows/schannel-only change with no observed downside; landing it as the correct response to a real, documented curl/schannel behavior.