### PR TITLE
Trim the Windows bundle's dictionaries to just en_GB

### DIFF
--- a/devsupport/packaging/windows/virtaal.spec
+++ b/devsupport/packaging/windows/virtaal.spec
@@ -140,7 +140,14 @@ datas = [
     (str(TRANSLATE_SHARE), "share"),
 ] + mo_files
 if ENCHANT_DATA is not None and ENCHANT_DATA.is_dir():
-    datas.append((str(ENCHANT_DATA), "enchant/data"))
+    # Only en_GB - enough to test; the rest comes via download, not
+    # bundled (~20MB of unused dictionaries otherwise).
+    for p in ENCHANT_DATA.rglob("*"):
+        if p.is_dir():
+            continue
+        if p.parent.name == "hunspell" and p.stem != "en_GB":
+            continue
+        datas.append((str(p), str(Path("enchant/data") / p.relative_to(ENCHANT_DATA).parent)))
 
 a = Analysis(  # noqa: F821
     [str(ROOT / "bin" / "virtaal")],


### PR DESCRIPTION
pyenchant's Windows wheel bundles `enchant/data/` wholesale - 24 English-locale dictionaries under `hunspell/` (~20MB), confirmed by inspecting the real wheel. Same fix as the macOS Intel build (#3423): only en_GB, enough to test; the rest via download instead.

No single `(src_dir, dest)` `datas` tuple can exclude files, so `virtaal.spec` now walks `ENCHANT_DATA` by hand and skips every other file under a `hunspell` directory. Verified the filtering logic directly against a real extracted copy of the wheel (46 of 48 dictionary files dropped, `en_GB.aff`/`en_GB.dic` kept, everything else in `bin/`/`lib/` untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)