### PR TITLE
Fix UnicodeEncodeError crashing the frozen build's log files

### DIFF
--- a/virtaal/common/pan_app.py
+++ b/virtaal/common/pan_app.py
@@ -47,18 +47,24 @@ def get_config_dir():
 
     return confdir
 
+def _open_frozen_log(path):
+    """Open a frozen-build log file for append.
+
+    No explicit encoding defaults to the system locale's codepage on
+    Windows (e.g. cp1252), which can't represent arbitrary translated
+    text - logging.debug() itself could then raise UnicodeEncodeError."""
+    return open(path, 'a', buffering=1, encoding='utf-8', errors='backslashreplace')
+
 # Only for the packaged (frozen/PyInstaller) build - a windowed
 # subsystem executable has no console, so this is the only way to get
 # error messages out of it.
 if os.name == 'nt' and getattr(sys, 'frozen', False):
     import time
     filename_template = os.path.join(get_config_dir(), '%s_virtaal.log')
-    # Append, not overwrite - a crash's own log was otherwise wiped the
-    # moment the app was relaunched to look at it. A separator line
-    # marks where each launch's own output starts, since a single file
-    # can now span several runs.
-    sys.stdout = open(filename_template % ('stdout'), 'a', buffering=1)
-    sys.stderr = open(filename_template % ('stderr'), 'a', buffering=1)
+    sys.stdout = _open_frozen_log(filename_template % ('stdout'))
+    sys.stderr = _open_frozen_log(filename_template % ('stderr'))
+    # A separator line marks where each launch's own output starts,
+    # since a single file can now span several runs.
     _launch_marker = '=== launch %s ===\n' % (time.strftime('%Y-%m-%d %H:%M:%S'))
     sys.stdout.write(_launch_marker)
     sys.stderr.write(_launch_marker)

--- a/virtaal/common/test_pan_app.py
+++ b/virtaal/common/test_pan_app.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2026 Zuza Software Foundation
+#
+# This file is part of Virtaal.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+
+import pytest
+
+from virtaal.common.pan_app import _open_frozen_log
+
+
+def test_open_frozen_log_survives_characters_a_locale_codepage_cant(tmp_path):
+    """Real Windows crash: the frozen build's stdout/stderr log used to
+    open with no explicit encoding, defaulting to the system locale's
+    codepage (e.g. cp1252) - logging.debug() writing a check-failure
+    message containing "≠" (U+2260) raised UnicodeEncodeError from
+    inside the logging call itself."""
+    message = "Different capitalization ≠ expected\n"
+
+    # Confirm this is a real failure mode, not a hypothetical one - the
+    # exact codepage the original crash's own traceback named.
+    with pytest.raises(UnicodeEncodeError):
+        message.encode('cp1252')
+
+    path = str(tmp_path / "test.log")
+    f = _open_frozen_log(path)
+    try:
+        f.write(message)
+    finally:
+        f.close()
+
+    with open(path, encoding='utf-8') as f:
+        assert message in f.read()


### PR DESCRIPTION
sys.stdout/stderr were redirected to log files opened with no explicit encoding, defaulting to the system locale's codepage (e.g. cp1252) on Windows. Logging a message containing a character that codepage can't represent (e.g. "≠" in a check-failure message) raised UnicodeEncodeError from inside the logging call itself.

Open the log files as UTF-8 with errors='backslashreplace' instead, so logging can't crash on its own output.