### PR TITLE
Fix Enter key permanently breaking after any plural unit

### DIFF
--- a/virtaal/test/test_unitcontroller.py
+++ b/virtaal/test/test_unitcontroller.py
@@ -18,7 +18,11 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-from gi.repository import GLib
+import os
+import tempfile
+
+from gi.repository import Gdk, GLib
+from translate.storage import factory
 
 from test_scaffolding import TestScaffolding
 
@@ -84,3 +88,130 @@ class TestUnitController(TestScaffolding):
 
         assert str(unit_b.target) == original_b_target
         assert not self.store_controller.is_modified()
+
+    class _FakeReturnEvent:
+        keyval = Gdk.KEY_Return
+        def get_state(self):
+            return Gdk.ModifierType(0)
+
+    def _make_temp_store(self, suffix, contents):
+        fd, path = tempfile.mkstemp(suffix=suffix)
+        os.write(fd, contents.encode('utf-8'))
+        os.close(fd)
+        return path
+
+    def _assert_enter_key_survives_plural_unit(self, plural_unit, *rest_units):
+        """Exhaust a plural unit's forms with Enter, then walk Enter
+        through each of rest_units (mixed types/states) confirming it
+        still advances. Shared across formats - see
+        test_enter_key_after_plural_unit_still_advances_po for the bug."""
+        assert plural_unit.hasplural()
+        assert rest_units, "need at least one unit after the plural one to test"
+        for u in rest_units:
+            assert not u.hasplural()
+
+        self.main_controller.lang_controller.target_lang.nplurals = 2
+
+        # Exhaust the plural unit's two forms - this part already worked
+        # before the fix, kept here so a future regression in the
+        # *other* direction gets caught too.
+        view = self.unit_controller.load_unit(plural_unit)
+        view.targets[0].set_text('one file')
+        view.targets[0].emit('key-pressed', self._FakeReturnEvent(), 'enter')
+        view.targets[1].set_text('N files')
+
+        done_calls = []
+        view.connect('editing-done', lambda *a: done_calls.append(a))
+        view.targets[1].emit('key-pressed', self._FakeReturnEvent(), 'enter')
+        assert done_calls, "Enter on the plural unit's last form should fire editing-done"
+        assert view.must_advance
+
+        # Now the real regression: load each *following* unit in turn
+        # (standing in for _keyboard_move()/select_index() actually
+        # advancing there in the real app) and confirm its own Enter
+        # key still works, whatever type or state it is.
+        for i, unit in enumerate(rest_units):
+            view = self.unit_controller.load_unit(unit)
+            assert not view.targets[1].get_parent().props.visible, \
+                "targets[1] should be hidden for a non-plural unit"
+
+            view.targets[0].set_text('translated %d' % i)
+            done_calls = []
+            view.connect('editing-done', lambda *a: done_calls.append(a))
+            view.targets[0].emit('key-pressed', self._FakeReturnEvent(), 'enter')
+
+            assert done_calls, (
+                "Enter on unit %d (fuzzy=%s) after a plural one should still "
+                "fire editing-done, not silently focus a hidden target box"
+                % (i, unit.isfuzzy())
+            )
+            assert view.must_advance
+
+    def test_enter_key_after_plural_unit_still_advances_po(self):
+        """Enter on a plural unit's last form used to permanently break
+        Enter for every unit after it - see unitview.py's
+        target_key_press_event() for the actual fix/why."""
+        po_contents = """\
+msgid ""
+msgstr ""
+"Plural-Forms: nplurals=2; plural=(n != 1);\\n"
+
+msgid "One file"
+msgid_plural "%d files"
+msgstr[0] ""
+msgstr[1] ""
+
+msgid "Second message"
+msgstr ""
+
+msgid "Third message"
+msgstr ""
+"""
+        path = self._make_temp_store('.po', po_contents)
+        try:
+            store = factory.getobject(path)
+            units = [u for u in store.units if not u.isheader()]
+            # units[1] stands in for "some other type/state", not just
+            # "the next plain unit" - see the shared helper's docstring.
+            units[1].markfuzzy(True)
+            self._assert_enter_key_survives_plural_unit(units[0], units[1], units[2])
+        finally:
+            os.unlink(path)
+
+    def test_enter_key_after_plural_unit_still_advances_ts(self):
+        """Same regression as the PO test above, for Qt Linguist's
+        numerus="yes"/numerusform plural mechanism."""
+        ts_contents = """\
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="af">
+<context>
+    <name>Test</name>
+    <message numerus="yes">
+        <source>%n file(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Second message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Third message</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>
+"""
+        path = self._make_temp_store('.ts', ts_contents)
+        try:
+            store = factory.getobject(path)
+            units = list(store.units)
+            # units[1] stands in for "some other type/state", not just
+            # "the next plain unit" - see the shared helper's docstring.
+            units[1].markfuzzy(True)
+            self._assert_enter_key_survives_plural_unit(units[0], units[1], units[2])
+        finally:
+            os.unlink(path)

--- a/virtaal/views/unitview.py
+++ b/virtaal/views/unitview.py
@@ -388,7 +388,7 @@ class UnitView(Gtk.EventBox, GObjectWrapper, Gtk.CellEditable, BaseView):
             if not eventname:
                 return False
             if eventname in  ('enter', 'ctrl-enter', 'ctrl-shift-enter'):
-                if next_textbox is not None and next_textbox.props.visible:
+                if next_textbox is not None and next_textbox.get_parent().props.visible:
                     self.focus_text_view(next_textbox)
                 else:
                     if eventname == 'ctrl-enter' and self.unit.STATE:


### PR DESCRIPTION
`target_key_press_event()` checked `next_textbox.props.visible` to decide whether Enter should move to the next plural form or advance the unit. But `_layout_update_targets()` hides an unused plural form by hiding its parent, not the textbox's own visible property - so once any plural unit had been shown, that flag stayed `True` forever, breaking every later unit's Enter key for the rest of the session.

Fixed by checking `next_textbox.get_parent().props.visible` instead. Confirmed via a live reproduction (real app, real window, real main loop) before and after the fix.

Added regression tests for both PO and Qt Linguist plurals, each walking Enter through a plural, fuzzy, and plain unit in sequence. Full suite passes (44 tests).