### PR TITLE
Install intltool in CI's pre-commit job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,14 @@ jobs:
         with:
           python-version: "3.x"
 
+      - name: Install system dependencies
+        # intltool-update: po/check-pot-freshness.sh needs it to check
+        # po/virtaal.pot against po/POTFILES.in; without it, that hook
+        # silently no-ops instead of enforcing anything.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y intltool
+
       - name: Install pre-commit
         run: pip install pre-commit
 

--- a/po/check-pot-freshness.sh
+++ b/po/check-pot-freshness.sh
@@ -18,7 +18,7 @@
 # Requires `intltool-update` on PATH (`brew install intltool` /
 # `apt install intltool`). Not everyone doing a routine commit will have
 # it installed - this degrades to a note, not a failure, in that case;
-# CI's docs-and-translations job always has it and is the real backstop.
+# CI's pre-commit job always has it and is the real backstop.
 set -eu
 cd "$(git rev-parse --show-toplevel)"
 
@@ -76,7 +76,7 @@ if ! command -v intltool-update >/dev/null 2>&1; then
     echo "NOTE: a file listed in po/POTFILES.in changed, but intltool-update" >&2
     echo "isn't installed here to check whether po/virtaal.pot needs" >&2
     echo "regenerating (brew install intltool / apt install intltool)." >&2
-    echo "CI's docs-and-translations job will still catch it if this is missed." >&2
+    echo "CI's pre-commit job will still catch it if this is missed." >&2
     exit 0
 fi
 


### PR DESCRIPTION
check-pot-freshness.sh silently no-ops without intltool-update on PATH - CI's pre-commit job never had it, so pot freshness was never actually enforced there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)