### PR TITLE
Fix Save As always crashing with ModuleNotFoundError

### DIFF
--- a/virtaal/controllers/storecontroller.py
+++ b/virtaal/controllers/storecontroller.py
@@ -88,9 +88,10 @@ class StoreController(BaseController):
         if self._archivetemp:
             return self._targetfname
 
-        from translate.storage.bundleprojstore import BundleProjectStore
-        if self.project and isinstance(self.project.store, BundleProjectStore):
-            return self.project.store.zip.filename
+        if self.project:
+            from translate.storage.bundleprojstore import BundleProjectStore
+            if isinstance(self.project.store, BundleProjectStore):
+                return self.project.store.zip.filename
         return None
 
     def get_store(self):

--- a/virtaal/test/test_storecontroller.py
+++ b/virtaal/test/test_storecontroller.py
@@ -25,3 +25,13 @@ class TestStoreController(TestScaffolding):
     def test_open_file(self):
         self.store_controller.open_file(self.testfile[1])
         assert self.store_controller.store.get_filename() == self.testfile[1]
+
+    def test_get_bundle_filename_on_a_plain_file(self):
+        """Regression: get_bundle_filename() imported
+        translate.storage.bundleprojstore unconditionally, before
+        checking whether a project bundle was actually open - a module
+        translate-toolkit no longer ships, so this crashed Save As
+        (maincontroller.save_file() -> get_bundle_filename()) for every
+        plain, non-bundle file, i.e. always."""
+        self.store_controller.open_file(self.testfile[1])
+        assert self.store_controller.get_bundle_filename() is None


### PR DESCRIPTION
get_bundle_filename() imported translate.storage.bundleprojstore unconditionally, before checking self.project - a module translate-toolkit no longer ships, so this crashed every Save As on any plain, non-bundle file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)