### PR TITLE
Terminology: Enter key submits the Add Term dialog

### DIFF
--- a/share/virtaal/virtaal.ui
+++ b/share/virtaal/virtaal.ui
@@ -1998,6 +1998,7 @@ If you are translating from English to French then French would be your translat
                 <property name="secondary_icon_activatable">False</property>
                 <property name="primary_icon_sensitive">True</property>
                 <property name="secondary_icon_sensitive">True</property>
+                <property name="activates_default">True</property>
               </object>
               <packing>
                 <property name="expand">True</property>
@@ -2030,6 +2031,7 @@ If you are translating from English to French then French would be your translat
                 <property name="secondary_icon_activatable">False</property>
                 <property name="primary_icon_sensitive">True</property>
                 <property name="secondary_icon_sensitive">True</property>
+                <property name="activates_default">True</property>
               </object>
               <packing>
                 <property name="expand">True</property>

--- a/virtaal/plugins/terminology/models/localfile/localfileview.py
+++ b/virtaal/plugins/terminology/models/localfile/localfileview.py
@@ -337,6 +337,10 @@ class TermAddDialog:
             setattr(self, name, self.gui.get_object(name))
 
         self.dialog = self.gui.get_object('TermAddDlg')
+        # Entries have activates_default set (virtaal.ui) - needs a
+        # default response to actually fire, since GTK doesn't infer
+        # one just from action-widgets' response mapping.
+        self.dialog.set_default_response(Gtk.ResponseType.OK)
 
         cellr = Gtk.CellRendererText()
         cellr.props.ellipsize = Pango.EllipsizeMode.MIDDLE


### PR DESCRIPTION
Reported live: pressing Enter in the source/target entry fields did nothing, only clicking Add or pressing Esc worked - despite \`btn_add_term\` already being wired to \`GTK_RESPONSE_OK\` via \`action-widgets\` in \`virtaal.ui\`.

Missing piece: \`activates_default\` only fires a dialog's *default* response widget, and nothing set one. Added \`activates_default\` to both entries and \`set_default_response(OK)\` on the dialog itself. Full test suite passes.