### PR TITLE
Wire dictionary downloading into the app

### DIFF
--- a/virtaal/main.py
+++ b/virtaal/main.py
@@ -147,6 +147,7 @@ class Virtaal(object):
         from virtaal.controllers.checkscontroller import ChecksController
         from virtaal.controllers.undocontroller import UndoController
         from virtaal.controllers.propertiescontroller import PropertiesController
+        from virtaal.support.dictionary_download_watcher import DictionaryDownloadWatcher
 
         defer = self.defer
         main_controller = self.main_controller
@@ -156,6 +157,7 @@ class Virtaal(object):
         defer(PluginController, main_controller)
         defer(PreferencesController, main_controller)
         defer(PropertiesController, main_controller)
+        defer(DictionaryDownloadWatcher, main_controller)
         defer(main_controller.load_plugins)
 
         # Only bundled builds (macOS .app, Windows installer) can't

--- a/virtaal/plugins/spellchecker.py
+++ b/virtaal/plugins/spellchecker.py
@@ -34,17 +34,11 @@ _dict_add_re = re.compile('Add "(.*)" to Dictionary')
 
 
 class Plugin(BasePlugin):
-    """A plugin to control spell checking.
-
-    It can also download spell checkers on Windows and Mac."""
+    """A plugin to control spell checking."""
 
     display_name = _('Spell Checker')
     description = _('Check spelling and provide suggestions')
     version = 0.1
-
-    _base_URL = 'http://dictionary.locamotion.org/hunspell/'
-    _dict_URL = _base_URL + '%s.tar.bz2'
-    _lang_list = 'languages.txt'
 
     # INITIALIZERS #
     def __init__(self, internal_name, main_controller):
@@ -88,11 +82,6 @@ class Plugin(BasePlugin):
         self._seen_languages = {}
         # languages supported by enchant:
         self._enchant_languages = self.enchant.list_languages()
-
-        # HTTP clients (Windows and Mac only)
-        self.clients = {}
-        # downloadable languages (Windows and Mac only)
-        self.languages = set()
 
         unit_view = main_controller.unit_controller.view
         self.unit_view = unit_view
@@ -138,109 +127,6 @@ class Plugin(BasePlugin):
 
     # METHODS #
 
-    def _build_client(self, url, clients_id, callback, error_callback=None):
-        from virtaal.support.httpclient import HTTPClient
-        client = HTTPClient()
-        client.set_virtaal_useragent()
-        self.clients[clients_id] = client
-        if logging.root.level != logging.DEBUG:
-            client.get(url, callback)
-        else:
-            def error_log(request, result):
-                logging.debug('Could not get %s: status %d' % (url, request.status))
-            client.get(url, callback, error_callback=error_log)
-
-    def _download_checker(self, language):
-        """A Windows-and Mac only way to obtain new dictionaries."""
-        if platform.is_windows and 'APPDATA' not in os.environ:
-            # We won't have an idea of where to save it, so let's give up now
-            return
-        if language in self.clients:
-            # We already tried earlier, or started the process
-            return
-        if not self.languages:
-            if self._lang_list not in self.clients:
-                # We don't yet have a list of available languages
-                url = self._base_URL + self._lang_list #index page listing all the dictionaries
-                callback = lambda *args: self._process_index(language=language, *args)
-                self._build_client(url, self._lang_list, callback)
-                # self._process_index will call this again, so we can exit
-            return
-
-        language_to_download = None
-        # People almost definitely want 'en_US' for 'en', so let's ensure
-        # that we get that right:
-        if language == 'en':
-            language_to_download = 'en_US'
-            self.clients[language] = None
-        else:
-            # Let's see if a dictionary is available for this language:
-            for l in self.languages:
-                if l == language or l.startswith(language+'_'):
-                    self.clients[language] = None
-                    logging.debug("Will use %s to spell check %s", l, language)
-                    language_to_download = l
-                    break
-            else:
-                # No dictionary available
-                # Indicate that we never need to try this language:
-                logging.debug("Found no suitable language for spell checking")
-                self.clients[language] = None
-                return
-
-       # Now download the actual files after we have determined that it is
-       # available
-        callback = lambda *args: self._process_tarball(language=language, *args)
-        url = self._dict_URL % language_to_download
-        self._build_client(url, language, callback)
-
-
-    def _tar_ok(self, tar):
-        # TODO: Verify that the tarball is ok:
-        # - only two files
-        # - must be .aff and .dic
-        # - language codes should be sane
-        # - file sizes should be ok
-        # - no directory structure
-        return True
-
-    def _ensure_dir(self, dir):
-        if not os.path.isdir(dir):
-            os.makedirs(dir)
-
-    def _process_index(self, request, result, language=None):
-        """Process the list of languages."""
-        if request.status == 200 and not self.languages:
-            self.languages = set(result.split())
-            self._download_checker(language)
-        else:
-            logging.debug("Couldn't get list of spell checkers")
-            #TODO: disable plugin
-
-    def _process_tarball(self, request, result, language=None):
-        # Indicate that we already tried and shouldn't try again later:
-        self.clients[language] = None
-
-        if request.status == 200:
-            logging.debug('Got a dictionary')
-            from io import BytesIO
-            import tarfile
-            file_obj = BytesIO(result)
-            tar = tarfile.open(fileobj=file_obj)
-            if not self._tar_ok(tar):
-                return
-            if platform.is_windows:
-                DICTDIR = os.path.join(os.environ['APPDATA'], 'enchant', 'myspell')
-            elif platform.is_mac:
-                DICTDIR = os.path.expanduser("~/.enchant/myspell")
-            self._ensure_dir(DICTDIR)
-            tar.extractall(DICTDIR)
-            self._seen_languages.pop(language, None)
-            self._enchant_languages = self.enchant.list_languages()
-            self.unit_view.update_languages()
-        else:
-            logging.debug("Couldn't get a dictionary. Status code: %d" % (request.status))
-
     def _disable_checking(self, text_view):
         """Disable checking on the given text_view."""
         if getattr(text_view, 'spell_lang', 'xxxx') is None:
@@ -285,14 +171,10 @@ class Plugin(BasePlugin):
                     language = code
                     break
             else:
-                #logging.debug('No code in enchant.list_languages() that starts with "%s"' % (language))
-
-                # If we are on Windows or Mac, let's try to download a spell checker:
-                if platform.is_windows or platform.is_mac:
-                    self._download_checker(language)
-                    # If we get it, it will only be activated asynchronously
-                    # later
-                #TODO: packagekit on Linux?
+                # DictionaryDownloadWatcher (wired to LanguageController,
+                # not this per-textview signal) handles trying to
+                # download a missing dictionary - nothing to do here but
+                # degrade gracefully for now.
 
                 # We couldn't find a dictionary for "language", so we should make sure that we don't
                 # have a spell checker for a different language on the text view. See bug 717.

--- a/virtaal/support/dictionary_download_watcher.py
+++ b/virtaal/support/dictionary_download_watcher.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2026 Zuza Software Foundation
+#
+# This file is part of Virtaal.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+
+"""Downloads a missing spell-check dictionary in the background the
+first time a target language is selected that enchant has no
+dictionary for.
+
+Wired directly to LanguageController's own target-lang-changed signal,
+independent of spellchecker.py's Plugin (which refuses to load in any
+frozen build - exactly where this matters most, since there's no
+system package manager to fall back on) and of ChecksController.
+"""
+
+import logging
+
+from virtaal.support.dictionary_downloader import DictionaryDownloader
+
+_UNSET = object()
+
+
+class DictionaryDownloadWatcher:
+    """No-ops entirely if enchant isn't importable - same graceful
+    degradation as everywhere else spell checking touches this."""
+
+    def __init__(self, main_controller, enchant_module=_UNSET, downloader_factory=None):
+        if enchant_module is _UNSET:
+            try:
+                import enchant as enchant_module
+            except ImportError:
+                enchant_module = None
+        self._enchant = enchant_module
+        self._downloader_factory = downloader_factory or DictionaryDownloader
+        self._tried = set()
+        if self._enchant is not None:
+            main_controller.lang_controller.connect(
+                'target-lang-changed', self._on_target_lang_changed)
+
+    def _has_dictionary(self, language):
+        if self._enchant.dict_exists(language):
+            return True
+        # A bare language code ("de") counts as covered if a country
+        # variant ("de_DE") is already installed - same match
+        # spellchecker.py's own Plugin already does.
+        return any(code == language or code.startswith(language + '_')
+                   for code in self._enchant.list_languages())
+
+    def _on_target_lang_changed(self, _lang_controller, language):
+        if language in self._tried:
+            return
+        self._tried.add(language)
+        if self._has_dictionary(language):
+            return
+        self._downloader_factory(
+            language, on_done=lambda: self._on_done(language)).start()
+
+    def _on_done(self, language):
+        logging.debug('Dictionary download attempt finished for %s', language)

--- a/virtaal/support/dictionary_downloader.py
+++ b/virtaal/support/dictionary_downloader.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2026 Zuza Software Foundation
+#
+# This file is part of Virtaal.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+
+"""Downloads a missing spell-check dictionary in the background, via
+the app's own async HTTPClient - the non-blocking counterpart to
+dictionary_source.py's synchronous download_dictionary() (kept as-is:
+simpler, directly testable, still useful standalone).
+
+Reimplements dictionary_source.py's fetch/match orchestration as an
+explicit callback chain (tree -> candidate xcu(s) -> files), since
+find_dictionary()/download_dictionary() are both written as blocking
+loops - one request in flight at a time doesn't fit that shape. The
+pure logic (list_dictionary_folders/candidate_folders/
+parse_dictionaries_xcu) is reused unchanged.
+"""
+
+import json
+import logging
+import os
+
+from virtaal.support.dictionary_source import (
+    RAW_BASE,
+    TREE_URL,
+    candidate_folders,
+    dictionary_write_dir,
+    list_dictionary_folders,
+    parse_dictionaries_xcu,
+)
+
+
+class DictionaryDownloader:
+    """Downloads locale_code's hunspell dictionary in the background,
+    calling on_done() (no arguments) once it's either written or given
+    up. Silent on failure, same as UpdateChecker: network problems
+    must never surface as an application error to the user."""
+
+    def __init__(self, locale_code, on_done=None, client=None, target_dir=None):
+        self.locale_code = locale_code.replace('-', '_')
+        self.on_done = on_done or (lambda: None)
+        self.target_dir = target_dir
+        if client is None:
+            from virtaal.support.httpclient import HTTPClient
+            client = HTTPClient()
+            client.set_virtaal_useragent()
+        self._client = client
+        self._written = []
+
+    def start(self):
+        self._client.get(TREE_URL, self._on_tree, error_callback=self._on_error)
+
+    def _on_tree(self, _request, result):
+        try:
+            tree = json.loads(result.decode('utf-8'))
+        except (ValueError, UnicodeDecodeError) as e:
+            logging.debug('dictionary download: bad tree response: %s', e)
+            return self._give_up()
+        folders = list_dictionary_folders(tree)
+        candidates = candidate_folders(self.locale_code, folders)
+        self._remaining_folders = candidates + [f for f in folders if f not in candidates]
+        self._try_next_folder()
+
+    def _try_next_folder(self):
+        if not self._remaining_folders:
+            return self._give_up()
+        self._folder = self._remaining_folders.pop(0)
+        url = RAW_BASE + self._folder + '/dictionaries.xcu'
+        self._client.get(url, self._on_xcu, error_callback=self._on_xcu_error)
+
+    def _on_xcu_error(self, _request, _status):
+        self._try_next_folder()
+
+    def _on_xcu(self, _request, result):
+        for entry in parse_dictionaries_xcu(result):
+            if self.locale_code in entry['locales']:
+                self._files = list(entry['files'])
+                return self._fetch_next_file()
+        self._try_next_folder()
+
+    def _fetch_next_file(self):
+        if not self._files:
+            return self._on_success()
+        filename = self._files.pop(0)
+        url = RAW_BASE + self._folder + '/' + filename
+        self._client.get(
+            url,
+            lambda request, result, fn=filename: self._on_file(fn, result),
+            error_callback=lambda request, status, fn=filename: self._on_file_error(fn, status),
+        )
+
+    def _on_file(self, filename, result):
+        target_dir = self.target_dir or dictionary_write_dir()
+        os.makedirs(target_dir, exist_ok=True)
+        dest = os.path.join(target_dir, filename)
+        with open(dest, 'wb') as f:
+            f.write(result)
+        self._written.append(dest)
+        self._fetch_next_file()
+
+    def _on_file_error(self, filename, status):
+        logging.debug('dictionary download: could not get %s/%s: status=%r',
+                       self._folder, filename, status)
+        for path in self._written:
+            os.remove(path)
+        self._give_up()
+
+    def _on_success(self):
+        logging.debug('Downloaded dictionary for %s', self.locale_code)
+        self.on_done()
+
+    def _on_error(self, _request, status):
+        logging.debug('dictionary download: request failed, status=%r', status)
+        self._give_up()
+
+    def _give_up(self):
+        logging.debug('No LibreOffice dictionary found for %s', self.locale_code)
+        self.on_done()

--- a/virtaal/support/dictionary_source.py
+++ b/virtaal/support/dictionary_source.py
@@ -177,15 +177,11 @@ def dictionary_write_dir():
     """Where enchant's hunspell backend looks for user-installed
     dictionaries.
 
-    NOT independently verified on every platform - built from
-    enchant's own get_user_config_dir() (the one per-user directory
-    pyenchant itself exposes cross-platform) plus a "hunspell"
-    subdirectory, the naming the currently-bundled Windows dictionaries
-    already use (enchant/data/mingw64/share/enchant/hunspell/ in that
-    wheel). Confirming this against a real hunspell-enabled enchant
-    install (this session's own dev machine only had aspell/AppleSpell
-    providers available, not hunspell) is a real follow-up, not done
-    here.
+    Confirmed against libenchant's own current source (rrthomas/enchant,
+    lib/provider.vala): a provider's user dict dir is
+    get_user_config_dir()/<provider's own identify string>, and the
+    hunspell provider's identify() returns literally "hunspell" -
+    matching enchant.get_user_config_dir() (Python) plus that name.
     """
     import enchant
     return os.path.join(enchant.get_user_config_dir(), 'hunspell')

--- a/virtaal/support/dictionary_source.py
+++ b/virtaal/support/dictionary_source.py
@@ -213,6 +213,11 @@ def download_dictionary(locale_code, target_dir=None):
             content = fetch_dictionary_file(folder, filename)
         except (HTTPError, URLError) as e:
             logging.warning('Could not download %s/%s: %s', folder, filename, e)
+            # A dictionary needs every one of its files (e.g. .aff
+            # without .dic is useless to enchant) - don't leave a
+            # partial one behind for a later run to mistake as real.
+            for path in written:
+                os.remove(path)
             return None
         dest = os.path.join(target_dir, filename)
         with open(dest, 'wb') as f:

--- a/virtaal/support/test_dictionary_download_watcher.py
+++ b/virtaal/support/test_dictionary_download_watcher.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2026 Zuza Software Foundation
+#
+# This file is part of Virtaal.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+
+from virtaal.support.dictionary_download_watcher import DictionaryDownloadWatcher
+
+
+class _FakeLangController:
+    def __init__(self):
+        self.handlers = {}
+
+    def connect(self, signal, handler):
+        self.handlers[signal] = handler
+
+    def emit_target_lang_changed(self, language):
+        self.handlers['target-lang-changed'](self, language)
+
+
+class _FakeMainController:
+    def __init__(self):
+        self.lang_controller = _FakeLangController()
+
+
+class _FakeEnchant:
+    def __init__(self, known_dicts=()):
+        self.known_dicts = set(known_dicts)
+        self.checked = []
+
+    def dict_exists(self, language):
+        self.checked.append(language)
+        return language in self.known_dicts
+
+    def list_languages(self):
+        return list(self.known_dicts)
+
+
+class _FakeDownloader:
+    instances = []
+
+    def __init__(self, language, on_done=None):
+        self.language = language
+        self.on_done = on_done
+        self.started = False
+        _FakeDownloader.instances.append(self)
+
+    def start(self):
+        self.started = True
+
+
+def _make_watcher(known_dicts=()):
+    _FakeDownloader.instances = []
+    main_controller = _FakeMainController()
+    watcher = DictionaryDownloadWatcher(
+        main_controller,
+        enchant_module=_FakeEnchant(known_dicts),
+        downloader_factory=_FakeDownloader,
+    )
+    return main_controller, watcher
+
+
+def test_does_not_connect_at_all_without_enchant():
+    main_controller = _FakeMainController()
+    DictionaryDownloadWatcher(main_controller, enchant_module=None)
+    assert main_controller.lang_controller.handlers == {}
+
+
+def test_skips_download_when_dictionary_already_exists():
+    main_controller, _watcher = _make_watcher(known_dicts={'de_DE'})
+    main_controller.lang_controller.emit_target_lang_changed('de_DE')
+    assert _FakeDownloader.instances == []
+
+
+def test_skips_download_when_a_country_variant_covers_a_bare_code():
+    main_controller, _watcher = _make_watcher(known_dicts={'de_DE'})
+    main_controller.lang_controller.emit_target_lang_changed('de')
+    assert _FakeDownloader.instances == []
+
+
+def test_starts_a_download_when_nothing_covers_the_language():
+    main_controller, _watcher = _make_watcher(known_dicts=set())
+    main_controller.lang_controller.emit_target_lang_changed('af_ZA')
+    assert len(_FakeDownloader.instances) == 1
+    assert _FakeDownloader.instances[0].language == 'af_ZA'
+    assert _FakeDownloader.instances[0].started
+
+
+def test_only_tries_each_language_once_per_run():
+    main_controller, _watcher = _make_watcher(known_dicts=set())
+    main_controller.lang_controller.emit_target_lang_changed('af_ZA')
+    main_controller.lang_controller.emit_target_lang_changed('af_ZA')
+    assert len(_FakeDownloader.instances) == 1
+
+
+def test_on_done_callback_does_not_raise():
+    main_controller, _watcher = _make_watcher(known_dicts=set())
+    main_controller.lang_controller.emit_target_lang_changed('af_ZA')
+    _FakeDownloader.instances[0].on_done()  # must not raise

--- a/virtaal/support/test_dictionary_downloader.py
+++ b/virtaal/support/test_dictionary_downloader.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2026 Zuza Software Foundation
+#
+# This file is part of Virtaal.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for DictionaryDownloader's callback-chain orchestration - a
+_FakeClient records each .get() call instead of doing real network
+I/O, so the test drives the chain step by step, synchronously."""
+
+import json
+import os
+
+from virtaal.support.dictionary_downloader import DictionaryDownloader
+from virtaal.support.test_dictionary_source import AR_XCU, DE_XCU
+
+TREE_RESULT = json.dumps({
+    'tree': [
+        {'path': 'de/dictionaries.xcu'},
+        {'path': 'ar/dictionaries.xcu'},
+    ],
+}).encode('utf-8')
+
+
+class _FakeClient:
+    def __init__(self):
+        self.calls = []
+
+    def get(self, url, callback, error_callback=None):
+        self.calls.append((url, callback, error_callback))
+
+    def last_url(self):
+        return self.calls[-1][0]
+
+
+def test_full_chain_writes_both_files(tmp_path):
+    client = _FakeClient()
+    done = []
+    downloader = DictionaryDownloader('de_DE', on_done=lambda: done.append(True),
+                                       client=client, target_dir=str(tmp_path))
+
+    downloader.start()
+    assert client.last_url().endswith('/git/trees/master?recursive=1')
+
+    _, tree_cb, _ = client.calls[-1]
+    tree_cb(None, TREE_RESULT)
+    assert client.last_url() == 'https://raw.githubusercontent.com/LibreOffice/dictionaries/master/de/dictionaries.xcu'
+
+    _, xcu_cb, _ = client.calls[-1]
+    xcu_cb(None, DE_XCU)
+    assert client.last_url().endswith('de_DE_frami.aff')
+
+    _, aff_cb, _ = client.calls[-1]
+    aff_cb(None, b'aff content')
+    assert client.last_url().endswith('de_DE_frami.dic')
+
+    _, dic_cb, _ = client.calls[-1]
+    dic_cb(None, b'dic content')
+
+    assert done == [True]
+    assert (tmp_path / 'de_DE_frami.aff').read_bytes() == b'aff content'
+    assert (tmp_path / 'de_DE_frami.dic').read_bytes() == b'dic content'
+
+
+def test_xcu_error_tries_the_next_folder(tmp_path):
+    client = _FakeClient()
+    done = []
+    downloader = DictionaryDownloader('ar_EG', on_done=lambda: done.append(True),
+                                       client=client, target_dir=str(tmp_path))
+
+    downloader.start()
+    _, tree_cb, _ = client.calls[-1]
+    tree_cb(None, TREE_RESULT)
+    # 'ar_EG' has no exact/bare-language candidate folder among
+    # {'de', 'ar'} that matches its own prefix ('ar_EG' -> 'ar' is a
+    # candidate, but suppose it 404s) - a failure on one folder tries
+    # the next rather than giving up outright.
+    assert client.last_url().endswith('ar/dictionaries.xcu')
+    _, xcu_cb, xcu_err = client.calls[-1]
+    xcu_err(None, 404)
+
+    assert client.last_url().endswith('de/dictionaries.xcu')
+
+
+def test_no_matching_locale_gives_up(tmp_path):
+    client = _FakeClient()
+    done = []
+    downloader = DictionaryDownloader('xx_YY', on_done=lambda: done.append(True),
+                                       client=client, target_dir=str(tmp_path))
+
+    downloader.start()
+    _, tree_cb, _ = client.calls[-1]
+    tree_cb(None, TREE_RESULT)
+    _, xcu_cb, _ = client.calls[-1]
+    xcu_cb(None, DE_XCU)
+    _, xcu_cb2, _ = client.calls[-1]
+    xcu_cb2(None, AR_XCU)
+
+    assert done == [True]
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_file_error_cleans_up_and_gives_up(tmp_path):
+    client = _FakeClient()
+    done = []
+    downloader = DictionaryDownloader('de_DE', on_done=lambda: done.append(True),
+                                       client=client, target_dir=str(tmp_path))
+
+    downloader.start()
+    _, tree_cb, _ = client.calls[-1]
+    tree_cb(None, TREE_RESULT)
+    _, xcu_cb, _ = client.calls[-1]
+    xcu_cb(None, DE_XCU)
+
+    _, aff_cb, _ = client.calls[-1]
+    aff_cb(None, b'aff content')
+    assert (tmp_path / 'de_DE_frami.aff').exists()
+
+    _, _dic_cb, dic_err = client.calls[-1]
+    dic_err(None, 500)
+
+    assert done == [True]
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_bad_tree_response_gives_up(tmp_path):
+    client = _FakeClient()
+    done = []
+    downloader = DictionaryDownloader('de_DE', on_done=lambda: done.append(True),
+                                       client=client, target_dir=str(tmp_path))
+
+    downloader.start()
+    _, tree_cb, _ = client.calls[-1]
+    tree_cb(None, b'not json')
+
+    assert done == [True]
+
+
+def test_tree_request_error_gives_up(tmp_path):
+    client = _FakeClient()
+    done = []
+    downloader = DictionaryDownloader('de_DE', on_done=lambda: done.append(True),
+                                       client=client, target_dir=str(tmp_path))
+
+    downloader.start()
+    _, _tree_cb, tree_err = client.calls[-1]
+    tree_err(None, 500)
+
+    assert done == [True]
+
+
+def test_default_on_done_is_a_noop(tmp_path):
+    """on_done is optional - a missing callback must not raise."""
+    client = _FakeClient()
+    downloader = DictionaryDownloader('xx_YY', client=client, target_dir=str(tmp_path))
+    downloader.start()
+    _, tree_cb, _ = client.calls[-1]
+    tree_cb(None, TREE_RESULT)
+    _, xcu_cb, _ = client.calls[-1]
+    xcu_cb(None, DE_XCU)
+    _, xcu_cb2, _ = client.calls[-1]
+    xcu_cb2(None, AR_XCU)  # no exception
+
+
+def test_default_target_dir_is_dictionary_write_dir(monkeypatch):
+    import virtaal.support.dictionary_downloader as dictionary_downloader
+    monkeypatch.setattr(dictionary_downloader, 'dictionary_write_dir', lambda: '/fake/dir')
+    client = _FakeClient()
+    downloader = DictionaryDownloader('de_DE', client=client)
+    downloader.start()
+    _, tree_cb, _ = client.calls[-1]
+    tree_cb(None, TREE_RESULT)
+    _, xcu_cb, _ = client.calls[-1]
+    xcu_cb(None, DE_XCU)
+    _, aff_cb, _ = client.calls[-1]
+
+    written = []
+    real_open = open
+
+    def fake_open(path, *args, **kwargs):
+        written.append(path)
+        return real_open(os.devnull, *args, **kwargs)
+
+    monkeypatch.setattr('builtins.open', fake_open)
+    monkeypatch.setattr('os.makedirs', lambda *a, **k: None)
+    aff_cb(None, b'aff content')
+
+    assert written == [os.path.join('/fake/dir', 'de_DE_frami.aff')]

--- a/virtaal/support/test_dictionary_source.py
+++ b/virtaal/support/test_dictionary_source.py
@@ -19,15 +19,20 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 """Tests for dictionary_source's pure enumerate/parse/match logic - the
-network calls themselves are thin, untested wrappers (see that
-module's own docstring); what's tested here is real content (fixtures
-below are actual copies from github.com/LibreOffice/dictionaries, not
-hand-written guesses), so a real repo-shape change would actually be
-caught.
+raw network calls (fetch_dictionary_tree/fetch_xcu/fetch_dictionary_file)
+are thin, untested wrappers (see that module's own docstring);
+download_dictionary()'s own orchestration is tested here with those
+three monkeypatched away. Fixtures below are actual copies from
+github.com/LibreOffice/dictionaries, not hand-written guesses, so a
+real repo-shape change would actually be caught.
 """
 
+from urllib.error import URLError
+
+from virtaal.support import dictionary_source
 from virtaal.support.dictionary_source import (
     candidate_folders,
+    download_dictionary,
     find_dictionary,
     list_dictionary_folders,
     parse_dictionaries_xcu,
@@ -184,3 +189,23 @@ def test_find_dictionary_falls_back_to_scanning_other_folders():
 def test_find_dictionary_returns_none_when_nothing_matches():
     result = find_dictionary('xx_YY', {'de': 's1'}, lambda folder: DE_XCU)
     assert result is None
+
+
+def test_download_dictionary_cleans_up_partial_write_on_failure(monkeypatch, tmp_path):
+    """de_DE_frami has two files - if the second one fails, the first
+    must not be left behind for a later run to mistake as a complete,
+    real dictionary."""
+    monkeypatch.setattr(dictionary_source, 'fetch_dictionary_tree',
+                         lambda: {'tree': [{'path': 'de/dictionaries.xcu'}]})
+    monkeypatch.setattr(dictionary_source, 'fetch_xcu', lambda folder: DE_XCU)
+
+    def fetch_dictionary_file(folder, filename):
+        if filename.endswith('.dic'):
+            raise URLError('boom')
+        return b'aff content'
+    monkeypatch.setattr(dictionary_source, 'fetch_dictionary_file', fetch_dictionary_file)
+
+    result = download_dictionary('de_DE', target_dir=str(tmp_path))
+
+    assert result is None
+    assert list(tmp_path.iterdir()) == []


### PR DESCRIPTION
Wires dictionary_source.py (#3424) into a real, non-blocking download flow.

- `dictionary_write_dir()`'s target path confirmed against libenchant's own current source (hunspell provider's `identify()` returns `"hunspell"`) - was a documented guess, now confirmed.
- Fixed `download_dictionary()` leaving a partial dictionary behind if one of its files failed to fetch.
- `DictionaryDownloader`: the same enumerate/match/download orchestration as an async `HTTPClient` callback chain, reusing the pure parsing logic unchanged.
- `DictionaryDownloadWatcher`: wired directly to `LanguageController`'s `target-lang-changed` - deliberately *not* inside `spellchecker.py`'s `Plugin`, which refuses to load in any frozen build (exactly where this matters most, since there's no system package manager to fall back on).
- Removed `spellchecker.py`'s old `_download_checker`/`_process_tarball` - pointed at a dead host (`dictionary.locamotion.org`), expected a tarball shape LibreOffice's repo doesn't have, and wrote to a `myspell` directory libenchant's hunspell provider hasn't used in years. Three independent ways it never actually worked, now fully superseded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)