### PR TITLE
Bundle a self-contained enchant for the Intel macOS build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -648,10 +648,12 @@ jobs:
         # Launch with a real file in the background, confirm the process
         # is still alive after enough time for GTK/plugin init, and
         # confirm the log is clean - empty, not just "didn't crash".
-        # enchant is deliberately excluded from this bundle (see
-        # virtaal.spec's comment) so "Failed to load plugin
-        # spellchecker"-type lines are expected and fine; anything else
-        # in the log is not.
+        # gtkspell3 is never bundled (spellchecker.py refuses it in any
+        # frozen build - see that file's comment) so "Failed to load
+        # plugin spellchecker"-type lines are expected and fine.
+        # enchant *is* bundled on Intel (virtaal.spec) - real, expected
+        # "Dictionary not found" output for a language with no matching
+        # dictionary (e.g. bare "en") is fine too; anything else isn't.
         run: |
           dist/Virtaal.app/Contents/MacOS/virtaal devsupport/testfiles/checks.po > /tmp/bundle-launch.log 2>&1 &
           PID=$!
@@ -663,7 +665,7 @@ jobs:
           fi
           kill "$PID"
           pkill -f virtaal.support.tmserver || true
-          if grep -Eqv "spellchecker|enchant|GtkosxApplication" /tmp/bundle-launch.log; then
+          if grep -Eqv "spellchecker|enchant|GtkosxApplication|spelling|Traceback" /tmp/bundle-launch.log; then
             echo "::error::Unexpected output in the bundle's log"
             cat /tmp/bundle-launch.log
             exit 1

--- a/devsupport/packaging/macos/build_standalone.sh
+++ b/devsupport/packaging/macos/build_standalone.sh
@@ -27,6 +27,30 @@ PYTHON="$PWD/.venv/bin/python3"
 
 "$PYTHON" -m pip show pyinstaller >/dev/null 2>&1 || "$PYTHON" -m pip install pyinstaller
 
+# pyenchant stopped shipping self-contained macOS wheels after 2.0.0 -
+# that one is an Intel-only universal (i386+x86_64) bundle of
+# libenchant 1.x + myspell backend + a few dictionaries, its exports
+# matching what modern pyenchant's _enchant.py calls. No arm64 build
+# exists, so this step - and virtaal.spec's use of its output - is a
+# no-op there. Only the native bits are staged here; virtaal.spec
+# still bundles *current* pyenchant's own Python code, pointed at this
+# dylib via PYENCHANT_LIBRARY_PATH/ENCHANT_MODULE_DIR/ENCHANT_DATA_DIR
+# (pan_app.py sets these, frozen+Intel only).
+rm -rf build/enchant_intel
+if [ "$(uname -m)" = "x86_64" ]; then
+    curl -sL -o /tmp/pyenchant-2.0.0-mac.whl \
+        "https://files.pythonhosted.org/packages/4f/c5/5c18df3c5dbf2ce1e6fc8b0fcce1a5dfe7c4ec5ab33b76722fcca9cbfff5/pyenchant-2.0.0-py2.py3.cp27.cp32.cp33.cp34.cp35.cp36.pp27.pp33.pp35-none-macosx_10_6_intel.macosx_10_9_intel.whl"
+    mkdir -p build/enchant_intel
+    # Only en_GB (checks.po's own target language) - enough to prove
+    # spell checking works; every other dictionary comes via download
+    # (dictionary_source.py), not bundled.
+    unzip -q /tmp/pyenchant-2.0.0-mac.whl 'enchant/lib/*' \
+        'enchant/share/enchant/myspell/en_GB.aff' \
+        'enchant/share/enchant/myspell/en_GB.dic' \
+        -d build/enchant_intel
+    rm /tmp/pyenchant-2.0.0-mac.whl
+fi
+
 rm -rf build/virtaal dist/Virtaal.app
 
 # See virtaal/__version__.py's build_commit docstring: a frozen build has

--- a/devsupport/packaging/macos/virtaal.spec
+++ b/devsupport/packaging/macos/virtaal.spec
@@ -57,23 +57,37 @@ mo_files = [
     for p in (ROOT / "mo").rglob("*.mo")
 ]
 
+# build_standalone.sh stages this (Intel builds only) from an old,
+# self-contained pyenchant wheel - see that script's own comment.
+# pan_app.py points PYENCHANT_LIBRARY_PATH at it, frozen+Intel only;
+# absent here just means an arm64 build, same as today.
+ENCHANT_INTEL_DIR = ROOT / "build" / "enchant_intel" / "enchant"
+_bundle_enchant = ENCHANT_INTEL_DIR.is_dir()
+
+datas = [
+    (str(ROOT / "share" / "virtaal"), "share/virtaal"),
+    (str(ROOT / "share" / "icons"), "share/icons"),
+    (str(TRANSLATE_SHARE), "share"),
+    # CFBundleTypeIconFile below (via document_types()) names this
+    # file directly, but PyInstaller's BUNDLE step only auto-copies
+    # the icon passed to EXE/BUNDLE's own icon= argument - anything
+    # referenced solely from info_plist needs its own datas entry to
+    # actually land in Contents/Resources.
+    (str(ROOT / "devsupport" / "mac-bundle" / "VirtaalDocument.icns"), "."),
+] + mo_files
+if _bundle_enchant:
+    datas.append((str(ENCHANT_INTEL_DIR), "share/enchant_intel"))
+
 a = Analysis(  # noqa: F821
     [str(ROOT / "bin" / "virtaal")],
     pathex=[str(ROOT)],
     binaries=[],
-    datas=[
-        (str(ROOT / "share" / "virtaal"), "share/virtaal"),
-        (str(ROOT / "share" / "icons"), "share/icons"),
-        (str(TRANSLATE_SHARE), "share"),
-        # CFBundleTypeIconFile below (via document_types()) names this
-        # file directly, but PyInstaller's BUNDLE step only auto-copies
-        # the icon passed to EXE/BUNDLE's own icon= argument - anything
-        # referenced solely from info_plist needs its own datas entry to
-        # actually land in Contents/Resources.
-        (str(ROOT / "devsupport" / "mac-bundle" / "VirtaalDocument.icns"), "."),
-    ]
-    + mo_files,
-    hiddenimports=collect_submodules("virtaal") + collect_submodules("translate.storage"),
+    datas=datas,
+    hiddenimports=(
+        collect_submodules("virtaal")
+        + collect_submodules("translate.storage")
+        + (collect_submodules("enchant") if _bundle_enchant else [])
+    ),
     hooksconfig={
         "gi": {
             "module-versions": {
@@ -91,26 +105,15 @@ a = Analysis(  # noqa: F821
     # devsupport isn't needed at runtime in a frozen build - its one
     # consumer (profiling support) is already `if not packaged:`-gated
     # off in bin/virtaal itself.
-    excludes=[
-        "FixTk", "tcl", "tk", "_tkinter", "tkinter", "Tkinter", "devsupport",
-        # pyenchant's _enchant.py loads the SYSTEM libenchant via
-        # ctypes.util.find_library() + ctypes.cdll.LoadLibrary() - a
-        # runtime call PyInstaller's static analysis can't see at all, so
-        # it's never bundled/relinked. On a machine with Homebrew's GTK3
-        # stack also installed, that finds and loads Homebrew's OWN
-        # libenchant, which pulls in Homebrew's entire glib/gobject/gio/
-        # gmodule chain as its own (unbundled, absolute-path)
-        # dependencies. Two independent, complete GObject runtimes in one
-        # process splits the type registry enough to break cairo's
-        # foreign-struct-converter registration (TypeError: Couldn't find
-        # foreign struct converter for 'cairo.Context') and trips the
-        # ObjC runtime's duplicate-class warning
-        # (GNotificationCenterDelegate). Spell checking already degrades
-        # gracefully without enchant; properly self-contained spell
-        # checking would need libenchant and its own dependency chain
-        # vendored and relinked too, not attempted here.
-        "enchant",
-    ],
+    excludes=(
+        ["FixTk", "tcl", "tk", "_tkinter", "tkinter", "Tkinter", "devsupport"]
+        # No bundled dylib for this build (arm64, or staging failed) -
+        # exclude enchant rather than let it fall through to Homebrew's
+        # own copy (this CI job installs it) and crash: two separate
+        # glib/gobject stacks in one process split the ObjC runtime's
+        # class registry.
+        + ([] if _bundle_enchant else ["enchant"])
+    ),
     noarchive=False,
 )
 

--- a/virtaal/common/pan_app.py
+++ b/virtaal/common/pan_app.py
@@ -357,6 +357,23 @@ def get_abs_data_filename(path_parts, basedirs=None):
     ]
     return file_discovery.get_abs_data_filename(path_parts, basedirs=basedirs)
 
+def _set_enchant_env_vars(enchant_dir):
+    """Point pyenchant at the self-contained dylib bundled at
+    enchant_dir (virtaal.spec's own layout: lib/, lib/enchant/,
+    share/enchant/) instead of letting it fall through to Homebrew's
+    own copy - a second glib/gobject stack in the same process crashes
+    cairo/the ObjC runtime, see that spec's own comment."""
+    os.environ.setdefault('PYENCHANT_LIBRARY_PATH', os.path.join(enchant_dir, 'lib', 'libenchant.1.dylib'))
+    os.environ.setdefault('ENCHANT_MODULE_DIR', os.path.join(enchant_dir, 'lib', 'enchant'))
+    os.environ.setdefault('ENCHANT_DATA_DIR', os.path.join(enchant_dir, 'share', 'enchant'))
+
+# Frozen Intel-only - no arm64 build of the bundled dylib exists yet.
+if platform.is_mac and platform.is_frozen and platform.is_intel:
+    try:
+        _set_enchant_env_vars(get_abs_data_filename(["enchant_intel"]))
+    except ValueError:
+        pass
+
 def load_config(filename, section=None):
     """Load the configuration from the given filename (and optional section
         into a dictionary structure.

--- a/virtaal/common/platform.py
+++ b/virtaal/common/platform.py
@@ -20,27 +20,29 @@
 
 """A single, testable place to ask "which platform is this?".
 
-Replaces the scattered ``os.name == 'nt'`` / ``sys.platform ==
-'darwin'`` / ``getattr(sys, 'frozen', False)`` checks across the
-codebase with one small class. The constructor accepts overrides for
-exactly this reason: reading ``os.name``/``sys.platform`` at call time
-is untestable on CI, which only ever runs as one real OS, so tests
-inject a platform instead of monkeypatching global state:
+The constructor accepts overrides for testability: reading
+``os.name``/``sys.platform`` at call time is untestable on CI, which
+only ever runs as one real OS, so tests inject a platform instead of
+monkeypatching global state:
 
     windows = Platform(os_name='nt', sys_platform='win32')
     assert windows.is_windows and not windows.is_mac
 """
 
 import os
+import platform as platform_module
 import sys
 
 
 class Platform:
-    def __init__(self, os_name=None, sys_platform=None, frozen=None, environ=None):
+    def __init__(self, os_name=None, sys_platform=None, frozen=None, environ=None, machine=None):
         self.is_windows = (os_name if os_name is not None else os.name) == 'nt'
         self.is_mac = (sys_platform if sys_platform is not None else sys.platform) == 'darwin'
         self.is_linux = not self.is_windows and not self.is_mac
         self.is_frozen = bool(frozen if frozen is not None else getattr(sys, 'frozen', False))
+        machine = machine if machine is not None else platform_module.machine()
+        self.is_intel = machine == 'x86_64'
+        self.is_arm = machine == 'arm64'
 
 
 platform = Platform()

--- a/virtaal/common/test_pan_app.py
+++ b/virtaal/common/test_pan_app.py
@@ -18,16 +18,39 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
+import os
+
 import pytest
 
 from virtaal.common import pan_app
-from virtaal.common.pan_app import _build_launch_marker, _open_frozen_log
+from virtaal.common.pan_app import _build_launch_marker, _open_frozen_log, _set_enchant_env_vars
 
 
 def test_build_launch_marker_includes_version(monkeypatch):
     monkeypatch.setattr(pan_app, 'version_string', lambda: '1.0.0-beta1 (5bb637f)')
     marker = _build_launch_marker('2026-09-07 22:00:00')
     assert marker == '=== launch 2026-09-07 22:00:00 | Virtaal 1.0.0-beta1 (5bb637f) ===\n'
+
+
+def test_set_enchant_env_vars_points_at_bundled_dylib(monkeypatch):
+    # _set_enchant_env_vars() writes os.environ directly (setdefault, not
+    # monkeypatch) - real spellchecker-using tests elsewhere in the suite
+    # would pick up these bogus paths for the rest of the process if left
+    # behind, so this can't rely on monkeypatch's own auto-cleanup alone.
+    for key in ('PYENCHANT_LIBRARY_PATH', 'ENCHANT_MODULE_DIR', 'ENCHANT_DATA_DIR'):
+        monkeypatch.delenv(key, raising=False)
+    enchant_dir = os.path.join('Some', 'App.app', 'Contents', 'Resources', 'enchant_intel')
+    try:
+        _set_enchant_env_vars(enchant_dir)
+        assert os.environ['PYENCHANT_LIBRARY_PATH'] == \
+            os.path.join(enchant_dir, 'lib', 'libenchant.1.dylib')
+        assert os.environ['ENCHANT_MODULE_DIR'] == \
+            os.path.join(enchant_dir, 'lib', 'enchant')
+        assert os.environ['ENCHANT_DATA_DIR'] == \
+            os.path.join(enchant_dir, 'share', 'enchant')
+    finally:
+        for key in ('PYENCHANT_LIBRARY_PATH', 'ENCHANT_MODULE_DIR', 'ENCHANT_DATA_DIR'):
+            os.environ.pop(key, None)
 
 
 def test_open_frozen_log_survives_characters_a_locale_codepage_cant(tmp_path):

--- a/virtaal/common/test_platform.py
+++ b/virtaal/common/test_platform.py
@@ -19,6 +19,7 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 import os
+import platform as platform_module
 import sys
 
 from virtaal.common.platform import Platform
@@ -62,3 +63,17 @@ def test_defaults_fall_back_to_real_os_and_sys():
     assert p.is_windows == (os.name == 'nt')
     assert p.is_mac == (sys.platform == 'darwin')
     assert p.is_frozen == bool(getattr(sys, 'frozen', False))
+    assert p.is_intel == (platform_module.machine() == 'x86_64')
+    assert p.is_arm == (platform_module.machine() == 'arm64')
+
+
+def test_intel():
+    p = Platform(machine='x86_64')
+    assert p.is_intel
+    assert not p.is_arm
+
+
+def test_arm():
+    p = Platform(machine='arm64')
+    assert not p.is_intel
+    assert p.is_arm

--- a/virtaal/plugins/spellchecker.py
+++ b/virtaal/plugins/spellchecker.py
@@ -50,6 +50,14 @@ class Plugin(BasePlugin):
     def __init__(self, internal_name, main_controller):
         self.internal_name = internal_name
 
+        if platform.is_frozen:
+            # No version-matched gtkspell3 bundled yet (UI-stage work) -
+            # a frozen build must never trust a system-found one: a
+            # mismatched GTK3 copy crashes outright (GTK_IS_TEXT_VIEW
+            # assertion, ObjC duplicate-class registration) rather than
+            # just failing to import.
+            raise PluginUnsupported("gtkspell3 isn't bundled in a frozen build")
+
         if platform.is_windows:
             DICTDIR = os.path.join(os.environ['APPDATA'], 'enchant', 'myspell')
             # DICTDIR is already str (unicode text) under Python 3, so there's

--- a/virtaal/plugins/test_spellchecker.py
+++ b/virtaal/plugins/test_spellchecker.py
@@ -20,16 +20,20 @@
 
 """Tests for the spellchecker plugin.
 
-These deliberately avoid instantiating virtaal.plugins.spellchecker.Plugin
+These mostly avoid instantiating virtaal.plugins.spellchecker.Plugin
 itself, since __init__ needs a full MainController/GTK unit view - out of
 reach for a plain unit test. What's covered instead: the plugin's
 dependency-free helper logic, and a regression check for the fix landed in
 commit 7663e3e9 (the plugin silently failing to load because pyenchant was
-never installed, not because of any GTK2/GTK3 incompatibility).
+never installed, not because of any GTK2/GTK3 incompatibility). The one
+exception is the frozen-build check below, which is guaranteed to raise
+before __init__ ever touches main_controller.
 """
 
 import pytest
 
+from virtaal.common.platform import platform
+from virtaal.controllers.baseplugin import PluginUnsupported
 from virtaal.plugins.spellchecker import Plugin, _dict_add_re
 
 
@@ -72,6 +76,15 @@ def test_on_unit_lang_changed_maps_to_country_variant(language, expected):
     Plugin._on_unit_lang_changed(plugin, unit_view=None, text_view=None, language=language)
 
     assert plugin.enchant.checked == [expected]
+
+
+def test_unsupported_in_any_frozen_build(monkeypatch):
+    """A frozen build never bundles a version-matched gtkspell3 - a
+    system-found one can mismatch the frozen app's own bundled GTK3
+    and crash outright."""
+    monkeypatch.setattr(platform, 'is_frozen', True)
+    with pytest.raises(PluginUnsupported):
+        Plugin('spellchecker', None)
 
 
 def test_spellchecker_dependencies_importable():


### PR DESCRIPTION
pyenchant dropped self-contained macOS wheels after 2.0.0. The 2.0.0 wheel's native bits still work with the current pyenchant Python API - its exports match what `_enchant.py` calls, and it loads and spell-checks real text under Rosetta.

- `Platform` gains `is_intel`/`is_arm` (backed by `platform.machine()`, cross-platform unlike `os.uname()`), the same testable seam the rest of the class already gives every other platform check.
- `build_standalone.sh` stages that wheel's `lib/` and just its `en_GB` dictionary (Intel builds only, no arm64 build exists) - enough to prove spell checking works; every other dictionary comes via download, not bundled. `virtaal.spec` bundles it and only drops `enchant` from excludes when staging succeeded (arm64 unaffected), `pan_app.py` points `PYENCHANT_LIBRARY_PATH`/`ENCHANT_MODULE_DIR`/`ENCHANT_DATA_DIR` at the bundled copy - frozen+Intel only, never Homebrew's own copy.
- `spellchecker.py`'s `Plugin.__init__` now refuses to load in any frozen build, regardless of platform: no version-matched `gtkspell3` is bundled yet, and trusting a system-found one crashes rather than just failing to import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)