### PR TITLE
Add LibreOffice dictionary sourcing (enumerate, parse, download)

### DIFF
--- a/virtaal/support/dictionary_source.py
+++ b/virtaal/support/dictionary_source.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2026 Zuza Software Foundation
+#
+# This file is part of Virtaal.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+
+"""Source hunspell spell-check dictionaries directly from LibreOffice's
+own dictionaries repo (github.com/LibreOffice/dictionaries) - LibreOffice
+is hunspell's own reference consumer, and the de facto community source.
+
+Two-step lookup, matching the repo's real shape:
+
+1. Enumerate every language folder via one recursive git-trees call
+   (list_dictionary_folders()).
+2. Per folder, read its own dictionaries.xcu (parse_dictionaries_xcu())
+   - the authoritative source for both the real .aff/.dic filenames
+   (not derivable from the locale code: German's is de_DE_frami.aff,
+   not de_DE.aff) and the full list of locale codes that dictionary
+   covers (Arabic's one dictionary covers 17 country variants).
+
+Deliberately synchronous (plain urllib), not wired into the app's own
+async HTTPClient/idle-download machinery yet - that integration is a
+separate, later step. Every network call is a thin wrapper so the
+parsing/matching logic above is independently testable without a
+network connection.
+"""
+
+import json
+import logging
+import os
+import urllib.request
+from urllib.error import HTTPError, URLError
+
+from lxml import etree
+
+TREE_URL = 'https://api.github.com/repos/LibreOffice/dictionaries/git/trees/master?recursive=1'
+RAW_BASE = 'https://raw.githubusercontent.com/LibreOffice/dictionaries/master/'
+
+_OOR = '{http://openoffice.org/2001/registry}'
+_XCU_SUFFIX = '/dictionaries.xcu'
+
+
+def list_dictionary_folders(tree_json):
+    """Parse one recursive git-trees API response (already-decoded
+    JSON) into {folder_path: xcu_blob_sha}, one entry per language
+    folder that has its own dictionaries.xcu. Pure function, no I/O."""
+    if tree_json.get('truncated'):
+        logging.warning(
+            'LibreOffice dictionaries tree response was truncated - '
+            'some languages may be missing')
+    return {
+        entry['path'][:-len(_XCU_SUFFIX)]: entry.get('sha')
+        for entry in tree_json.get('tree', [])
+        if entry.get('path', '').endswith(_XCU_SUFFIX)
+    }
+
+
+def _prop_value(node, prop_name):
+    for prop in node.iterfind('prop'):
+        if prop.get(_OOR + 'name') == prop_name:
+            value = prop.find('value')
+            return value.text if value is not None else None
+    return None
+
+
+def parse_dictionaries_xcu(xml_bytes):
+    """Parse one folder's dictionaries.xcu into a list of
+    {'files': [...], 'locales': [...]} dicts, one per HunSpellDic_*
+    node (Format == DICT_SPELL specifically - hyphenation/thesaurus
+    nodes in the same file are real but out of scope here). 'files'
+    are bare filenames (the "%origin%/" prefix stripped); 'locales'
+    are underscore-normalised (enchant's own convention), not the
+    repo's hyphenated BCP47 form. Pure function, no I/O."""
+    root = etree.fromstring(xml_bytes)
+    result = []
+    for node in root.iter('node'):
+        name = node.get(_OOR + 'name', '')
+        if not name.startswith('HunSpellDic_'):
+            continue
+        if _prop_value(node, 'Format') != 'DICT_SPELL':
+            continue
+        locations = (_prop_value(node, 'Locations') or '').split()
+        files = [
+            f[len('%origin%/'):] if f.startswith('%origin%/') else f
+            for f in locations
+        ]
+        locales = [
+            loc.replace('-', '_')
+            for loc in (_prop_value(node, 'Locales') or '').split()
+        ]
+        if files and locales:
+            result.append({'files': files, 'locales': locales})
+    return result
+
+
+def candidate_folders(locale_code, known_folders):
+    """Folder names worth trying first for locale_code (e.g. 'de_DE'),
+    cheapest/most-specific first, given the set of real folder names
+    already known from list_dictionary_folders(). Real folder naming
+    isn't one consistent pattern - some are bare language codes
+    covering many regions in one dictionaries.xcu ('ar', 'de'), others
+    are the full underscored locale ('af_ZA') - so try the exact
+    match, then the bare language part, before falling back to a full
+    scan elsewhere. Doesn't guarantee a hit; the caller still needs to
+    check the actual xcu content."""
+    locale_code = locale_code.replace('-', '_')
+    lang = locale_code.split('_')[0]
+    candidates = [c for c in (locale_code, lang) if c in known_folders]
+    # Stable order, no duplicates, without needing a set (small lists).
+    seen = []
+    for c in candidates:
+        if c not in seen:
+            seen.append(c)
+    return seen
+
+
+def find_dictionary(locale_code, folders, fetch_xcu):
+    """Find the HunSpellDic_* entry covering locale_code.
+
+    folders: {folder_path: sha}, from list_dictionary_folders().
+    fetch_xcu: callable(folder_path) -> xcu bytes - injected so this
+    is testable without real network access.
+
+    Tries the likely candidate folders first (candidate_folders());
+    falls back to every remaining folder if none of those actually
+    cover this locale, since folder naming isn't fully predictable.
+    Returns (folder_path, files) for the first match, or None.
+    """
+    locale_code = locale_code.replace('-', '_')
+    ordered = candidate_folders(locale_code, folders)
+    ordered += [f for f in folders if f not in ordered]
+    for folder in ordered:
+        for entry in parse_dictionaries_xcu(fetch_xcu(folder)):
+            if locale_code in entry['locales']:
+                return folder, entry['files']
+    return None
+
+
+# --- Network I/O - thin, replaceable wrappers around the pure logic above ---
+
+def _get(url):
+    with urllib.request.urlopen(url, timeout=10) as response:
+        return response.read()
+
+
+def fetch_dictionary_tree():
+    """The real, live git-trees listing - list_dictionary_folders()'s
+    own input."""
+    return json.loads(_get(TREE_URL).decode('utf-8'))
+
+
+def fetch_xcu(folder):
+    return _get(RAW_BASE + folder + _XCU_SUFFIX)
+
+
+def fetch_dictionary_file(folder, filename):
+    return _get(RAW_BASE + folder + '/' + filename)
+
+
+# --- Where downloaded dictionaries need to end up for enchant to find them ---
+
+def dictionary_write_dir():
+    """Where enchant's hunspell backend looks for user-installed
+    dictionaries.
+
+    NOT independently verified on every platform - built from
+    enchant's own get_user_config_dir() (the one per-user directory
+    pyenchant itself exposes cross-platform) plus a "hunspell"
+    subdirectory, the naming the currently-bundled Windows dictionaries
+    already use (enchant/data/mingw64/share/enchant/hunspell/ in that
+    wheel). Confirming this against a real hunspell-enabled enchant
+    install (this session's own dev machine only had aspell/AppleSpell
+    providers available, not hunspell) is a real follow-up, not done
+    here.
+    """
+    import enchant
+    return os.path.join(enchant.get_user_config_dir(), 'hunspell')
+
+
+def download_dictionary(locale_code, target_dir=None):
+    """Find and download the hunspell dictionary covering locale_code,
+    writing its files into target_dir (dictionary_write_dir() by
+    default). Returns the list of local file paths written, or None if
+    no dictionary covers this locale.
+
+    Synchronous, real network I/O - not meant to be called from the
+    UI thread as-is; see this module's own docstring."""
+    if target_dir is None:
+        target_dir = dictionary_write_dir()
+
+    tree = fetch_dictionary_tree()
+    folders = list_dictionary_folders(tree)
+    match = find_dictionary(locale_code, folders, fetch_xcu)
+    if match is None:
+        logging.debug('No LibreOffice dictionary found for %s', locale_code)
+        return None
+    folder, files = match
+
+    os.makedirs(target_dir, exist_ok=True)
+    written = []
+    for filename in files:
+        try:
+            content = fetch_dictionary_file(folder, filename)
+        except (HTTPError, URLError) as e:
+            logging.warning('Could not download %s/%s: %s', folder, filename, e)
+            return None
+        dest = os.path.join(target_dir, filename)
+        with open(dest, 'wb') as f:
+            f.write(content)
+        written.append(dest)
+    return written

--- a/virtaal/support/test_dictionary_source.py
+++ b/virtaal/support/test_dictionary_source.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2026 Zuza Software Foundation
+#
+# This file is part of Virtaal.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for dictionary_source's pure enumerate/parse/match logic - the
+network calls themselves are thin, untested wrappers (see that
+module's own docstring); what's tested here is real content (fixtures
+below are actual copies from github.com/LibreOffice/dictionaries, not
+hand-written guesses), so a real repo-shape change would actually be
+caught.
+"""
+
+from virtaal.support.dictionary_source import (
+    candidate_folders,
+    find_dictionary,
+    list_dictionary_folders,
+    parse_dictionaries_xcu,
+)
+
+# Actual copy (trimmed to the parts these tests need) of
+# de/dictionaries.xcu (blob 0cccf05960e3d6479e9b7df39eb486dc21214e72) -
+# de_DE_frami.aff isn't guessable from the locale code (de_DE.aff
+# would be the guess), and one folder covers three distinct locales.
+DE_XCU = b"""<?xml version="1.0" encoding="UTF-8"?>
+<oor:component-data xmlns:oor="http://openoffice.org/2001/registry" xmlns:xs="http://www.w3.org/2001/XMLSchema" oor:name="Linguistic" oor:package="org.openoffice.Office">
+ <node oor:name="ServiceManager">
+    <node oor:name="Dictionaries">
+        <node oor:name="HunSpellDic_de-AT_frami" oor:op="fuse">
+            <prop oor:name="Locations" oor:type="oor:string-list">
+                <value>%origin%/de_AT_frami.aff %origin%/de_AT_frami.dic</value>
+            </prop>
+            <prop oor:name="Format" oor:type="xs:string">
+                <value>DICT_SPELL</value>
+            </prop>
+            <prop oor:name="Locales" oor:type="oor:string-list">
+                <value>de-AT</value>
+            </prop>
+        </node>
+        <node oor:name="HunSpellDic_de-DE_frami" oor:op="fuse">
+            <prop oor:name="Locations" oor:type="oor:string-list">
+                <value>%origin%/de_DE_frami.aff %origin%/de_DE_frami.dic</value>
+            </prop>
+            <prop oor:name="Format" oor:type="xs:string">
+                <value>DICT_SPELL</value>
+            </prop>
+            <prop oor:name="Locales" oor:type="oor:string-list">
+                <value>de-DE</value>
+            </prop>
+        </node>
+        <node oor:name="HyphDic_de-DE" oor:op="fuse">
+            <prop oor:name="Locations" oor:type="oor:string-list">
+                <value>%origin%/hyph_de_DE.dic</value>
+            </prop>
+            <prop oor:name="Format" oor:type="xs:string">
+                <value>DICT_HYPH</value>
+            </prop>
+            <prop oor:name="Locales" oor:type="oor:string-list">
+                <value>de de-DE</value>
+            </prop>
+        </node>
+    </node>
+ </node>
+</oor:component-data>
+"""
+
+# Actual copy of ar/dictionaries.xcu (blob
+# cd34b51d72c3ae0dd4801fe3c28cde29e20290cc) - the case with the most
+# locales sharing one dictionary (17).
+AR_XCU = b"""<?xml version="1.0" encoding="UTF-8"?>
+<oor:component-data xmlns:oor="http://openoffice.org/2001/registry" xmlns:xs="http://www.w3.org/2001/XMLSchema" oor:name="Linguistic" oor:package="org.openoffice.Office">
+ <node oor:name="ServiceManager">
+    <node oor:name="Dictionaries">
+        <node oor:name="HunSpellDic_ar" oor:op="fuse">
+            <prop oor:name="Locations" oor:type="oor:string-list">
+                <value>%origin%/ar.aff %origin%/ar.dic</value>
+            </prop>
+            <prop oor:name="Format" oor:type="xs:string">
+                <value>DICT_SPELL</value>
+            </prop>
+            <prop oor:name="Locales" oor:type="oor:string-list">
+                <value>ar-SA ar-DZ ar-BH ar-EG ar-IQ ar-JO ar-KW ar-LB ar-LY ar-MA ar-OM ar-QA ar-SD ar-SY ar-TN ar-AE ar-YE</value>
+            </prop>
+        </node>
+    </node>
+ </node>
+</oor:component-data>
+"""
+
+
+def test_parse_dictionaries_xcu_strips_origin_prefix_and_normalises_locale():
+    """de_DE's real filename isn't derivable from the locale code, and
+    Locales use hyphens where enchant/Virtaal want underscores."""
+    entries = parse_dictionaries_xcu(DE_XCU)
+    by_locale = {loc: e for e in entries for loc in e['locales']}
+    assert by_locale['de_DE']['files'] == ['de_DE_frami.aff', 'de_DE_frami.dic']
+    assert by_locale['de_AT']['files'] == ['de_AT_frami.aff', 'de_AT_frami.dic']
+
+
+def test_parse_dictionaries_xcu_ignores_non_spelling_nodes():
+    """HyphDic_* (hyphenation) is real content in the same file but out
+    of scope - only DICT_SPELL/HunSpellDic_* nodes should come back."""
+    entries = parse_dictionaries_xcu(DE_XCU)
+    assert len(entries) == 2
+    assert all('frami' in f for e in entries for f in e['files'])
+
+
+def test_parse_dictionaries_xcu_handles_one_dict_covering_many_locales():
+    entries = parse_dictionaries_xcu(AR_XCU)
+    assert len(entries) == 1
+    assert entries[0]['files'] == ['ar.aff', 'ar.dic']
+    assert 'ar_EG' in entries[0]['locales']
+    assert len(entries[0]['locales']) == 17
+
+
+def test_list_dictionary_folders_from_real_tree_shape():
+    tree_json = {
+        'truncated': False,
+        'tree': [
+            {'path': 'de/dictionaries.xcu', 'sha': 'abc123'},
+            {'path': 'af_ZA/dictionaries.xcu', 'sha': 'def456'},
+            {'path': 'de/de_DE_frami.dic', 'sha': 'not-an-xcu'},
+            {'path': 'README.md', 'sha': 'irrelevant'},
+        ],
+    }
+    folders = list_dictionary_folders(tree_json)
+    assert folders == {'de': 'abc123', 'af_ZA': 'def456'}
+
+
+def test_candidate_folders_tries_exact_then_bare_language():
+    known = {'af_ZA': 'x', 'de': 'y'}
+    assert candidate_folders('af_ZA', known) == ['af_ZA']
+    assert candidate_folders('de_DE', known) == ['de']
+    assert candidate_folders('xx_YY', known) == []
+
+
+def test_find_dictionary_uses_candidate_before_scanning_everything():
+    folders = {'de': 's1', 'ar': 's2'}
+    fetched = []
+
+    def fetch_xcu(folder):
+        fetched.append(folder)
+        return {'de': DE_XCU, 'ar': AR_XCU}[folder]
+
+    result = find_dictionary('de_DE', folders, fetch_xcu)
+    assert result == ('de', ['de_DE_frami.aff', 'de_DE_frami.dic'])
+    # 'de' is de_DE's own candidate folder - no need to have also
+    # fetched 'ar' to find it.
+    assert fetched == ['de']
+
+
+def test_find_dictionary_falls_back_to_scanning_other_folders():
+    """ar_EG's own dictionary isn't in a folder candidate_folders()
+    would guess from the locale code alone ('ar_EG'/'ar_EG's folder
+    is actually just 'ar') - covered by candidate_folders itself, but
+    confirm the orchestration doesn't silently miss a match sitting in
+    a folder named differently from any prefix of the locale code."""
+    folders = {'de': 's1', 'ar': 's2'}
+    fetched = []
+
+    def fetch_xcu(folder):
+        fetched.append(folder)
+        return {'de': DE_XCU, 'ar': AR_XCU}[folder]
+
+    result = find_dictionary('ar_EG', folders, fetch_xcu)
+    assert result == ('ar', ['ar.aff', 'ar.dic'])
+
+
+def test_find_dictionary_returns_none_when_nothing_matches():
+    result = find_dictionary('xx_YY', {'de': 's1'}, lambda folder: DE_XCU)
+    assert result is None


### PR DESCRIPTION
First slice of the dictionary-sourcing work - the core enumerate/parse/download pipeline against github.com/LibreOffice/dictionaries.

- Enumerates via one recursive git-trees call, reads each folder's own dictionaries.xcu for the real filenames and locale coverage (not derivable from the locale code alone).
- Pure parsing/matching logic unit tested against real, fetched xcu content.

Not yet wired into the UI's idle-download flow or into spellchecker.py - deliberately synchronous and dependency-injected for testability first. `dictionary_write_dir()`'s target directory is a best-effort guess, flagged in the code as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)