### PR TITLE
Replace scattered platform checks with a Platform class

### DIFF
--- a/virtaal/common/pan_app.py
+++ b/virtaal/common/pan_app.py
@@ -29,11 +29,12 @@
 import os
 import sys
 
+from .platform import platform
 from .utils import get_unicode
 
 
 def get_config_dir():
-    if os.name == 'nt':
+    if platform.is_windows:
         confdir = os.path.join(os.environ['APPDATA'], 'Virtaal')
     elif sys.platform == 'darwin':
         confdir = os.path.expanduser('~/Library/Application Support/Virtaal')
@@ -58,7 +59,7 @@ def _open_frozen_log(path):
 # Only for the packaged (frozen/PyInstaller) build - a windowed
 # subsystem executable has no console, so this is the only way to get
 # error messages out of it.
-if os.name == 'nt' and getattr(sys, 'frozen', False):
+if platform.is_windows and getattr(sys, 'frozen', False):
     import time
     filename_template = os.path.join(get_config_dir(), '%s_virtaal.log')
     sys.stdout = _open_frozen_log(filename_template % ('stdout'))
@@ -332,7 +333,7 @@ else:
     main_dir = os.path.dirname(get_unicode(sys.argv[0]))
 
 
-if os.name =='nt' and getattr(sys, 'frozen', False):
+if platform.is_windows and getattr(sys, 'frozen', False):
     fix_libintl(main_dir)
 
 if _(''):

--- a/virtaal/common/pan_app.py
+++ b/virtaal/common/pan_app.py
@@ -36,7 +36,7 @@ from .utils import get_unicode
 def get_config_dir():
     if platform.is_windows:
         confdir = os.path.join(os.environ['APPDATA'], 'Virtaal')
-    elif sys.platform == 'darwin':
+    elif platform.is_mac:
         confdir = os.path.expanduser('~/Library/Application Support/Virtaal')
     else:
         #TODO: skuif na ~/.config/virtaal en migreer
@@ -105,7 +105,7 @@ def get_locale_lang():
     # guess default target lang based on locale, simplify to commonly used form
     try:
         lang = locale.getdefaultlocale(('LANGUAGE', 'LC_ALL', 'LANG'))[0]
-        if not lang and sys.platform == "darwin":
+        if not lang and platform.is_mac:
            lang = osx_lang()
         if lang:
             return data.simplify_to_common(lang)
@@ -318,7 +318,7 @@ def set_ui_language(lang):
         pass
     localedir = os.path.join(sys.prefix, 'share', 'locale')
     gettext.translation('virtaal', localedir=localedir, languages=[lang], fallback=False).install()
-    if sys.platform != 'win32':
+    if not platform.is_windows:
         # Gtk.Builder's own translatable strings go through C-level
         # gettext, not Python's - see bind_libintl_posix's docstring.
         bind_libintl_posix(localedir)

--- a/virtaal/common/pan_app.py
+++ b/virtaal/common/pan_app.py
@@ -59,7 +59,7 @@ def _open_frozen_log(path):
 # Only for the packaged (frozen/PyInstaller) build - a windowed
 # subsystem executable has no console, so this is the only way to get
 # error messages out of it.
-if platform.is_windows and getattr(sys, 'frozen', False):
+if platform.is_windows and platform.is_frozen:
     import time
     filename_template = os.path.join(get_config_dir(), '%s_virtaal.log')
     sys.stdout = _open_frozen_log(filename_template % ('stdout'))
@@ -327,13 +327,13 @@ def set_ui_language(lang):
 
 # Determine the directory the main executable is running from
 main_dir = u''
-if getattr(sys, 'frozen', False):
+if platform.is_frozen:
     main_dir = os.path.dirname(get_unicode(sys.executable))
 else:
     main_dir = os.path.dirname(get_unicode(sys.argv[0]))
 
 
-if platform.is_windows and getattr(sys, 'frozen', False):
+if platform.is_windows and platform.is_frozen:
     fix_libintl(main_dir)
 
 if _(''):

--- a/virtaal/common/pan_app.py
+++ b/virtaal/common/pan_app.py
@@ -97,11 +97,6 @@ def osx_lang():
     return CoreFoundation.CFLocaleCopyPreferredLanguages()[0]
 
 def get_locale_lang():
-    #if we wanted to determine the UI language ourselves, this should work:
-    #lang = locale.getdefaultlocale(('LANGUAGE', 'LC_ALL', 'LC_MESSAGES', 'LANG'))[0]
-    #if not lang and sys.platform == "darwin":
-    #   lang = osx_lang()
-
     # guess default target lang based on locale, simplify to commonly used form
     try:
         lang = locale.getdefaultlocale(('LANGUAGE', 'LC_ALL', 'LANG'))[0]

--- a/virtaal/common/platform.py
+++ b/virtaal/common/platform.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2026 Zuza Software Foundation
+#
+# This file is part of Virtaal.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+
+"""A single, testable place to ask "which platform is this?".
+
+Replaces the scattered ``os.name == 'nt'`` / ``sys.platform ==
+'darwin'`` / ``getattr(sys, 'frozen', False)`` checks across the
+codebase with one small class. The constructor accepts overrides for
+exactly this reason: reading ``os.name``/``sys.platform`` at call time
+is untestable on CI, which only ever runs as one real OS, so tests
+inject a platform instead of monkeypatching global state:
+
+    windows = Platform(os_name='nt', sys_platform='win32')
+    assert windows.is_windows and not windows.is_mac
+"""
+
+import os
+import sys
+
+
+class Platform:
+    def __init__(self, os_name=None, sys_platform=None, frozen=None, environ=None):
+        self.is_windows = (os_name if os_name is not None else os.name) == 'nt'
+        self.is_mac = (sys_platform if sys_platform is not None else sys.platform) == 'darwin'
+        self.is_linux = not self.is_windows and not self.is_mac
+        self.is_frozen = bool(frozen if frozen is not None else getattr(sys, 'frozen', False))
+
+
+platform = Platform()

--- a/virtaal/common/test_platform.py
+++ b/virtaal/common/test_platform.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2026 Zuza Software Foundation
+#
+# This file is part of Virtaal.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+
+import os
+import sys
+
+from virtaal.common.platform import Platform
+
+
+def test_windows():
+    p = Platform(os_name='nt', sys_platform='win32')
+    assert p.is_windows
+    assert not p.is_mac
+    assert not p.is_linux
+
+
+def test_mac():
+    p = Platform(os_name='posix', sys_platform='darwin')
+    assert not p.is_windows
+    assert p.is_mac
+    assert not p.is_linux
+
+
+def test_linux():
+    p = Platform(os_name='posix', sys_platform='linux')
+    assert not p.is_windows
+    assert not p.is_mac
+    assert p.is_linux
+
+
+def test_frozen_is_independent_of_os():
+    """is_frozen deliberately doesn't fold in is_windows - a frozen
+    build exists on any platform and call sites combine the two flags
+    themselves where that matters."""
+    p = Platform(os_name='posix', sys_platform='darwin', frozen=True)
+    assert p.is_mac
+    assert p.is_frozen
+
+    p = Platform(os_name='posix', sys_platform='darwin', frozen=False)
+    assert not p.is_frozen
+
+
+def test_defaults_fall_back_to_real_os_and_sys():
+    p = Platform()
+    assert p.is_windows == (os.name == 'nt')
+    assert p.is_mac == (sys.platform == 'darwin')
+    assert p.is_frozen == bool(getattr(sys, 'frozen', False))

--- a/virtaal/controllers/maincontroller.py
+++ b/virtaal/controllers/maincontroller.py
@@ -19,8 +19,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-import os
-
 import gi
 
 gi.require_version('Gtk', '3.0')
@@ -28,6 +26,7 @@ from gi.repository import Gtk, GObject
 
 from .basecontroller import BaseController
 from virtaal.common import GObjectWrapper, pan_app
+from virtaal.common.platform import platform
 from virtaal.models.storemodel import SaveCancelled
 from virtaal.views.mainview import MainView
 
@@ -197,7 +196,7 @@ class MainController(BaseController):
             # Unnecessary to test for 'discard'
 
         if filename.startswith('file://'):
-            if os.name == "nt":
+            if platform.is_windows:
                 filename = filename[len('file:///'):]
             else:
                 filename = filename[len('file://'):]

--- a/virtaal/controllers/plugincontroller.py
+++ b/virtaal/controllers/plugincontroller.py
@@ -227,7 +227,7 @@ class PluginController(BaseController):
                     continue
                 # Don't show dev-only plugins (_helloworld, _python_console,
                 # ...) on frozen builds, regardless of DEBUG's value here.
-                if getattr(sys, 'frozen', False) and name[0] == u'_':
+                if platform.is_frozen and name[0] == u'_':
                     continue
                 if pan_app.DEBUG or name[0] != u'_':
                     plugin_names.append(name)

--- a/virtaal/controllers/plugincontroller.py
+++ b/virtaal/controllers/plugincontroller.py
@@ -26,11 +26,12 @@ from gi.repository import GLib, GObject
 from gi.repository.GObject import TYPE_PYOBJECT
 
 from virtaal.common import pan_app, GObjectWrapper
+from virtaal.common.platform import platform
 from virtaal.common.utils import get_unicode
 from .basecontroller import BaseController
 from .baseplugin import PluginUnsupported, BasePlugin
 
-if os.name == 'nt':
+if platform.is_windows:
     sys.path.insert(0, pan_app.main_dir)
 if 'RESOURCEPATH' in os.environ:
     sys.path.insert(0, os.path.join(os.environ['RESOURCEPATH']))
@@ -81,7 +82,7 @@ class PluginController(BaseController):
         self.plugins       = {}
         self.pluginmodules = {}
 
-        if os.name == 'nt':
+        if platform.is_windows:
             self.PLUGIN_DIRS.insert(0, os.path.join(pan_app.main_dir, u'virtaal_plugins'))
         if 'RESOURCEPATH' in os.environ:
             self.PLUGIN_DIRS.insert(0, os.path.join(os.environ['RESOURCEPATH'].decode(sys.getfilesystemencoding()), u'virtaal_plugins'))

--- a/virtaal/main.py
+++ b/virtaal/main.py
@@ -26,9 +26,9 @@
 # after the GUI is already showing.
 
 
-import sys
-
 from gi.repository import GLib
+
+from virtaal.common.platform import platform
 
 
 class _Deferer:
@@ -161,7 +161,7 @@ class Virtaal(object):
         # Only bundled builds (macOS .app, Windows installer) can't
         # already control their own updates the way a checkout/pip
         # install can.
-        if getattr(sys, 'frozen', False):
+        if platform.is_frozen:
             defer(self._check_for_update)
 
     def _check_for_update(self):

--- a/virtaal/plugins/migration.py
+++ b/virtaal/plugins/migration.py
@@ -27,7 +27,6 @@ import both relied on the Python 2-only bsddb module and were removed.)
 
 import logging
 import os
-import sys
 from os import path
 
 from io import StringIO
@@ -39,6 +38,7 @@ except ImportError:
     from pysqlite2 import dbapi2
 
 from virtaal.common import pan_app
+from virtaal.common.platform import platform
 from virtaal.controllers.baseplugin import BasePlugin
 
 from virtaal.support import tmdb
@@ -61,7 +61,7 @@ class Plugin(BasePlugin):
 
     def _init_plugin(self):
         # Source paths need to be set up before the evidence check below.
-        if sys.platform == "darwin":
+        if platform.is_mac:
             self.poedit_dir = path.expanduser('~/Library/Preferences')
         else:
             self.poedit_dir = path.expanduser('~/.poedit')
@@ -126,13 +126,13 @@ class Plugin(BasePlugin):
         return False
 
     def _poedit_config_exists(self):
-        if sys.platform == 'darwin':
+        if platform.is_mac:
             config_filename = path.join(self.poedit_dir, 'net.poedit.Poedit.cfg')
         else:
             config_filename = path.join(self.poedit_dir, 'config')
         if path.exists(config_filename):
             return True
-        if sys.platform != 'win32':
+        if not platform.is_windows:
             return False
         try:
             import winreg
@@ -146,7 +146,7 @@ class Plugin(BasePlugin):
 
     def poedit_settings_import(self):
         """Attempt to import the settings from Poedit."""
-        if sys.platform == 'darwin':
+        if platform.is_mac:
             config_filename = path.join(self.poedit_dir, 'net.poedit.Poedit.cfg')
         else:
             config_filename = path.join(self.poedit_dir, 'config')

--- a/virtaal/plugins/spellchecker.py
+++ b/virtaal/plugins/spellchecker.py
@@ -22,7 +22,6 @@ import logging
 import os
 import os.path
 import re
-import sys
 from gettext import dgettext
 
 from gi.repository import GLib
@@ -224,7 +223,7 @@ class Plugin(BasePlugin):
                 return
             if platform.is_windows:
                 DICTDIR = os.path.join(os.environ['APPDATA'], 'enchant', 'myspell')
-            elif sys.platform == 'darwin':
+            elif platform.is_mac:
                 DICTDIR = os.path.expanduser("~/.enchant/myspell")
             self._ensure_dir(DICTDIR)
             tar.extractall(DICTDIR)
@@ -281,7 +280,7 @@ class Plugin(BasePlugin):
                 #logging.debug('No code in enchant.list_languages() that starts with "%s"' % (language))
 
                 # If we are on Windows or Mac, let's try to download a spell checker:
-                if platform.is_windows or sys.platform == 'darwin':
+                if platform.is_windows or platform.is_mac:
                     self._download_checker(language)
                     # If we get it, it will only be activated asynchronously
                     # later

--- a/virtaal/plugins/spellchecker.py
+++ b/virtaal/plugins/spellchecker.py
@@ -27,6 +27,7 @@ from gettext import dgettext
 
 from gi.repository import GLib
 
+from virtaal.common.platform import platform
 from virtaal.controllers.baseplugin import PluginUnsupported, BasePlugin
 
 
@@ -50,7 +51,7 @@ class Plugin(BasePlugin):
     def __init__(self, internal_name, main_controller):
         self.internal_name = internal_name
 
-        if os.name == 'nt':
+        if platform.is_windows:
             DICTDIR = os.path.join(os.environ['APPDATA'], 'enchant', 'myspell')
             # DICTDIR is already str (unicode text) under Python 3, so there's
             # nothing to decode - .decode() doesn't exist on str at all and
@@ -144,7 +145,7 @@ class Plugin(BasePlugin):
 
     def _download_checker(self, language):
         """A Windows-and Mac only way to obtain new dictionaries."""
-        if os.name == 'nt' and 'APPDATA' not in os.environ:
+        if platform.is_windows and 'APPDATA' not in os.environ:
             # We won't have an idea of where to save it, so let's give up now
             return
         if language in self.clients:
@@ -221,7 +222,7 @@ class Plugin(BasePlugin):
             tar = tarfile.open(fileobj=file_obj)
             if not self._tar_ok(tar):
                 return
-            if os.name == 'nt':
+            if platform.is_windows:
                 DICTDIR = os.path.join(os.environ['APPDATA'], 'enchant', 'myspell')
             elif sys.platform == 'darwin':
                 DICTDIR = os.path.expanduser("~/.enchant/myspell")
@@ -280,7 +281,7 @@ class Plugin(BasePlugin):
                 #logging.debug('No code in enchant.list_languages() that starts with "%s"' % (language))
 
                 # If we are on Windows or Mac, let's try to download a spell checker:
-                if os.name == 'nt' or sys.platform == 'darwin':
+                if platform.is_windows or sys.platform == 'darwin':
                     self._download_checker(language)
                     # If we get it, it will only be activated asynchronously
                     # later

--- a/virtaal/plugins/tm/models/localtm.py
+++ b/virtaal/plugins/tm/models/localtm.py
@@ -24,6 +24,7 @@ import socket
 import sys
 
 from virtaal.common import pan_app
+from virtaal.common.platform import platform
 from . import remotetm
 from .basetmmodel import BaseTMModel
 
@@ -119,7 +120,7 @@ class TMModel(remotetm.TMModel):
         ))
 
     def destroy(self):
-        if os.name == "nt":
+        if platform.is_windows:
             import ctypes
             ctypes.windll.kernel32.TerminateProcess(int(self.tmserver._handle), -1)
             logging.debug("killing tmserver with handle %d" % int(self.tmserver._handle))

--- a/virtaal/plugins/tm/models/localtm.py
+++ b/virtaal/plugins/tm/models/localtm.py
@@ -69,7 +69,7 @@ class TMModel(remotetm.TMModel):
         # virtaal handles a "--run-module <name>" sentinel for exactly this
         # case (dispatches via runpy, same as -m would), gated the same
         # way this branches.
-        if getattr(sys, "frozen", False):
+        if platform.is_frozen:
             command = [sys.executable, "--run-module", "virtaal.support.tmserver"]
         else:
             command = [sys.executable, "-m", "virtaal.support.tmserver"]
@@ -90,7 +90,7 @@ class TMModel(remotetm.TMModel):
             from virtaal.support import tmclient
 
             env = os.environ.copy()
-            if not getattr(sys, "frozen", False):
+            if not platform.is_frozen:
                 # Make sure the subprocess can "import virtaal.support.tmserver"
                 # regardless of how *this* process ended up able to (an
                 # explicit PYTHONPATH from a source checkout, an editable

--- a/virtaal/support/libi18n/locale.py
+++ b/virtaal/support/libi18n/locale.py
@@ -23,6 +23,8 @@
 import os
 import sys
 
+from virtaal.common.platform import platform
+
 
 def _isofromlangid(langid):
     # ISO 639-1
@@ -323,7 +325,7 @@ def fix_locale(lang=None):
     """This fixes some strange issues to ensure locale and gettext works
     correctly, also within glade, even with a non-default locale passed as
     parameter."""
-    if sys.platform == 'win32':
+    if platform.is_windows:
         lang = lang or _getlang()
 
         _putenv('LANGUAGE', lang)

--- a/virtaal/support/openmailto.py
+++ b/virtaal/support/openmailto.py
@@ -35,6 +35,8 @@ import os
 import sys
 import logging
 
+from virtaal.common.platform import platform
+
 
 # Some imports are only necessary on some platforms, and are postponed to try
 # to speed up startup
@@ -63,7 +65,7 @@ class Controller(BaseController):
 
     def _invoke(self, cmdline):
         import subprocess
-        if sys.platform[:3] == 'win':
+        if platform.is_windows:
             closefds = False
             startupinfo = subprocess.STARTUPINFO()
             startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
@@ -71,8 +73,8 @@ class Controller(BaseController):
             closefds = True
             startupinfo = None
 
-        if (os.environ.get('DISPLAY') or sys.platform[:3] == 'win' or
-                                                    sys.platform == 'darwin'):
+        if (os.environ.get('DISPLAY') or platform.is_windows or
+                                                    platform.is_mac):
             inout = subprocess.DEVNULL
         else:
             # for TTY programs, we need stdin/out
@@ -108,7 +110,7 @@ class Controller(BaseController):
 
 
 # Platform support for Windows
-if sys.platform[:3] == 'win':
+if platform.is_windows:
 
     class Start(BaseController):
         '''Controller for the win32 start progam through os.startfile.'''
@@ -128,7 +130,7 @@ if sys.platform[:3] == 'win':
 
 
 # Platform support for MacOS
-elif sys.platform == 'darwin':
+elif platform.is_mac:
     _controllers['open']= Controller('open')
     _open = _controllers['open'].open
 

--- a/virtaal/support/statsdb.py
+++ b/virtaal/support/statsdb.py
@@ -49,6 +49,8 @@ from translate.misc.multistring import multistring
 from translate.storage import factory
 from translate.storage.workflow import StateEnum
 
+from virtaal.common.platform import platform
+
 
 logger = logging.getLogger(__name__)
 
@@ -340,7 +342,7 @@ class StatsCache(object):
             if not cls.defaultfile:
                 userdir = os.path.expanduser("~")
                 cachedir = None
-                if os.name == "nt":
+                if platform.is_windows:
                     cachedir = os.path.join(userdir, "Translate Toolkit")
                 else:
                     cachedir = os.path.join(userdir, ".translate_toolkit")

--- a/virtaal/support/translate_compat.py
+++ b/virtaal/support/translate_compat.py
@@ -38,13 +38,14 @@ vendoring note above for exactly where these came from and why).
 
 import gettext
 import locale
-import os
 import re
 
 try:
     import pycountry
 except ImportError:
     pycountry = None
+
+from virtaal.common.platform import platform
 
 
 _fixed_names = {
@@ -132,7 +133,7 @@ def gettext_domain(langcode, domain, localedir=None):
         fallback=True)
     if langcode:
         kwargs['languages'] = [langcode]
-    elif os.name == "nt":
+    elif platform.is_windows:
         # On Windows the default locale is not used for some reason
         kwargs['languages'] = [locale.getdefaultlocale()[0]]
     t = gettext.translation(**kwargs)

--- a/virtaal/views/langview.py
+++ b/virtaal/views/langview.py
@@ -20,12 +20,12 @@
 
 import locale
 import logging
-import os
 
 from gi.repository import GLib
 from gi.repository import Gdk
 from gi.repository import Gtk
 
+from virtaal.common.platform import platform
 from virtaal.models.langmodel import LanguageModel
 from .baseview import BaseView
 from .widgets.popupmenubutton import PopupMenuButton
@@ -89,7 +89,7 @@ class LanguageView(BaseView):
         # While it seems that the arrows are not well supported on Windows
         # systems, we fall back to using the French quotes. It automatically
         # does the right thing for RTL.
-        if os.name == 'nt':
+        if platform.is_windows:
             pairlabel = u'%s » %s' % (srclang.name, tgtlang.name)
         return pairlabel
 

--- a/virtaal/views/mainview.py
+++ b/virtaal/views/mainview.py
@@ -22,7 +22,6 @@ import locale
 import logging
 import os
 import subprocess
-import sys
 
 from gi.repository import Gdk
 from gi.repository import Gtk
@@ -120,7 +119,7 @@ class MainView(BaseView):
         self.btn_app = None
         self.app_menu = None
 
-        if sys.platform == 'darwin':
+        if platform.is_mac:
             # Follow the system light/dark appearance - GTK3 themes (Adwaita
             # included) already derive their colours from this setting.
             try:
@@ -168,7 +167,7 @@ class MainView(BaseView):
                 import logging
                 logging.debug("GtkosxApplication not found (brew install gtk-mac-integration for native macOS menu-bar integration). Expect zero integration with the Mac desktop.")
 
-        elif sys.platform == 'win32':
+        elif platform.is_windows:
             # AppsUseLightTheme: 0 means dark, 1 (or absent) means light.
             try:
                 import winreg
@@ -392,7 +391,7 @@ class MainView(BaseView):
         self.main_window.connect("drag-data-received", self._on_drag_data_received)
 
     def _on_drag_data_received(self, w, context, x, y, data, info, time):
-        if sys.platform == 'darwin' or Gtk.targets_include_uri(context.list_targets()):
+        if platform.is_mac or Gtk.targets_include_uri(context.list_targets()):
             # We don't check for valid targets on Mac (darwin) since there is
             # a bug in target_incude_uri on that platform, no adverse situations
             # seem to arise but we leave other platforms to do the right thing.

--- a/virtaal/views/mainview.py
+++ b/virtaal/views/mainview.py
@@ -28,6 +28,7 @@ from gi.repository import Gdk
 from gi.repository import Gtk
 
 from virtaal.common import pan_app
+from virtaal.common.platform import platform
 from virtaal.common.utils import get_unicode
 from virtaal.views import theme
 from .baseview import BaseView
@@ -93,7 +94,7 @@ class MainView(BaseView):
         self.controller = controller
         self.modified = False
 
-        if os.name == 'nt':
+        if platform.is_windows:
             # Make sure that rule-hints are shown in Windows
             rc_string = """
                 style "show-rules"
@@ -411,7 +412,7 @@ class MainView(BaseView):
     def _on_style_set(self, widget, prev_style=None):
         theme.update_style(widget)
         # on windows the tooltip colour is wrong in inverse themes (bug 1923)
-        if os.name == 'nt':
+        if platform.is_windows:
             if theme.INVERSE:
                 tooltip_text = "white"
             else:
@@ -884,7 +885,7 @@ class MainView(BaseView):
             if getattr(self, '_uri', None):
                 recent.rm.add_item(self._uri)
             else:
-                if os.name == 'nt':
+                if platform.is_windows:
                     url = 'file:///' + os.path.abspath(store_controller.store.filename)
                 else:
                     url = 'file://' + os.path.abspath(store_controller.store.filename)


### PR DESCRIPTION
Platform checks are scattered and inconsistent.

- Add a `Platform` class.
- Replace `os.name == 'nt'` with `platform.is_windows`.
- Replace `sys.platform` checks with `platform.is_mac`/`is_windows`.
- Replace `getattr(sys, 'frozen', False)` with `platform.is_frozen`.

Pure substitution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)