### PR TITLE
Fix InvalidWriteError crash saving Pontoon terminology config

### DIFF
--- a/virtaal/plugins/terminology/models/pontoon.py
+++ b/virtaal/plugins/terminology/models/pontoon.py
@@ -184,11 +184,11 @@ class TerminologyModel(BaseTerminologyModel):
         return (time.mktime(datetime.now().timetuple()) - stats.st_mtime) > THREE_DAYS
 
     def _check_for_update(self, srclang, tgtlang):
-        localfile = self._get_curr_term_filename(srclang, tgtlang)
-        localfile = os.path.join(self.TERMDIR, localfile)
+        filename = self._get_curr_term_filename(srclang, tgtlang)
+        localfile = os.path.join(self.TERMDIR, filename)
         etag = None
-        if os.path.isfile(localfile) and localfile in self.config:
-            etag = self.config[os.path.abspath(localfile)]
+        if os.path.isfile(localfile) and filename in self.config:
+            etag = self.config[filename]
 
         url = self._l10n_URL % {
             'srclang': _pontoon_locale_code(srclang),
@@ -264,7 +264,7 @@ class TerminologyModel(BaseTerminologyModel):
             etagline = [l for l in headers if l.lower().startswith(b'etag:')]
             if etagline:
                 etag = etagline[0][7:-1].decode('ascii', errors='replace')
-            self.config[os.path.abspath(localfile)] = etag
+            self.config[os.path.basename(localfile)] = etag
         else:
             logging.debug('Unhandled status code: %d' % (request.status))
             localfile = ''

--- a/virtaal/plugins/terminology/models/test_pontoon.py
+++ b/virtaal/plugins/terminology/models/test_pontoon.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2026 Zuza Software Foundation
+#
+# This file is part of Virtaal.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+
+import io
+import os
+
+import configparser
+
+from virtaal.plugins.terminology.models.pontoon import TerminologyModel
+
+
+class _FakeRequest:
+    status = 200
+
+    def __init__(self, headers=b'ETag: "abc123"\r\n'):
+        self.result_headers = io.BytesIO(headers)
+
+
+def test_process_header_config_key_is_a_bare_filename(tmp_path):
+    """self.config used to be keyed by an absolute path, which on Windows
+    always contains ":" - a char configparser rejects in a key."""
+    fake_self = TerminologyModel.__new__(TerminologyModel)
+    fake_self.config = {}
+    fake_self.matcher = None
+
+    localfile = os.path.join(str(tmp_path), 'en__am.tbx')
+    TerminologyModel._process_header(fake_self, _FakeRequest(), b'<tbx/>', localfile=localfile)
+
+    assert list(fake_self.config.keys()) == ['en__am.tbx']
+    assert os.path.isfile(localfile)
+
+    # Confirm the key actually survives a real configparser round-trip.
+    parser = configparser.ConfigParser()
+    parser.add_section('pontoon')
+    for key, value in fake_self.config.items():
+        parser.set('pontoon', key, value)
+    parser.write(io.StringIO())  # raises configparser.InvalidWriteError if broken


### PR DESCRIPTION
The ETag cache was keyed by a file's absolute path. On Windows that always contains ":", which configparser refuses to write as part of a key - crashing on every app exit once a Pontoon term file had been downloaded.

Fixed by using the bare filename instead, which is already unique per language pair. Added a test that confirms the resulting key survives a real configparser write.