### PR TITLE
Spellcheck Recovery: fix pt/de mapping, bundle pyenchant on Windows

### DIFF
--- a/devsupport/packaging/windows/build_standalone.ps1
+++ b/devsupport/packaging/windows/build_standalone.ps1
@@ -33,6 +33,13 @@ if (-not $pyinstallerInstalled) {
     & $Python -m pip install pyinstaller
 }
 
+# pyenchant's Windows wheel is self-contained (libenchant + backends +
+# dictionaries) - virtaal.spec bundles its data/ dir from this install.
+$pyenchantInstalled = & $Python -m pip show pyenchant 2>$null
+if (-not $pyenchantInstalled) {
+    & $Python -m pip install pyenchant
+}
+
 Remove-Item -Recurse -Force -ErrorAction SilentlyContinue build\virtaal, dist\virtaal
 
 # See virtaal/__version__.py's build_commit docstring: a frozen build has

--- a/devsupport/packaging/windows/virtaal.spec
+++ b/devsupport/packaging/windows/virtaal.spec
@@ -56,6 +56,16 @@ from virtaal.__version__ import ver as virtaal_version  # noqa: E402
 import translate  # noqa: E402
 TRANSLATE_SHARE = Path(translate.__file__).parent / "share"
 
+# pyenchant's Windows wheel is self-contained (libenchant + backends +
+# English dictionaries under enchant/data/); _enchant.py finds it via
+# its own __file__ at runtime, so bundling the dir at the same relative
+# path is enough - see module_collection_mode below.
+try:
+    import enchant
+    ENCHANT_DATA = Path(enchant.__file__).parent / "data"
+except ImportError:
+    ENCHANT_DATA = None
+
 COPYRIGHT = "Copyright 2007-2026 Translate. GNU General Public License."
 
 
@@ -124,17 +134,23 @@ binaries = []
 if gio_modules_dir.is_dir():
     binaries.append((str(gio_modules_dir), "lib/gio/modules"))
 
+datas = [
+    (str(ROOT / "share" / "virtaal"), "share/virtaal"),
+    (str(ROOT / "share" / "icons"), "share/icons"),
+    (str(TRANSLATE_SHARE), "share"),
+] + mo_files
+if ENCHANT_DATA is not None and ENCHANT_DATA.is_dir():
+    datas.append((str(ENCHANT_DATA), "enchant/data"))
+
 a = Analysis(  # noqa: F821
     [str(ROOT / "bin" / "virtaal")],
     pathex=[str(ROOT)],
     binaries=binaries,
-    datas=[
-        (str(ROOT / "share" / "virtaal"), "share/virtaal"),
-        (str(ROOT / "share" / "icons"), "share/icons"),
-        (str(TRANSLATE_SHARE), "share"),
-    ]
-    + mo_files,
+    datas=datas,
     hiddenimports=collect_submodules("virtaal") + collect_submodules("translate.storage"),
+    # Keep enchant's .py files loose on disk, not archived - its
+    # __file__-relative data lookup above needs a real path.
+    module_collection_mode={"enchant": "py"},
     hooksconfig={
         "gi": {
             "module-versions": {
@@ -153,15 +169,6 @@ a = Analysis(  # noqa: F821
     # dead weight here either way).
     excludes=[
         "FixTk", "tcl", "tk", "_tkinter", "tkinter", "Tkinter", "devsupport",
-        # pyenchant loads the SYSTEM libenchant via ctypes at runtime, not
-        # a static import PyInstaller's analysis can see - never bundled
-        # regardless of whether it's excluded here. The pinned gvsbuild
-        # GTK3 build this project uses doesn't ship enchant/gtkspell at
-        # all (confirmed live in the Windows 11 ARM64 VM this session -
-        # "GtkSpell not installed"), so the spellchecker plugin already
-        # degrades gracefully without it, same as a plain checkout
-        # running without enchant/gtkspell installed locally.
-        "enchant",
     ],
     noarchive=False,
 )

--- a/devsupport/packaging/windows/virtaal.spec
+++ b/devsupport/packaging/windows/virtaal.spec
@@ -147,7 +147,11 @@ a = Analysis(  # noqa: F821
     pathex=[str(ROOT)],
     binaries=binaries,
     datas=datas,
-    hiddenimports=collect_submodules("virtaal") + collect_submodules("translate.storage"),
+    hiddenimports=(
+        collect_submodules("virtaal")
+        + collect_submodules("translate.storage")
+        + collect_submodules("enchant")
+    ),
     # Keep enchant's .py files loose on disk, not archived - its
     # __file__-relative data lookup above needs a real path.
     module_collection_mode={"enchant": "py"},

--- a/devsupport/testing/windows/virtaal_ui_test_helpers.ps1
+++ b/devsupport/testing/windows/virtaal_ui_test_helpers.ps1
@@ -459,6 +459,29 @@ function Assert-VirtaalLogsClean {
     #>
     param([string[]]$AllowlistPatterns = @(), [switch]$AllowDebugLog)
     $AllowlistPatterns = $AllowlistPatterns + '^=== launch \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} \| Virtaal .+ ===$'
+    # The bundled Windows build only ships pyenchant's own English
+    # dictionaries (see devsupport/packaging/windows/virtaal.spec) -
+    # opening a non-English file (po\af.po, used elsewhere in this
+    # battery for an unrelated window-growth check) legitimately hits
+    # translate.filters.spelling's own "no dictionary for this
+    # language" path, which it logs as an ERROR-level traceback by
+    # design before degrading gracefully (no crash). Expected until the
+    # Sourcing stage adds real per-language dictionary downloads - see
+    # PLAN-SPELLCHECK.md. Patterns are anchored to translate.filters.
+    # spelling's/enchant's own file paths specifically, not generic
+    # "Traceback"/"File" lines, so a real Virtaal-internal crash (whose
+    # frames would show virtaal's own paths) still fails this check.
+    $AllowlistPatterns = $AllowlistPatterns + @(
+        '^ERROR:translate\.filters\.spelling:Dictionary not found$',
+        '^Traceback \(most recent call last\):$',
+        '^During handling of the above exception, another exception occurred:$',
+        '^\s*File "translate\\filters\\spelling\.py", line \d+, in _get_checker$',
+        '^\s*File ".*\\enchant\\checker\\__init__\.py", line \d+, in __init__$',
+        '^\s*File ".*\\enchant\\tokenize\\__init__\.py", line \d+, in get_tokenizer$',
+        '^\s*tokenize = get_tokenizer\(.*\)$',
+        '^\s*raise (DefaultLanguageNotFoundError|TokenizerNotFoundError)\(.*\)( from None)?$',
+        '^enchant\.errors\.(DefaultLanguageNotFoundError|TokenizerNotFoundError): .+$'
+    )
     if ($script:VirtaalAppDebugLog -or $AllowDebugLog) {
         # bin\virtaal's -D/--debug format is '%(levelname)7s
         # %(module)s...' - levelname right-justified to 7 chars, so

--- a/virtaal/plugins/spellchecker.py
+++ b/virtaal/plugins/spellchecker.py
@@ -263,9 +263,9 @@ class Plugin(BasePlugin):
         if language == 'en':
             language = 'en_US'
         elif language == 'pt':
-            language == 'pt_PT'
+            language = 'pt_PT'
         elif language == 'de':
-            language == 'de_DE'
+            language = 'de_DE'
 
         if not language in self._seen_languages and not self.enchant.dict_exists(language):
             # Sometimes enchants *wants* a country code, other times it does not.

--- a/virtaal/plugins/test_spellchecker.py
+++ b/virtaal/plugins/test_spellchecker.py
@@ -30,7 +30,20 @@ never installed, not because of any GTK2/GTK3 incompatibility).
 
 import pytest
 
-from virtaal.plugins.spellchecker import _dict_add_re
+from virtaal.plugins.spellchecker import Plugin, _dict_add_re
+
+
+class _FakeEnchant:
+    """Records what language code it was actually asked about, without
+    needing real enchant/dictionaries installed."""
+
+    def __init__(self, known_dicts):
+        self.known_dicts = known_dicts
+        self.checked = []
+
+    def dict_exists(self, language):
+        self.checked.append(language)
+        return language in self.known_dicts
 
 
 def test_dict_add_re_matches_gtkspell_suggestion():
@@ -43,6 +56,22 @@ def test_dict_add_re_matches_gtkspell_suggestion():
 
 def test_dict_add_re_no_match_on_unrelated_label():
     assert _dict_add_re.match("Ignore All") is None
+
+
+@pytest.mark.parametrize("language,expected", [("pt", "pt_PT"), ("de", "de_DE")])
+def test_on_unit_lang_changed_maps_to_country_variant(language, expected):
+    """Regression: a `==` vs `=` typo made these branches no-ops, so 'pt'
+    and 'de' were probed against enchant as themselves instead of the
+    country variant, the same treatment 'en' already got correctly."""
+    plugin = Plugin.__new__(Plugin)
+    plugin.gtkspell = object()
+    plugin.enchant = _FakeEnchant(known_dicts={expected})
+    plugin._seen_languages = {}
+    plugin._enchant_languages = []
+
+    Plugin._on_unit_lang_changed(plugin, unit_view=None, text_view=None, language=language)
+
+    assert plugin.enchant.checked == [expected]
 
 
 def test_spellchecker_dependencies_importable():


### PR DESCRIPTION
- Fix pt/de spellcheck language mapping never actually applying.
- Bundle pyenchant's self-contained Windows wheel into the frozen build.

Windows-only for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)