### PR TITLE
Stamp version + build commit into output logs

### DIFF
--- a/bin/virtaal
+++ b/bin/virtaal
@@ -156,6 +156,8 @@ def main(argv):
                 except IOError:
                     parser.error(_("Could not open log file '%(filename)s'") % {"filename": options.log})
 
+            logging.info("Virtaal %s", __version__.version_string())
+
 
         def set_config(options):
             try:

--- a/bin/virtaal
+++ b/bin/virtaal
@@ -107,16 +107,11 @@ def main(argv):
         # - without this, its generated chrome stays untranslated.
         argparse._ = _
         parser = argparse.ArgumentParser()
-        # See virtaal.__version__.build_commit's own docstring. Short
-        # (7-char) since a human's the one reading this, matching
-        # `git rev-parse --short`. Note for a packaged Windows build:
-        # pan_app's stdout/stderr redirection runs at import time,
-        # before this ever executes, so this text lands in
-        # %APPDATA%\Virtaal\stdout_virtaal.log, not a caller's console.
-        version_string = __version__.ver
-        if __version__.build_commit:
-            version_string += " (%s)" % __version__.build_commit[:7]
-        parser.add_argument("-v", "--version", action="version", version=version_string)
+        # Note for a packaged Windows build: pan_app's stdout/stderr
+        # redirection runs at import time, before this ever executes,
+        # so this text lands in %APPDATA%\Virtaal\stdout_virtaal.log,
+        # not a caller's console.
+        parser.add_argument("-v", "--version", action="version", version=__version__.version_string())
         parser.add_argument("-l", "--log", dest="log", metavar=_("LOG"),
                              help=_("turn on logging, storing the result to the supplied filename."))
         parser.add_argument("-c", "--config", dest="config", metavar=_("CONFIG"),

--- a/devsupport/testing/windows/virtaal_ui_test_helpers.ps1
+++ b/devsupport/testing/windows/virtaal_ui_test_helpers.ps1
@@ -458,7 +458,7 @@ function Assert-VirtaalLogsClean {
     past that is real unexpected output.
     #>
     param([string[]]$AllowlistPatterns = @(), [switch]$AllowDebugLog)
-    $AllowlistPatterns = $AllowlistPatterns + '^=== launch \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} ===$'
+    $AllowlistPatterns = $AllowlistPatterns + '^=== launch \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} \| Virtaal .+ ===$'
     if ($script:VirtaalAppDebugLog -or $AllowDebugLog) {
         # bin\virtaal's -D/--debug format is '%(levelname)7s
         # %(module)s...' - levelname right-justified to 7 chars, so

--- a/virtaal/__version__.py
+++ b/virtaal/__version__.py
@@ -57,3 +57,10 @@ def _get_build_commit():
 
 
 build_commit = _get_build_commit()
+
+
+def version_string():
+    """`ver`, with the short build commit appended when known, e.g.
+    "1.0.0-beta1 (5bb637f)" - falls back to "(unknown)" rather than a
+    literal "None" when build_commit isn't available."""
+    return "%s (%s)" % (ver, build_commit[:7] if build_commit else "unknown")

--- a/virtaal/common/pan_app.py
+++ b/virtaal/common/pan_app.py
@@ -29,6 +29,7 @@
 import os
 import sys
 
+from virtaal.__version__ import version_string
 from .platform import platform
 from .utils import get_unicode
 
@@ -56,6 +57,12 @@ def _open_frozen_log(path):
     text - logging.debug() itself could then raise UnicodeEncodeError."""
     return open(path, 'a', buffering=1, encoding='utf-8', errors='backslashreplace')
 
+def _build_launch_marker(timestamp):
+    """The separator line written to a frozen build's log at each
+    launch - a single file can span several runs, so this both marks
+    where one starts and identifies which build produced it."""
+    return '=== launch %s | Virtaal %s ===\n' % (timestamp, version_string())
+
 # Only for the packaged (frozen/PyInstaller) build - a windowed
 # subsystem executable has no console, so this is the only way to get
 # error messages out of it.
@@ -64,9 +71,7 @@ if platform.is_windows and platform.is_frozen:
     filename_template = os.path.join(get_config_dir(), '%s_virtaal.log')
     sys.stdout = _open_frozen_log(filename_template % ('stdout'))
     sys.stderr = _open_frozen_log(filename_template % ('stderr'))
-    # A separator line marks where each launch's own output starts,
-    # since a single file can now span several runs.
-    _launch_marker = '=== launch %s ===\n' % (time.strftime('%Y-%m-%d %H:%M:%S'))
+    _launch_marker = _build_launch_marker(time.strftime('%Y-%m-%d %H:%M:%S'))
     sys.stdout.write(_launch_marker)
     sys.stderr.write(_launch_marker)
 

--- a/virtaal/common/test_pan_app.py
+++ b/virtaal/common/test_pan_app.py
@@ -20,7 +20,14 @@
 
 import pytest
 
-from virtaal.common.pan_app import _open_frozen_log
+from virtaal.common import pan_app
+from virtaal.common.pan_app import _build_launch_marker, _open_frozen_log
+
+
+def test_build_launch_marker_includes_version(monkeypatch):
+    monkeypatch.setattr(pan_app, 'version_string', lambda: '1.0.0-beta1 (5bb637f)')
+    marker = _build_launch_marker('2026-09-07 22:00:00')
+    assert marker == '=== launch 2026-09-07 22:00:00 | Virtaal 1.0.0-beta1 (5bb637f) ===\n'
 
 
 def test_open_frozen_log_survives_characters_a_locale_codepage_cant(tmp_path):

--- a/virtaal/test_version.py
+++ b/virtaal/test_version.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2026 Zuza Software Foundation
+#
+# This file is part of Virtaal.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+
+from virtaal import __version__
+
+
+def test_version_string_includes_short_commit(monkeypatch):
+    monkeypatch.setattr(__version__, 'ver', '1.0.0-beta1')
+    monkeypatch.setattr(__version__, 'build_commit', '5bb637f1234567890')
+    assert __version__.version_string() == '1.0.0-beta1 (5bb637f)'
+
+
+def test_version_string_falls_back_when_commit_unknown(monkeypatch):
+    monkeypatch.setattr(__version__, 'ver', '1.0.0-beta1')
+    monkeypatch.setattr(__version__, 'build_commit', None)
+    assert __version__.version_string() == '1.0.0-beta1 (unknown)'


### PR DESCRIPTION
- Add \`version_string()\` to \`__version__.py\`, and switch \`bin/virtaal --version\` to it.
- Stamp it into the frozen build's log launch marker and into \`bin/virtaal --debug\`/\`--log\`'s startup line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)