### PR TITLE
Drop dead python shebangs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,6 +45,7 @@ repos:
         entry: po/check-pot-freshness.sh
         language: system
         pass_filenames: true
+        require_serial: true
       - id: check-icons-freshness
         name: check macOS .icns files are up to date with their .svg sources
         entry: devsupport/mac-bundle/check_icons_freshness.sh

--- a/devsupport/__init__.py
+++ b/devsupport/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2009 Zuza Software Foundation
 #

--- a/devsupport/debugging.py
+++ b/devsupport/debugging.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2009 Zuza Software Foundation
 #

--- a/devsupport/packaging/macos/generate_info_plist.py
+++ b/devsupport/packaging/macos/generate_info_plist.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 #
 # Copyright 2026 Zuza Software Foundation
 #

--- a/devsupport/profiling.py
+++ b/devsupport/profiling.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2009 Zuza Software Foundation
 #

--- a/devsupport/pseudo-translation/generate_pseudo_translation.py
+++ b/devsupport/pseudo-translation/generate_pseudo_translation.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Generates synthetic gettext locales from po/virtaal.pot, for
 exercising every translatable string in the UI without an actual
 translation:

--- a/devsupport/testing/fuzz/fuzz_ui.py
+++ b/devsupport/testing/fuzz/fuzz_ui.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2026 Zuza Software Foundation
 #

--- a/devsupport/tmp_strings.py
+++ b/devsupport/tmp_strings.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2009 Zuza Software Foundation
 #

--- a/virtaal/__init__.py
+++ b/virtaal/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2009 Zuza Software Foundation
 #

--- a/virtaal/__version__.py
+++ b/virtaal/__version__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2009 Zuza Software Foundation
 #

--- a/virtaal/common/__init__.py
+++ b/virtaal/common/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2009 Zuza Software Foundation
 #

--- a/virtaal/common/gobjectwrapper.py
+++ b/virtaal/common/gobjectwrapper.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2010 Zuza Software Foundation
 #

--- a/virtaal/common/pan_app.py
+++ b/virtaal/common/pan_app.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2007-2010 Zuza Software Foundation
 # Copyright 2013-2014 F Wolff

--- a/virtaal/common/platform.py
+++ b/virtaal/common/platform.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2026 Zuza Software Foundation
 #

--- a/virtaal/common/test_pan_app.py
+++ b/virtaal/common/test_pan_app.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2026 Zuza Software Foundation
 #

--- a/virtaal/common/test_platform.py
+++ b/virtaal/common/test_platform.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2026 Zuza Software Foundation
 #

--- a/virtaal/controllers/__init__.py
+++ b/virtaal/controllers/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2010 Zuza Software Foundation
 #

--- a/virtaal/controllers/basecontroller.py
+++ b/virtaal/controllers/basecontroller.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2009 Zuza Software Foundation
 #

--- a/virtaal/controllers/baseplugin.py
+++ b/virtaal/controllers/baseplugin.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2009 Zuza Software Foundation
 #

--- a/virtaal/controllers/cursor.py
+++ b/virtaal/controllers/cursor.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2009 Zuza Software Foundation
 #

--- a/virtaal/controllers/langcontroller.py
+++ b/virtaal/controllers/langcontroller.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2009-2011 Zuza Software Foundation
 #

--- a/virtaal/controllers/maincontroller.py
+++ b/virtaal/controllers/maincontroller.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2010 Zuza Software Foundation
 # Copyright 2013 F Wolff

--- a/virtaal/controllers/modecontroller.py
+++ b/virtaal/controllers/modecontroller.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2009 Zuza Software Foundation
 #

--- a/virtaal/controllers/placeablescontroller.py
+++ b/virtaal/controllers/placeablescontroller.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2009-2010 Zuza Software Foundation
 # Copyright 2016 F Wolff

--- a/virtaal/controllers/plugincontroller.py
+++ b/virtaal/controllers/plugincontroller.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2011 Zuza Software Foundation
 #

--- a/virtaal/controllers/prefscontroller.py
+++ b/virtaal/controllers/prefscontroller.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2009 Zuza Software Foundation
 #

--- a/virtaal/controllers/propertiescontroller.py
+++ b/virtaal/controllers/propertiescontroller.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2011 Zuza Software Foundation
 #

--- a/virtaal/controllers/storecontroller.py
+++ b/virtaal/controllers/storecontroller.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2010 Zuza Software Foundation
 # Copyright 2014 F Wolff

--- a/virtaal/controllers/unitcontroller.py
+++ b/virtaal/controllers/unitcontroller.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2011 Zuza Software Foundation
 #

--- a/virtaal/controllers/welcomescreencontroller.py
+++ b/virtaal/controllers/welcomescreencontroller.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2011 Zuza Software Foundation
 # Copyright 2014 F Wolff

--- a/virtaal/main.py
+++ b/virtaal/main.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2011 Zuza Software Foundation
 # Copyright 2013-2014 F Wolff

--- a/virtaal/models/__init__.py
+++ b/virtaal/models/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2009 Zuza Software Foundation
 #

--- a/virtaal/models/basemodel.py
+++ b/virtaal/models/basemodel.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2009 Zuza Software Foundation
 #

--- a/virtaal/models/langmodel.py
+++ b/virtaal/models/langmodel.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2009 Zuza Software Foundation
 #

--- a/virtaal/models/storemodel.py
+++ b/virtaal/models/storemodel.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2011 Zuza Software Foundation
 #

--- a/virtaal/models/undomodel.py
+++ b/virtaal/models/undomodel.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2009 Zuza Software Foundation
 # Copyright 2013 F Wolff

--- a/virtaal/modes/__init__.py
+++ b/virtaal/modes/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2010 Zuza Software Foundation
 #

--- a/virtaal/modes/basemode.py
+++ b/virtaal/modes/basemode.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2009 Zuza Software Foundation
 #

--- a/virtaal/modes/defaultmode.py
+++ b/virtaal/modes/defaultmode.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2009 Zuza Software Foundation
 #

--- a/virtaal/modes/qualitycheckmode.py
+++ b/virtaal/modes/qualitycheckmode.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2010-2011 Zuza Software Foundation
 #

--- a/virtaal/modes/quicktransmode.py
+++ b/virtaal/modes/quicktransmode.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2009 Zuza Software Foundation
 #

--- a/virtaal/modes/searchmode.py
+++ b/virtaal/modes/searchmode.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2011 Zuza Software Foundation
 # Copyright 2013,2015,2016 F Wolff

--- a/virtaal/modes/test_searchmode.py
+++ b/virtaal/modes/test_searchmode.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2026 Zuza Software Foundation
 #

--- a/virtaal/modes/workflowmode.py
+++ b/virtaal/modes/workflowmode.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2010-2011 Zuza Software Foundation
 #

--- a/virtaal/plugins/__init__.py
+++ b/virtaal/plugins/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2009 Zuza Software Foundation
 #

--- a/virtaal/plugins/_helloworld.py
+++ b/virtaal/plugins/_helloworld.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2009 Zuza Software Foundation
 #

--- a/virtaal/plugins/_ipython_console/__init__.py
+++ b/virtaal/plugins/_ipython_console/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 
 from gi.repository import Gdk
 from gi.repository import Gtk

--- a/virtaal/plugins/_ipython_console/ipython_view.py
+++ b/virtaal/plugins/_ipython_console/ipython_view.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 '''
 Provides IPython console widget.
 

--- a/virtaal/plugins/_python_console.py
+++ b/virtaal/plugins/_python_console.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 
 import re
 import sys

--- a/virtaal/plugins/autocompletor.py
+++ b/virtaal/plugins/autocompletor.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2010 Zuza Software Foundation
 # Copyright 2013 F Wolff

--- a/virtaal/plugins/autocorrector.py
+++ b/virtaal/plugins/autocorrector.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2009 Zuza Software Foundation
 # Copyright 2013 F Wolff

--- a/virtaal/plugins/lookup/__init__.py
+++ b/virtaal/plugins/lookup/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2009 Zuza Software Foundation
 #

--- a/virtaal/plugins/lookup/lookupcontroller.py
+++ b/virtaal/plugins/lookup/lookupcontroller.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2009 Zuza Software Foundation
 #

--- a/virtaal/plugins/lookup/models/__init__.py
+++ b/virtaal/plugins/lookup/models/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2009 Zuza Software Foundation
 #

--- a/virtaal/plugins/lookup/models/baselookupmodel.py
+++ b/virtaal/plugins/lookup/models/baselookupmodel.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2009 Zuza Software Foundation
 #

--- a/virtaal/plugins/lookup/models/weblookup.py
+++ b/virtaal/plugins/lookup/models/weblookup.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2009 Zuza Software Foundation
 # Copyright 2014 F Wolff

--- a/virtaal/plugins/migration.py
+++ b/virtaal/plugins/migration.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2009 Zuza Software Foundation
 #

--- a/virtaal/plugins/spellchecker.py
+++ b/virtaal/plugins/spellchecker.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2010-2011 Zuza Software Foundation
 #

--- a/virtaal/plugins/terminology/__init__.py
+++ b/virtaal/plugins/terminology/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2009 Zuza Software Foundation
 # Copyright 2014 F Wolff

--- a/virtaal/plugins/terminology/models/__init__.py
+++ b/virtaal/plugins/terminology/models/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2009 Zuza Software Foundation
 #

--- a/virtaal/plugins/terminology/models/autoterm.py
+++ b/virtaal/plugins/terminology/models/autoterm.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2009-2010 Zuza Software Foundation
 #

--- a/virtaal/plugins/terminology/models/basetermmodel.py
+++ b/virtaal/plugins/terminology/models/basetermmodel.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2009 Zuza Software Foundation
 #

--- a/virtaal/plugins/terminology/models/localfile/__init__.py
+++ b/virtaal/plugins/terminology/models/localfile/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2009 Zuza Software Foundation
 #

--- a/virtaal/plugins/terminology/models/pontoon.py
+++ b/virtaal/plugins/terminology/models/pontoon.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2009-2010 Zuza Software Foundation
 #

--- a/virtaal/plugins/terminology/models/test_pontoon.py
+++ b/virtaal/plugins/terminology/models/test_pontoon.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2026 Zuza Software Foundation
 #

--- a/virtaal/plugins/terminology/termcontroller.py
+++ b/virtaal/plugins/terminology/termcontroller.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2009-2010 Zuza Software Foundation
 #

--- a/virtaal/plugins/terminology/termview.py
+++ b/virtaal/plugins/terminology/termview.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2009-2011 Zuza Software Foundation
 #

--- a/virtaal/plugins/test_autocorrector.py
+++ b/virtaal/plugins/test_autocorrector.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2026 Zuza Software Foundation
 #

--- a/virtaal/plugins/test_spellchecker.py
+++ b/virtaal/plugins/test_spellchecker.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2026 Zuza Software Foundation
 #

--- a/virtaal/plugins/tm/__init__.py
+++ b/virtaal/plugins/tm/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2009 Zuza Software Foundation
 # Copyright 2014 F Wolff

--- a/virtaal/plugins/tm/models/__init__.py
+++ b/virtaal/plugins/tm/models/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2009 Zuza Software Foundation
 #

--- a/virtaal/plugins/tm/models/_dummytm.py
+++ b/virtaal/plugins/tm/models/_dummytm.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2009 Zuza Software Foundation
 #

--- a/virtaal/plugins/tm/models/apertium.py
+++ b/virtaal/plugins/tm/models/apertium.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2009-2010 Zuza Software Foundation
 #

--- a/virtaal/plugins/tm/models/basetmmodel.py
+++ b/virtaal/plugins/tm/models/basetmmodel.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2009 Zuza Software Foundation
 #

--- a/virtaal/plugins/tm/models/currentfile.py
+++ b/virtaal/plugins/tm/models/currentfile.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2011 Zuza Software Foundation
 #

--- a/virtaal/plugins/tm/models/google_translate.py
+++ b/virtaal/plugins/tm/models/google_translate.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2009 Zuza Software Foundation
 # Copyright 2014 F Wolff

--- a/virtaal/plugins/tm/models/localtm.py
+++ b/virtaal/plugins/tm/models/localtm.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2009,2011 Zuza Software Foundation
 #

--- a/virtaal/plugins/tm/models/moses.py
+++ b/virtaal/plugins/tm/models/moses.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2009-2011 Zuza Software Foundation
 #

--- a/virtaal/plugins/tm/models/remotetm.py
+++ b/virtaal/plugins/tm/models/remotetm.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2011 Zuza Software Foundation
 #

--- a/virtaal/plugins/tm/models/test_basetmmodel.py
+++ b/virtaal/plugins/tm/models/test_basetmmodel.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2009 Zuza Software Foundation
 #

--- a/virtaal/plugins/tm/tmcontroller.py
+++ b/virtaal/plugins/tm/tmcontroller.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2011 Zuza Software Foundation
 # Copyright 2016 F Wolff

--- a/virtaal/plugins/tm/tmview.py
+++ b/virtaal/plugins/tm/tmview.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2011 Zuza Software Foundation
 # Copyright 2016 F Wolff

--- a/virtaal/plugins/tm/tmwidgets.py
+++ b/virtaal/plugins/tm/tmwidgets.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2010 Zuza Software Foundation
 #

--- a/virtaal/support/__init__.py
+++ b/virtaal/support/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2009 Zuza Software Foundation
 #

--- a/virtaal/support/autocorrect_downloader.py
+++ b/virtaal/support/autocorrect_downloader.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2026 Zuza Software Foundation
 #

--- a/virtaal/support/autocorrect_source.py
+++ b/virtaal/support/autocorrect_source.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2026 Zuza Software Foundation
 #

--- a/virtaal/support/depcheck.py
+++ b/virtaal/support/depcheck.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2009-2010 Zuza Software Foundation
 # Copyright 2013,2015 F Wolff

--- a/virtaal/support/dictionary_download_watcher.py
+++ b/virtaal/support/dictionary_download_watcher.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2026 Zuza Software Foundation
 #

--- a/virtaal/support/dictionary_downloader.py
+++ b/virtaal/support/dictionary_downloader.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2026 Zuza Software Foundation
 #

--- a/virtaal/support/dictionary_source.py
+++ b/virtaal/support/dictionary_source.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2026 Zuza Software Foundation
 #

--- a/virtaal/support/libi18n/__init__.py
+++ b/virtaal/support/libi18n/__init__.py
@@ -1,1 +1,0 @@
-#!/usr/bin/env python

--- a/virtaal/support/libi18n/locale.py
+++ b/virtaal/support/libi18n/locale.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright (C) 2007-2008 Dieter Verfaillie <dieterv@optionexplicit.be>
 # Copyright 2009-2010 Zuza Software Foundation

--- a/virtaal/support/mosesclient.py
+++ b/virtaal/support/mosesclient.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2011 Zuza Software Foundation
 #

--- a/virtaal/support/openmailto.py
+++ b/virtaal/support/openmailto.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2009 Zuza Software Foundation
 #

--- a/virtaal/support/set_enumerator.py
+++ b/virtaal/support/set_enumerator.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2007-2009,2011 Zuza Software Foundation
 #

--- a/virtaal/support/simplegeneric.py
+++ b/virtaal/support/simplegeneric.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2009 Zuza Software Foundation
 #

--- a/virtaal/support/sorted_set.py
+++ b/virtaal/support/sorted_set.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2007-2009 Zuza Software Foundation
 #

--- a/virtaal/support/test_autocorrect_downloader.py
+++ b/virtaal/support/test_autocorrect_downloader.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2026 Zuza Software Foundation
 #

--- a/virtaal/support/test_autocorrect_source.py
+++ b/virtaal/support/test_autocorrect_source.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2026 Zuza Software Foundation
 #

--- a/virtaal/support/test_dictionary_download_watcher.py
+++ b/virtaal/support/test_dictionary_download_watcher.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2026 Zuza Software Foundation
 #

--- a/virtaal/support/test_dictionary_downloader.py
+++ b/virtaal/support/test_dictionary_downloader.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2026 Zuza Software Foundation
 #

--- a/virtaal/support/test_dictionary_source.py
+++ b/virtaal/support/test_dictionary_source.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2026 Zuza Software Foundation
 #

--- a/virtaal/support/test_tmclient.py
+++ b/virtaal/support/test_tmclient.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2026 Zuza Software Foundation
 #

--- a/virtaal/support/test_update_check.py
+++ b/virtaal/support/test_update_check.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2026 Zuza Software Foundation
 #

--- a/virtaal/support/tmclient.py
+++ b/virtaal/support/tmclient.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2010 Zuza Software Foundation
 # Copyright 2013 F Wolff

--- a/virtaal/support/tutorial.py
+++ b/virtaal/support/tutorial.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2013 Zuza Software Foundation
 # Copyright 2012 Leandro Regueiro Iglesias

--- a/virtaal/support/update_check.py
+++ b/virtaal/support/update_check.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2026 Zuza Software Foundation
 #

--- a/virtaal/test/test_langmodel.py
+++ b/virtaal/test/test_langmodel.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2026 Zuza Software Foundation
 #

--- a/virtaal/test/test_maincontroller.py
+++ b/virtaal/test/test_maincontroller.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2009 Zuza Software Foundation
 #

--- a/virtaal/test/test_modecontroller.py
+++ b/virtaal/test/test_modecontroller.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2009 Zuza Software Foundation
 #

--- a/virtaal/test/test_scaffolding.py
+++ b/virtaal/test/test_scaffolding.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2009 Zuza Software Foundation
 #

--- a/virtaal/test/test_storecontroller.py
+++ b/virtaal/test/test_storecontroller.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2009 Zuza Software Foundation
 #

--- a/virtaal/test/test_storecursor.py
+++ b/virtaal/test/test_storecursor.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2009 Zuza Software Foundation
 #

--- a/virtaal/test/test_storemodel.py
+++ b/virtaal/test/test_storemodel.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2009 Zuza Software Foundation
 #

--- a/virtaal/test/test_unitcontroller.py
+++ b/virtaal/test/test_unitcontroller.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2009 Zuza Software Foundation
 #

--- a/virtaal/test_version.py
+++ b/virtaal/test_version.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2026 Zuza Software Foundation
 #

--- a/virtaal/tips.py
+++ b/virtaal/tips.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2007-2009 Zuza Software Foundation
 #

--- a/virtaal/views/__init__.py
+++ b/virtaal/views/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2009 Zuza Software Foundation
 #

--- a/virtaal/views/baseview.py
+++ b/virtaal/views/baseview.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2009 Zuza Software Foundation
 # Copyright 2013 F Wolff

--- a/virtaal/views/checksunitview.py
+++ b/virtaal/views/checksunitview.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2010 Zuza Software Foundation
 #

--- a/virtaal/views/langview.py
+++ b/virtaal/views/langview.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2009-2011 Zuza Software Foundation
 #

--- a/virtaal/views/markup.py
+++ b/virtaal/views/markup.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2007-2011 Zuza Software Foundation
 # Copyright 2014 F Wolff

--- a/virtaal/views/modeview.py
+++ b/virtaal/views/modeview.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2009 Zuza Software Foundation
 #

--- a/virtaal/views/placeablesguiinfo.py
+++ b/virtaal/views/placeablesguiinfo.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2009-2010 Zuza Software Foundation
 # Copyright 2013,2016 F Wolff

--- a/virtaal/views/prefsview.py
+++ b/virtaal/views/prefsview.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2009 Zuza Software Foundation
 #

--- a/virtaal/views/propertiesview.py
+++ b/virtaal/views/propertiesview.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2011 Zuza Software Foundation
 # Copyright 2016 F Wolff

--- a/virtaal/views/recent.py
+++ b/virtaal/views/recent.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2009 Zuza Software Foundation
 #

--- a/virtaal/views/rendering.py
+++ b/virtaal/views/rendering.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2009 Zuza Software Foundation
 #

--- a/virtaal/views/storeview.py
+++ b/virtaal/views/storeview.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2011 Zuza Software Foundation
 #

--- a/virtaal/views/test_mainview.py
+++ b/virtaal/views/test_mainview.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2026 Zuza Software Foundation
 #

--- a/virtaal/views/test_markup.py
+++ b/virtaal/views/test_markup.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2026 Zuza Software Foundation
 #

--- a/virtaal/views/test_modeview.py
+++ b/virtaal/views/test_modeview.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2026 Zuza Software Foundation
 #

--- a/virtaal/views/test_propertiesview.py
+++ b/virtaal/views/test_propertiesview.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2026 Zuza Software Foundation
 #

--- a/virtaal/views/theme.py
+++ b/virtaal/views/theme.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2010 Zuza Software Foundation
 #

--- a/virtaal/views/unitview.py
+++ b/virtaal/views/unitview.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2011 Zuza Software Foundation
 #

--- a/virtaal/views/util.py
+++ b/virtaal/views/util.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2009 Zuza Software Foundation
 #

--- a/virtaal/views/welcomescreenview.py
+++ b/virtaal/views/welcomescreenview.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2011 Zuza Software Foundation
 # Copyright 2013 F Wolff

--- a/virtaal/views/widgets/__init__.py
+++ b/virtaal/views/widgets/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2009 Zuza Software Foundation
 #

--- a/virtaal/views/widgets/aboutdialog.py
+++ b/virtaal/views/widgets/aboutdialog.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2010 Zuza Software Foundation
 #

--- a/virtaal/views/widgets/cellrendererwidget.py
+++ b/virtaal/views/widgets/cellrendererwidget.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2009 Zuza Software Foundation
 # Copyright 2016 F Wolff

--- a/virtaal/views/widgets/demo_selectdialog.py
+++ b/virtaal/views/widgets/demo_selectdialog.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2009 Zuza Software Foundation
 #

--- a/virtaal/views/widgets/demo_selectview.py
+++ b/virtaal/views/widgets/demo_selectview.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2009 Zuza Software Foundation
 #

--- a/virtaal/views/widgets/demo_textbox.py
+++ b/virtaal/views/widgets/demo_textbox.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2009 Zuza Software Foundation
 #

--- a/virtaal/views/widgets/label_expander.py
+++ b/virtaal/views/widgets/label_expander.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2009 Zuza Software Foundation
 #

--- a/virtaal/views/widgets/langadddialog.py
+++ b/virtaal/views/widgets/langadddialog.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2009 Zuza Software Foundation
 #

--- a/virtaal/views/widgets/langselectdialog.py
+++ b/virtaal/views/widgets/langselectdialog.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2009 Zuza Software Foundation
 #

--- a/virtaal/views/widgets/listnav.py
+++ b/virtaal/views/widgets/listnav.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2010-2011 Zuza Software Foundation
 #

--- a/virtaal/views/widgets/popupmenubutton.py
+++ b/virtaal/views/widgets/popupmenubutton.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2011 Zuza Software Foundation
 #

--- a/virtaal/views/widgets/popupwidgetbutton.py
+++ b/virtaal/views/widgets/popupwidgetbutton.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2010 Zuza Software Foundation
 #

--- a/virtaal/views/widgets/selectdialog.py
+++ b/virtaal/views/widgets/selectdialog.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2009-2011 Zuza Software Foundation
 #

--- a/virtaal/views/widgets/shortcutswindow.py
+++ b/virtaal/views/widgets/shortcutswindow.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2026 Zuza Software Foundation
 #

--- a/virtaal/views/widgets/storecellrenderer.py
+++ b/virtaal/views/widgets/storecellrenderer.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2010 Zuza Software Foundation
 #

--- a/virtaal/views/widgets/storetreemodel.py
+++ b/virtaal/views/widgets/storetreemodel.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2011 Zuza Software Foundation
 #

--- a/virtaal/views/widgets/storetreeview.py
+++ b/virtaal/views/widgets/storetreeview.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2010 Zuza Software Foundation
 # Copyright 2016 F Wolff

--- a/virtaal/views/widgets/test_langadddialog.py
+++ b/virtaal/views/widgets/test_langadddialog.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2026 Zuza Software Foundation
 #

--- a/virtaal/views/widgets/test_popupmenubutton.py
+++ b/virtaal/views/widgets/test_popupmenubutton.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2026 Zuza Software Foundation
 #

--- a/virtaal/views/widgets/util.py
+++ b/virtaal/views/widgets/util.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright 2008-2009 Zuza Software Foundation
 #


### PR DESCRIPTION
None of these files are executable or run directly - only bin/virtaal and setup.py actually are, and both keep theirs. virtaal/main.py had a shebang and the executable bit but is only ever imported, never run directly - drops both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)