### PR TITLE
Fix About dialog's website link - dead SourceForge wiki

### DIFF
--- a/virtaal/views/widgets/aboutdialog.py
+++ b/virtaal/views/widgets/aboutdialog.py
@@ -48,7 +48,7 @@ GNU Library General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with this program; if not, see <http://www.gnu.org/licenses/>.""")
-        self.set_website("http://translate.sourceforge.net/wiki/virtaal/index")
+        self.set_website("https://virtaal.translatehouse.org")
         self.set_website_label(_("Virtaal website"))
         authors = [
                 "Friedel Wolff",


### PR DESCRIPTION
Reported live: the About screen's website link is wrong. Confirmed dead: \`translate.sourceforge.net/wiki/virtaal/index\` redirects (301) to \`translate.sourceforge.io/wiki/virtaal/index\`, which 404s.

Pointed at \`pyproject.toml\`'s own declared \`Homepage\` instead (\`virtaal.translatehouse.org\`) - confirmed live, same URL the packaging metadata already treats as canonical.

**Same dead domain appears in several more places** (not fixed here, scoping first): the welcome screen's Manual/Localization Guide/Feedback/Features links (\`welcomescreencontroller.py\`), \`mainview.py\`'s own duplicate of two of those, \`docs/conf.py\`'s Sphinx \`wiki\` extlink role, and a few \`.ui\` tooltips/translator comments. The real replacement for most of these already exists and is live - \`docs.translatehouse.org\`'s own current Virtaal docs (this same repo's \`docs/\`) has real "Using Virtaal" and "Features" pages - but each needs its own correct target page, not a blanket find-replace. Follow-up PR to come.