### PR TITLE
Fix Open/Save As silently doing nothing on click

### DIFF
--- a/virtaal/views/mainview.py
+++ b/virtaal/views/mainview.py
@@ -304,6 +304,7 @@ class MainView(BaseView):
                     continue
                 new_filter = Gtk.FileFilter()
                 new_filter.set_name(name)
+                # Extensions only - mimetypes prevent native file dialogues.
                 if extensions:
                     for extension in extensions:
                         new_filter.add_pattern("*." + extension)
@@ -311,10 +312,6 @@ class MainView(BaseView):
                         for compress_extension in storage_factory.decompressclass.keys():
                             new_filter.add_pattern("*.%s.%s" % (extension, compress_extension))
                             all_supported_filter.add_pattern("*.%s.%s" % (extension, compress_extension))
-                if mimetypes:
-                    for mimetype in mimetypes:
-                        new_filter.add_mime_type(mimetype)
-                        all_supported_filter.add_mime_type(mimetype)
                 self._open_chooser.add_filter(new_filter)
 
             # doc_filter = Gtk.FileFilter()

--- a/virtaal/views/mainview.py
+++ b/virtaal/views/mainview.py
@@ -638,7 +638,7 @@ class MainView(BaseView):
         # below): FileChooserNative isn't a Gtk.Window, so it can't
         # itself be passed to another dialog's set_transient_for later.
         self.open_chooser.set_transient_for(self._top_window)
-        response = self.open_chooser.run() == Gtk.ResponseType.OK
+        response = self.open_chooser.run() == Gtk.ResponseType.ACCEPT
         self.open_chooser.hide()
 
         if response:
@@ -701,7 +701,7 @@ class MainView(BaseView):
         response = self.save_chooser.run()
         self.save_chooser.hide()
 
-        if response == Gtk.ResponseType.OK:
+        if response == Gtk.ResponseType.ACCEPT:
             filename = get_unicode(self.save_chooser.get_filename())
             #FIXME: do we need uri here?
             return filename

--- a/virtaal/views/test_mainview.py
+++ b/virtaal/views/test_mainview.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2026 Zuza Software Foundation
+#
+# This file is part of Virtaal.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+
+"""Regression tests for MainView's native file dialogs.
+
+GtkFileChooserNative (a GtkNativeDialog) returns Gtk.ResponseType.ACCEPT
+on accept, never .OK - confirmed against GTK's own docs
+(Gtk-3.0.gir: "will return #GTK_RESPONSE_ACCEPT if the user accepted").
+show_open_dialog()/show_save_dialog() compared against .OK instead,
+which is never returned by a real click - clicking Open/Save silently
+did nothing, no error.
+"""
+
+import gi
+gi.require_version('Gtk', '3.0')
+from gi.repository import Gtk
+
+from virtaal.views.mainview import MainView
+
+
+class _FakeChooser:
+    """Stands in for a GtkFileChooserNative without opening a real
+    dialog - only the calls show_open_dialog()/show_save_dialog()
+    actually make."""
+
+    def __init__(self, response, filename='/tmp/test.po'):
+        self._response = response
+        self._filename = filename
+        self.title = None
+
+    def set_title(self, title):
+        self.title = title
+
+    def set_current_folder(self, folder):
+        pass
+
+    def set_current_name(self, name):
+        pass
+
+    def set_transient_for(self, window):
+        pass
+
+    def run(self):
+        return self._response
+
+    def hide(self):
+        pass
+
+    def get_filename(self):
+        return self._filename
+
+    def get_uri(self):
+        return 'file://' + self._filename
+
+
+def _make_view_with_chooser(attr, chooser):
+    view = MainView.__new__(MainView)
+    view._top_window = None
+    setattr(view, attr, chooser)
+    return view
+
+
+def test_show_open_dialog_returns_filename_on_accept():
+    view = _make_view_with_chooser(
+        '_open_chooser', _FakeChooser(Gtk.ResponseType.ACCEPT))
+    filename, uri = view.show_open_dialog()
+    assert filename == '/tmp/test.po'
+
+
+def test_show_open_dialog_returns_nothing_on_cancel():
+    view = _make_view_with_chooser(
+        '_open_chooser', _FakeChooser(Gtk.ResponseType.CANCEL))
+    assert view.show_open_dialog() == ()
+
+
+def test_show_save_dialog_returns_filename_on_accept():
+    view = _make_view_with_chooser(
+        '_save_chooser', _FakeChooser(Gtk.ResponseType.ACCEPT))
+    assert view.show_save_dialog('Save', current_filename='/tmp/test.po') == '/tmp/test.po'
+
+
+def test_show_save_dialog_returns_none_on_cancel():
+    view = _make_view_with_chooser(
+        '_save_chooser', _FakeChooser(Gtk.ResponseType.CANCEL))
+    assert view.show_save_dialog('Save', current_filename='/tmp/test.po') is None


### PR DESCRIPTION
- GtkFileChooserNative returns Gtk.ResponseType.ACCEPT on accept, never .OK - show_open_dialog()/show_save_dialog() compared against .OK, which a real click never returns, so clicking Open or Save silently did nothing.
- The Open dialog's mimetype-based filters were also making GTK fall back to its own drawn dialog instead of Windows' native IFileDialog (documented GTK behaviour) - dropped, since the glob patterns already added for every extension cover the same files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)