### PR TITLE
Enable ruff's import-sorting (isort) lint rule

### DIFF
--- a/devsupport/testing/fuzz/fuzz_ui.py
+++ b/devsupport/testing/fuzz/fuzz_ui.py
@@ -54,17 +54,18 @@ REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 
 sys.path.insert(0, REPO_ROOT)
 
 import gi
+
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
 
 from virtaal.common import pan_app
-from virtaal.controllers.maincontroller import MainController
-from virtaal.controllers.storecontroller import StoreController
-from virtaal.controllers.unitcontroller import UnitController
-from virtaal.controllers.undocontroller import UndoController
-from virtaal.controllers.modecontroller import ModeController
 from virtaal.controllers.checkscontroller import ChecksController
 from virtaal.controllers.langcontroller import LanguageController
+from virtaal.controllers.maincontroller import MainController
+from virtaal.controllers.modecontroller import ModeController
+from virtaal.controllers.storecontroller import StoreController
+from virtaal.controllers.undocontroller import UndoController
+from virtaal.controllers.unitcontroller import UnitController
 
 TESTFILES_DIR = os.path.join(REPO_ROOT, 'devsupport', 'testfiles')
 DEFAULT_TESTFILES = ['workflow.po', 'workflow.xliff', 'workflow.ts', 'checks.po']

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,8 +10,8 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
 import os
+import sys
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,11 +83,12 @@ exclude = ["virtaal.test"]
 builtins = ["_"]
 
 [tool.ruff.lint]
-# F (pyflakes: unused imports/variables, undefined names) + UP
-# (pyupgrade: obsolete py2-compat patterns like super(Cls, self)).
-# Deliberately not the default style/whitespace rule families -
-# that's ruff format's job, not enabled yet.
-select = ["F", "UP"]
+# F (pyflakes: unused imports/variables, undefined names), UP
+# (pyupgrade: obsolete py2-compat patterns like super(Cls, self)), and
+# I (isort: import sorting/grouping). Deliberately not the default
+# style/whitespace rule families - that's ruff format's job, not
+# enabled yet.
+select = ["F", "I", "UP"]
 ignore = [
     # %-format -> f-string: 198 sites, needs real per-call
     # verification (escaping/argument-shape can change), not a

--- a/virtaal/common/gobjectwrapper.py
+++ b/virtaal/common/gobjectwrapper.py
@@ -17,6 +17,7 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 from gi.repository import GObject
+
 #import logging
 
 

--- a/virtaal/common/pan_app.py
+++ b/virtaal/common/pan_app.py
@@ -28,6 +28,7 @@ import os
 import sys
 
 from virtaal.__version__ import version_string
+
 from .platform import platform
 from .utils import get_unicode
 
@@ -76,14 +77,16 @@ if platform.is_windows and platform.is_frozen:
 
 # Ok, now we can continue with what we actually wanted to do
 
-import configparser as ConfigParser
 import builtins as __builtin__
-import locale, gettext
-from virtaal.support.libi18n.locale import fix_locale, fix_libintl, bind_libintl_posix
-from translate.misc import file_discovery
+import configparser as ConfigParser
+import gettext
+import locale
+
 from translate.lang import data
+from translate.misc import file_discovery
 
 from virtaal.__version__ import ver
+from virtaal.support.libi18n.locale import bind_libintl_posix, fix_libintl, fix_locale
 
 DEBUG = True # Enable debugging by default, while bin/virtaal still disables it by default.
              # This means that if Virtaal (or parts thereof) is run in some other strange way,

--- a/virtaal/common/test_pan_app.py
+++ b/virtaal/common/test_pan_app.py
@@ -21,7 +21,11 @@ import os
 import pytest
 
 from virtaal.common import pan_app
-from virtaal.common.pan_app import _build_launch_marker, _open_frozen_log, _set_enchant_env_vars
+from virtaal.common.pan_app import (
+    _build_launch_marker,
+    _open_frozen_log,
+    _set_enchant_env_vars,
+)
 
 
 def test_build_launch_marker_includes_version(monkeypatch):

--- a/virtaal/common/utils.py
+++ b/virtaal/common/utils.py
@@ -1,7 +1,6 @@
 import sys
 
 
-
 def get_unicode(string, encoding=None):
     if isinstance(string, str):
         return string

--- a/virtaal/controllers/checkscontroller.py
+++ b/virtaal/controllers/checkscontroller.py
@@ -22,6 +22,7 @@ import logging
 from gi.repository import GLib, GObject
 
 from virtaal.common import GObjectWrapper
+
 from .basecontroller import BaseController
 
 check_names = {

--- a/virtaal/controllers/langcontroller.py
+++ b/virtaal/controllers/langcontroller.py
@@ -22,6 +22,7 @@ from gi.repository import GObject
 
 from virtaal.common import GObjectWrapper, pan_app
 from virtaal.models.langmodel import LanguageModel
+
 from .basecontroller import BaseController
 
 

--- a/virtaal/controllers/maincontroller.py
+++ b/virtaal/controllers/maincontroller.py
@@ -20,13 +20,14 @@
 import gi
 
 gi.require_version('Gtk', '3.0')
-from gi.repository import Gtk, GObject
+from gi.repository import GObject, Gtk
 
-from .basecontroller import BaseController
 from virtaal.common import GObjectWrapper, pan_app
 from virtaal.common.platform import platform
 from virtaal.models.storemodel import SaveCancelled
 from virtaal.views.mainview import MainView
+
+from .basecontroller import BaseController
 
 
 class MainController(BaseController):
@@ -224,8 +225,8 @@ class MainController(BaseController):
 
         # Open the file just created on the fly.
         self.open_file(filename, forget_dir=True)
-        import shutil
         import os.path
+        import shutil
         shutil.rmtree(os.path.dirname(filename))
 
 

--- a/virtaal/controllers/modecontroller.py
+++ b/virtaal/controllers/modecontroller.py
@@ -19,6 +19,7 @@
 from gi.repository import GObject
 
 from virtaal.common import GObjectWrapper
+
 from .basecontroller import BaseController
 
 
@@ -46,7 +47,7 @@ class ModeController(BaseController):
         self.main_controller.mode_controller = self
 
         self._init_modes()
-        from virtaal.views.modeview  import ModeView
+        from virtaal.views.modeview import ModeView
         self.view = ModeView(self)
         self.view.connect('mode-selected', self._on_mode_selected)
 
@@ -59,7 +60,7 @@ class ModeController(BaseController):
         self.modes = {}
         self.modenames = {}
 
-        from virtaal.modes  import modeclasses
+        from virtaal.modes import modeclasses
         for modeclass in modeclasses:
             newmode = modeclass(self)
             self.modes[newmode.name] = newmode

--- a/virtaal/controllers/placeablescontroller.py
+++ b/virtaal/controllers/placeablescontroller.py
@@ -18,10 +18,12 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 from gi.repository import GObject
-from translate.storage.placeables import general, StringElem, parse as parse_placeables
+from translate.storage.placeables import StringElem, general
+from translate.storage.placeables import parse as parse_placeables
 
-from virtaal.common import pan_app, GObjectWrapper
+from virtaal.common import GObjectWrapper, pan_app
 from virtaal.views import placeablesguiinfo
+
 from .basecontroller import BaseController
 
 

--- a/virtaal/controllers/plugincontroller.py
+++ b/virtaal/controllers/plugincontroller.py
@@ -23,11 +23,12 @@ import sys
 from gi.repository import GLib, GObject
 from gi.repository.GObject import TYPE_PYOBJECT
 
-from virtaal.common import pan_app, GObjectWrapper
+from virtaal.common import GObjectWrapper, pan_app
 from virtaal.common.platform import platform
 from virtaal.common.utils import get_unicode
+
 from .basecontroller import BaseController
-from .baseplugin import PluginUnsupported, BasePlugin
+from .baseplugin import BasePlugin, PluginUnsupported
 
 if platform.is_windows:
     sys.path.insert(0, pan_app.main_dir)

--- a/virtaal/controllers/prefscontroller.py
+++ b/virtaal/controllers/prefscontroller.py
@@ -17,6 +17,7 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 from virtaal.common import GObjectWrapper, pan_app
+
 from .basecontroller import BaseController
 
 

--- a/virtaal/controllers/propertiescontroller.py
+++ b/virtaal/controllers/propertiescontroller.py
@@ -17,6 +17,7 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 from virtaal.common import GObjectWrapper
+
 from .basecontroller import BaseController
 
 

--- a/virtaal/controllers/storecontroller.py
+++ b/virtaal/controllers/storecontroller.py
@@ -22,6 +22,7 @@ import os
 from gi.repository import GObject
 
 from virtaal.common import GObjectWrapper
+
 from .basecontroller import BaseController
 
 
@@ -184,12 +185,14 @@ class StoreController(BaseController):
             self.cursor.index = i
 
     def open_file(self, filename, uri='', forget_dir=False):
-        from virtaal.models.storemodel import StoreModel
         from translate.convert import factory as convert_factory
+
+        from virtaal.models.storemodel import StoreModel
         force_saveas = False
         extension = filename.split(os.extsep)[-1]
         if extension == 'zip':
             import logging
+
             from translate.storage import bundleprojstore
             try:
                 from translate.storage.project import Project
@@ -385,6 +388,7 @@ class StoreController(BaseController):
         from translate.convert import factory as convert_factory
         if extension in convert_factory.converters:
             import logging
+
             from translate.storage import factory
             try:
                 outfile = convert_factory.convert(open(filename))[0]
@@ -481,6 +485,7 @@ class StoreController(BaseController):
 
             @returns: The suggested file name for the bundle."""
         from tempfile import mkstemp
+
         from translate.storage.project import split_extensions
         fname, extensions = split_extensions(infilename)
 

--- a/virtaal/controllers/undocontroller.py
+++ b/virtaal/controllers/undocontroller.py
@@ -17,12 +17,11 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-from gi.repository import GLib
-from gi.repository import Gdk
-from gi.repository import Gtk
+from gi.repository import Gdk, GLib, Gtk
 from translate.storage.placeables import StringElem
 
 from virtaal.common import GObjectWrapper, pan_app
+
 from .basecontroller import BaseController
 
 

--- a/virtaal/controllers/unitcontroller.py
+++ b/virtaal/controllers/unitcontroller.py
@@ -19,9 +19,10 @@
 from gi.repository.GLib import timeout_add
 from gi.repository.GObject import SignalFlags
 from translate.storage import workflow
-from translate.storage.workflow import Workflow, UnitState
+from translate.storage.workflow import UnitState, Workflow
 
 from virtaal.common import GObjectWrapper
+
 from .basecontroller import BaseController
 
 

--- a/virtaal/controllers/welcomescreencontroller.py
+++ b/virtaal/controllers/welcomescreencontroller.py
@@ -18,6 +18,7 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 from virtaal.common.utils import get_unicode
+
 from .basecontroller import BaseController
 
 

--- a/virtaal/main.py
+++ b/virtaal/main.py
@@ -76,8 +76,8 @@ class Virtaal:
 
         # We try to get the welcomescreen loaded as early as possible
         from virtaal.controllers.maincontroller import MainController
-        from virtaal.controllers.welcomescreencontroller import WelcomeScreenController
         from virtaal.controllers.storecontroller import StoreController
+        from virtaal.controllers.welcomescreencontroller import WelcomeScreenController
 
         main_controller = MainController()
         store_controller = StoreController(main_controller)
@@ -106,10 +106,10 @@ class Virtaal:
 
     def _open_with_file(self, startupfile):
         # Things needed for opening a file, including inter-dependencies
-        from virtaal.controllers.unitcontroller import UnitController
-        from virtaal.controllers.modecontroller import ModeController
         from virtaal.controllers.langcontroller import LanguageController
+        from virtaal.controllers.modecontroller import ModeController
         from virtaal.controllers.placeablescontroller import PlaceablesController
+        from virtaal.controllers.unitcontroller import UnitController
 
         main_controller = self.main_controller
 
@@ -125,10 +125,10 @@ class Virtaal:
         return main_controller.open_file(startupfile)
 
     def _open_with_welcome(self):
-        from virtaal.controllers.unitcontroller import UnitController
-        from virtaal.controllers.modecontroller import ModeController
         from virtaal.controllers.langcontroller import LanguageController
+        from virtaal.controllers.modecontroller import ModeController
         from virtaal.controllers.placeablescontroller import PlaceablesController
+        from virtaal.controllers.unitcontroller import UnitController
 
         defer = self.defer
         main_controller = self.main_controller
@@ -140,12 +140,14 @@ class Virtaal:
         self.defer(self._load_extras)
 
     def _load_extras(self):
+        from virtaal.controllers.checkscontroller import ChecksController
         from virtaal.controllers.plugincontroller import PluginController
         from virtaal.controllers.prefscontroller import PreferencesController
-        from virtaal.controllers.checkscontroller import ChecksController
-        from virtaal.controllers.undocontroller import UndoController
         from virtaal.controllers.propertiescontroller import PropertiesController
-        from virtaal.support.dictionary_download_watcher import DictionaryDownloadWatcher
+        from virtaal.controllers.undocontroller import UndoController
+        from virtaal.support.dictionary_download_watcher import (
+            DictionaryDownloadWatcher,
+        )
 
         defer = self.defer
         main_controller = self.main_controller

--- a/virtaal/models/langmodel.py
+++ b/virtaal/models/langmodel.py
@@ -23,6 +23,7 @@ from translate.lang.data import languages as toolkit_langs
 
 from virtaal.common.pan_app import ui_language
 from virtaal.support.translate_compat import tr_lang
+
 from .basemodel import BaseModel
 
 gettext_lang = tr_lang(ui_language)

--- a/virtaal/models/storemodel.py
+++ b/virtaal/models/storemodel.py
@@ -18,8 +18,8 @@
 
 import os
 
-
 from virtaal.common import pan_app
+
 from .basemodel import BaseModel
 
 
@@ -211,8 +211,8 @@ class StoreModel(BaseModel):
         self._trans_store.fileobj = oldfileobj #Let's attempt to keep the old file and name if possible
 
         #FIXME: ugly tempfile hack, can we please have a pure store implementation of statsdb
-        import tempfile
         import os
+        import tempfile
         tempfd, tempfilename = tempfile.mkstemp()
         os.write(tempfd, str(self._trans_store))
         self.update_stats(filename=tempfilename)

--- a/virtaal/modes/qualitycheckmode.py
+++ b/virtaal/modes/qualitycheckmode.py
@@ -20,7 +20,8 @@ import locale
 
 from gi.repository import Gtk
 
-from virtaal.views.widgets.popupmenubutton import PopupMenuButton, POS_NW_SW
+from virtaal.views.widgets.popupmenubutton import POS_NW_SW, PopupMenuButton
+
 from .basemode import BaseMode
 
 

--- a/virtaal/modes/quicktransmode.py
+++ b/virtaal/modes/quicktransmode.py
@@ -18,6 +18,7 @@
 
 from virtaal.support.set_enumerator import UnionSetEnumerator
 from virtaal.support.sorted_set import SortedSet
+
 from .basemode import BaseMode
 
 

--- a/virtaal/modes/searchmode.py
+++ b/virtaal/modes/searchmode.py
@@ -19,11 +19,12 @@
 
 import logging
 
-from gi.repository import GLib, Gtk, Gdk
+from gi.repository import Gdk, GLib, Gtk
 
 from virtaal.common.utils import get_unicode
 from virtaal.controllers.cursor import Cursor
 from virtaal.views.theme import current_theme
+
 from .basemode import BaseMode
 
 

--- a/virtaal/modes/workflowmode.py
+++ b/virtaal/modes/workflowmode.py
@@ -16,10 +16,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-from gi.repository import Gtk
-from gi.repository import GLib
+from gi.repository import GLib, Gtk
 
-from virtaal.views.widgets.popupmenubutton import PopupMenuButton, POS_NW_SW
+from virtaal.views.widgets.popupmenubutton import POS_NW_SW, PopupMenuButton
+
 from .basemode import BaseMode
 
 

--- a/virtaal/plugins/_ipython_console/__init__.py
+++ b/virtaal/plugins/_ipython_console/__init__.py
@@ -1,9 +1,8 @@
 
-from gi.repository import Gdk
-from gi.repository import Gtk
-from gi.repository import Pango
+from gi.repository import Gdk, Gtk, Pango
 
 from virtaal.controllers.baseplugin import BasePlugin
+
 from .ipython_view import IPythonView
 
 

--- a/virtaal/plugins/_ipython_console/ipython_view.py
+++ b/virtaal/plugins/_ipython_console/ipython_view.py
@@ -15,11 +15,10 @@ import os
 import re
 import sys
 from functools import reduce
-
 from io import StringIO
 
 import IPython
-from gi.repository import GLib, Pango, Gtk, Gdk
+from gi.repository import Gdk, GLib, Gtk, Pango
 
 
 class IterableIPShell:

--- a/virtaal/plugins/_python_console.py
+++ b/virtaal/plugins/_python_console.py
@@ -3,10 +3,7 @@ import re
 import sys
 import traceback
 
-from gi.repository import GLib
-from gi.repository import Gdk
-from gi.repository import Gtk
-from gi.repository import Pango
+from gi.repository import Gdk, GLib, Gtk, Pango
 
 from virtaal.controllers.baseplugin import BasePlugin
 

--- a/virtaal/plugins/lookup/__init__.py
+++ b/virtaal/plugins/lookup/__init__.py
@@ -19,6 +19,7 @@
 """Performs external look-ups on selected text."""
 
 from virtaal.controllers.baseplugin import BasePlugin
+
 from .lookupcontroller import LookupController
 
 

--- a/virtaal/plugins/lookup/lookupcontroller.py
+++ b/virtaal/plugins/lookup/lookupcontroller.py
@@ -23,6 +23,7 @@ from gi.repository import GObject
 from virtaal.common import GObjectWrapper
 from virtaal.controllers.basecontroller import BaseController
 from virtaal.controllers.plugincontroller import PluginController
+
 from .lookupview import LookupView
 from .models.baselookupmodel import BaseLookupModel
 

--- a/virtaal/plugins/lookup/models/weblookup.py
+++ b/virtaal/plugins/lookup/models/weblookup.py
@@ -17,11 +17,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-from urllib import parse
 from os import path
+from urllib import parse
 
-from gi.repository import Gtk
-from gi.repository import Pango
+from gi.repository import Gtk, Pango
 
 from virtaal.common import pan_app
 from virtaal.views.baseview import BaseView

--- a/virtaal/plugins/migration.py
+++ b/virtaal/plugins/migration.py
@@ -23,19 +23,16 @@ Lokalize, and Translation Memory from Lokalize. (Poedit's and KBabel's TM
 import both relied on the Python 2-only bsddb module and were removed.)
 """
 
+import configparser as ConfigParser
 import logging
 import os
-from os import path
-
 from io import StringIO
-import configparser as ConfigParser
-
+from os import path
 from sqlite3 import dbapi2
 
 from virtaal.common import pan_app
 from virtaal.common.platform import platform
 from virtaal.controllers.baseplugin import BasePlugin
-
 from virtaal.support import tmdb
 
 

--- a/virtaal/plugins/spellchecker.py
+++ b/virtaal/plugins/spellchecker.py
@@ -25,8 +25,7 @@ from gettext import dgettext
 from gi.repository import GLib
 
 from virtaal.common.platform import platform
-from virtaal.controllers.baseplugin import PluginUnsupported, BasePlugin
-
+from virtaal.controllers.baseplugin import BasePlugin, PluginUnsupported
 
 _dict_add_re = re.compile('Add "(.*)" to Dictionary')
 
@@ -70,8 +69,8 @@ class Plugin(BasePlugin):
         try:
             import gi
             gi.require_version('GtkSpell', '3.0')
-            from gi.repository import GtkSpell as gtkspell
             import enchant
+            from gi.repository import GtkSpell as gtkspell
         except (ImportError, ValueError) as e:
             raise PluginUnsupported(str(e))
         self.gtkspell = gtkspell

--- a/virtaal/plugins/terminology/__init__.py
+++ b/virtaal/plugins/terminology/__init__.py
@@ -18,6 +18,7 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 from virtaal.controllers.baseplugin import BasePlugin
+
 from .termcontroller import TerminologyController
 
 

--- a/virtaal/plugins/terminology/models/autoterm.py
+++ b/virtaal/plugins/terminology/models/autoterm.py
@@ -27,6 +27,7 @@ from translate.storage.placeables.terminology import TerminologyPlaceable
 
 from virtaal.common import pan_app
 from virtaal.support.httpclient import HTTPClient
+
 from .basetermmodel import BaseTerminologyModel
 
 THREE_DAYS = 60 * 60 * 24 * 3
@@ -179,6 +180,7 @@ class TerminologyModel(BaseTerminologyModel):
         # content is real bytes, not str - BytesIO, not StringIO.
         # _guessextention was also renamed upstream to _guess_extension.
         from io import BytesIO
+
         from translate.storage.factory import _guess_extension
         s = BytesIO(content)
         try:

--- a/virtaal/plugins/terminology/models/localfile/localfileview.py
+++ b/virtaal/plugins/terminology/models/localfile/localfileview.py
@@ -19,9 +19,7 @@
 
 import locale
 
-from gi.repository import Gdk
-from gi.repository import Gtk
-from gi.repository import Pango
+from gi.repository import Gdk, Gtk, Pango
 from translate.storage import factory as store_factory
 
 from virtaal.views.baseview import BaseView
@@ -455,6 +453,7 @@ class TermAddDialog:
             # We want to separate multiple terms with the correct list
             # separator for the UI language:
             from translate.lang import factory as lang_factory
+
             from virtaal.common.pan_app import ui_language
             separator = lang_factory.getlanguage(ui_language).listseperator
 

--- a/virtaal/plugins/terminology/models/pontoon.py
+++ b/virtaal/plugins/terminology/models/pontoon.py
@@ -28,6 +28,7 @@ from translate.storage.placeables.terminology import TerminologyPlaceable
 
 from virtaal.common import pan_app
 from virtaal.support.httpclient import HTTPClient
+
 from .basetermmodel import BaseTerminologyModel
 
 THREE_DAYS = 60 * 60 * 24 * 3
@@ -224,6 +225,7 @@ class TerminologyModel(BaseTerminologyModel):
         # function was also renamed upstream from the misspelled
         # _guessextention to _guess_extension.
         from io import BytesIO
+
         from translate.storage.factory import _guess_extension
         s = BytesIO(content)
         try:

--- a/virtaal/plugins/terminology/models/test_pontoon.py
+++ b/virtaal/plugins/terminology/models/test_pontoon.py
@@ -16,10 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
+import configparser
 import io
 import os
-
-import configparser
 
 from virtaal.plugins.terminology.models.pontoon import TerminologyModel
 

--- a/virtaal/plugins/terminology/termcontroller.py
+++ b/virtaal/plugins/terminology/termcontroller.py
@@ -25,6 +25,7 @@ from virtaal.common import GObjectWrapper
 from virtaal.controllers.basecontroller import BaseController
 from virtaal.controllers.plugincontroller import PluginController
 from virtaal.views import placeablesguiinfo
+
 from .models.basetermmodel import BaseTerminologyModel
 from .termview import TerminologyGUIInfo, TerminologyView
 

--- a/virtaal/plugins/tm/__init__.py
+++ b/virtaal/plugins/tm/__init__.py
@@ -18,6 +18,7 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 from virtaal.controllers.baseplugin import BasePlugin
+
 from .tmcontroller import TMController
 
 

--- a/virtaal/plugins/tm/models/apertium.py
+++ b/virtaal/plugins/tm/models/apertium.py
@@ -29,10 +29,10 @@ which needs no appId.
 import json
 from urllib.parse import urlencode
 
-from .basetmmodel import BaseTMModel, unescape_html_entities
-
 from virtaal.common.utils import get_unicode
 from virtaal.support.httpclient import HTTPClient, RESTRequest
+
+from .basetmmodel import BaseTMModel, unescape_html_entities
 
 
 class TMModel(BaseTMModel):

--- a/virtaal/plugins/tm/models/google_translate.py
+++ b/virtaal/plugins/tm/models/google_translate.py
@@ -19,15 +19,14 @@
 
 import json
 import logging
-
 from urllib.parse import quote_plus
 
 import pycurl
 
 from virtaal.common.utils import get_unicode
-from .basetmmodel import BaseTMModel, unescape_html_entities
 from virtaal.support.httpclient import HTTPClient, RESTRequest
 
+from .basetmmodel import BaseTMModel, unescape_html_entities
 
 # Some codes are weird or can be reused for others
 code_translation = {

--- a/virtaal/plugins/tm/models/localtm.py
+++ b/virtaal/plugins/tm/models/localtm.py
@@ -23,6 +23,7 @@ import sys
 
 from virtaal.common import pan_app
 from virtaal.common.platform import platform
+
 from . import remotetm
 from .basetmmodel import BaseTMModel
 
@@ -85,6 +86,7 @@ class TMModel(remotetm.TMModel):
         logging.debug("launching tmserver with command {}".format(" ".join(command)))
         try:
             import subprocess
+
             from virtaal.support import tmclient
 
             env = os.environ.copy()

--- a/virtaal/plugins/tm/models/remotetm.py
+++ b/virtaal/plugins/tm/models/remotetm.py
@@ -17,6 +17,7 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 from virtaal.common.utils import get_unicode
+
 from .basetmmodel import BaseTMModel
 
 

--- a/virtaal/plugins/tm/models/test_basetmmodel.py
+++ b/virtaal/plugins/tm/models/test_basetmmodel.py
@@ -18,6 +18,7 @@
 
 from .basetmmodel import unescape_html_entities
 
+
 def test_unescape_html_entities():
     """Test the unescaping of &amp; and &#39; type HTML escapes"""
     assert unescape_html_entities("This &amp; That") == "This & That"

--- a/virtaal/plugins/tm/tmview.py
+++ b/virtaal/plugins/tm/tmview.py
@@ -19,10 +19,11 @@
 
 import logging
 
-from gi.repository import GLib, GObject, Gdk, Gtk
+from gi.repository import Gdk, GLib, GObject, Gtk
 
 from virtaal.common import GObjectWrapper
 from virtaal.views.baseview import BaseView
+
 from .tmwidgets import TMWindow
 
 

--- a/virtaal/plugins/tm/tmwidgets.py
+++ b/virtaal/plugins/tm/tmwidgets.py
@@ -17,9 +17,7 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 
-from gi.repository import GObject
-from gi.repository import Gtk
-from gi.repository import Pango
+from gi.repository import GObject, Gtk, Pango
 
 from virtaal.views import markup, rendering
 

--- a/virtaal/support/httpclient.py
+++ b/virtaal/support/httpclient.py
@@ -19,10 +19,10 @@
 
 import logging
 from io import BytesIO
+from urllib import parse, request
 
 import pycurl
 from gi.repository import GLib, GObject
-from urllib import request, parse
 
 try:
     import libproxy
@@ -253,6 +253,7 @@ class HTTPClient:
         if self.user_agent and self.user_agent.startswith('Virtaal'):
             return
         import sys
+
         from virtaal.__version__ import ver as version
         platform = sys.platform
         if platform.startswith('linux'):

--- a/virtaal/support/mosesclient.py
+++ b/virtaal/support/mosesclient.py
@@ -17,8 +17,8 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 import logging
-
 import xmlrpc.client as xmlrpclib
+
 from gi.repository import GObject
 
 from virtaal.support.httpclient import HTTPClient, HTTPRequest

--- a/virtaal/support/openmailto.py
+++ b/virtaal/support/openmailto.py
@@ -29,12 +29,11 @@ and for sending e-mail using the user's preferred composer."""
 __version__ = '1.0'
 __all__ = ['open', 'mailto']
 
+import logging
 import os
 import sys
-import logging
 
 from virtaal.common.platform import platform
-
 
 # Some imports are only necessary on some platforms, and are postponed to try
 # to speed up startup
@@ -136,8 +135,8 @@ elif platform.is_mac:
 # Platform support for Unix
 else:
 
-    import subprocess
     import shutil
+    import subprocess
 
     class KfmClient(Controller):
         '''Controller for the KDE kfmclient program.'''

--- a/virtaal/support/set_enumerator.py
+++ b/virtaal/support/set_enumerator.py
@@ -22,7 +22,6 @@ from gi.repository import GObject
 
 from virtaal.support.sorted_set import SortedSet
 
-
 # FIXME: Add docstrings!
 
 class UnionSetEnumerator(GObject.GObject):

--- a/virtaal/support/simplegeneric.py
+++ b/virtaal/support/simplegeneric.py
@@ -20,6 +20,7 @@
 __all__ = ["generic"]
 
 from types import FunctionType
+
 classtypes = (type,)
 
 

--- a/virtaal/support/statsdb.py
+++ b/virtaal/support/statsdb.py
@@ -33,8 +33,8 @@
 
 """
 
-import logging
 import _thread
+import logging
 import os.path
 import re
 import stat
@@ -49,7 +49,6 @@ from translate.storage import factory
 from translate.storage.workflow import StateEnum
 
 from virtaal.common.platform import platform
-
 
 logger = logging.getLogger(__name__)
 

--- a/virtaal/support/test_autocorrect_downloader.py
+++ b/virtaal/support/test_autocorrect_downloader.py
@@ -23,7 +23,10 @@ I/O, so the test drives the chain step by step, synchronously."""
 import json
 
 from virtaal.support.autocorrect_downloader import AutocorrectDownloader
-from virtaal.support.test_autocorrect_source import AF_ZA_DOCUMENT_LIST, CONTENTS_LISTING
+from virtaal.support.test_autocorrect_source import (
+    AF_ZA_DOCUMENT_LIST,
+    CONTENTS_LISTING,
+)
 
 LISTING_RESULT = json.dumps(CONTENTS_LISTING).encode('utf-8')
 

--- a/virtaal/support/tmclient.py
+++ b/virtaal/support/tmclient.py
@@ -19,9 +19,9 @@
 
 # These two json modules are API compatible
 try:
-    import simplejson as json #should be a bit faster; needed for Python < 2.6
+    import simplejson as json  #should be a bit faster; needed for Python < 2.6
 except ImportError:
-    import json #available since Python 2.6
+    import json  #available since Python 2.6
 
 import pycurl
 

--- a/virtaal/support/translate_compat.py
+++ b/virtaal/support/translate_compat.py
@@ -46,7 +46,6 @@ except ImportError:
 
 from virtaal.common.platform import platform
 
-
 _fixed_names = {
     "Asturian; Bable; Leonese; Asturleonese": "Asturian",
     "Bokmål, Norwegian; Norwegian Bokmål": "Norwegian Bokmål",

--- a/virtaal/test/test_scaffolding.py
+++ b/virtaal/test/test_scaffolding.py
@@ -18,15 +18,16 @@
 
 import os
 import tempfile
+
 from translate.storage import factory
 
-from virtaal.controllers.maincontroller import MainController
-from virtaal.controllers.storecontroller import StoreController
-from virtaal.controllers.unitcontroller import UnitController
-from virtaal.controllers.undocontroller import UndoController
-from virtaal.controllers.modecontroller import ModeController
 from virtaal.controllers.checkscontroller import ChecksController
 from virtaal.controllers.langcontroller import LanguageController
+from virtaal.controllers.maincontroller import MainController
+from virtaal.controllers.modecontroller import ModeController
+from virtaal.controllers.storecontroller import StoreController
+from virtaal.controllers.undocontroller import UndoController
+from virtaal.controllers.unitcontroller import UnitController
 
 
 class TestScaffolding:

--- a/virtaal/test/test_storemodel.py
+++ b/virtaal/test/test_storemodel.py
@@ -16,9 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-from virtaal.models.storemodel import StoreModel
-
 from test_scaffolding import TestScaffolding
+
+from virtaal.models.storemodel import StoreModel
 
 
 class TestStoreModel(TestScaffolding):

--- a/virtaal/test/test_unitcontroller.py
+++ b/virtaal/test/test_unitcontroller.py
@@ -20,9 +20,8 @@ import os
 import tempfile
 
 from gi.repository import Gdk, GLib
-from translate.storage import factory
-
 from test_scaffolding import TestScaffolding
+from translate.storage import factory
 
 from virtaal.controllers.placeablescontroller import PlaceablesController
 

--- a/virtaal/tips.py
+++ b/virtaal/tips.py
@@ -20,7 +20,6 @@
 
 from gettext import gettext as _
 
-
 tips = [
     _("At the end of a translation, simply press <Enter> to continue with the next one."),
     _("To copy the original string into the target field, simply press <Alt+Down>."),

--- a/virtaal/views/checksprojview.py
+++ b/virtaal/views/checksprojview.py
@@ -22,6 +22,7 @@ import locale
 from gi.repository import Gtk
 
 from virtaal.views.widgets.popupmenubutton import PopupMenuButton
+
 from .baseview import BaseView
 
 

--- a/virtaal/views/checksunitview.py
+++ b/virtaal/views/checksunitview.py
@@ -18,12 +18,12 @@
 
 import locale
 
-from gi.repository import Gtk
-from gi.repository import Pango
+from gi.repository import Gtk, Pango
 from translate.lang import factory as lang_factory
 
 from virtaal.common.pan_app import ui_language
-from virtaal.views.widgets.popupwidgetbutton import PopupWidgetButton, POS_SE_NE
+from virtaal.views.widgets.popupwidgetbutton import POS_SE_NE, PopupWidgetButton
+
 from .baseview import BaseView
 
 

--- a/virtaal/views/langview.py
+++ b/virtaal/views/langview.py
@@ -19,12 +19,11 @@
 import locale
 import logging
 
-from gi.repository import GLib
-from gi.repository import Gdk
-from gi.repository import Gtk
+from gi.repository import Gdk, GLib, Gtk
 
 from virtaal.common.platform import platform
 from virtaal.models.langmodel import LanguageModel
+
 from .baseview import BaseView
 from .widgets.popupmenubutton import PopupMenuButton
 
@@ -41,8 +40,8 @@ class LanguageView(BaseView):
         self._init_gui()
 
     def _create_dialogs(self):
-        from .widgets.langselectdialog import LanguageSelectDialog
         from .widgets.langadddialog import LanguageAddDialog
+        from .widgets.langselectdialog import LanguageSelectDialog
         langs = [LanguageModel(lc) for lc in LanguageModel.languages]
         langs.sort(key=lambda x: locale.strxfrm(x.name))
         self.select_dialog = LanguageSelectDialog(langs, parent=self.controller.main_controller.view.main_window)

--- a/virtaal/views/mainview.py
+++ b/virtaal/views/mainview.py
@@ -22,13 +22,13 @@ import os
 import subprocess
 import time
 
-from gi.repository import Gdk
-from gi.repository import Gtk
+from gi.repository import Gdk, Gtk
 
 from virtaal.common import pan_app
 from virtaal.common.platform import platform
 from virtaal.common.utils import get_unicode
 from virtaal.views import theme
+
 from .baseview import BaseView
 
 

--- a/virtaal/views/modeview.py
+++ b/virtaal/views/modeview.py
@@ -16,10 +16,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-from gi.repository import GObject
-from gi.repository import Gtk
+from gi.repository import GObject, Gtk
 
 from virtaal.common import GObjectWrapper
+
 from .baseview import BaseView
 
 

--- a/virtaal/views/placeablesguiinfo.py
+++ b/virtaal/views/placeablesguiinfo.py
@@ -17,9 +17,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-from gi.repository import Gtk, Gdk
-from gi.repository import Pango
-from translate.storage.placeables import base, StringElem, general, xliff
+from gi.repository import Gdk, Gtk, Pango
+from translate.storage.placeables import StringElem, base, general, xliff
 
 from virtaal.views import theme
 from virtaal.views.rendering import get_role_font_description, make_pango_layout

--- a/virtaal/views/prefsview.py
+++ b/virtaal/views/prefsview.py
@@ -16,12 +16,11 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-from gi.repository import Gtk, Gdk
-from gi.repository import Pango
-from gi.repository import GObject
+from gi.repository import Gdk, GObject, Gtk, Pango
 
 from virtaal.common import GObjectWrapper, pan_app
 from virtaal.views.widgets.selectview import SelectView
+
 from .baseview import BaseView
 
 

--- a/virtaal/views/propertiesview.py
+++ b/virtaal/views/propertiesview.py
@@ -22,6 +22,7 @@ import logging
 from gi.repository import Gtk
 
 from virtaal.common import GObjectWrapper
+
 from .baseview import BaseView
 
 

--- a/virtaal/views/storeview.py
+++ b/virtaal/views/storeview.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-from gi.repository import Gtk, Gdk
+from gi.repository import Gdk, Gtk
 
 from .baseview import BaseView
 from .widgets.storetreeview import StoreTreeView

--- a/virtaal/views/test_mainview.py
+++ b/virtaal/views/test_mainview.py
@@ -27,6 +27,7 @@ did nothing, no error.
 """
 
 import gi
+
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
 

--- a/virtaal/views/theme.py
+++ b/virtaal/views/theme.py
@@ -22,7 +22,7 @@
 The colors are kept as strings so that the can easily be interpolated into
 pango markup. A different solution is likely to be better in the long run."""
 
-from gi.repository import Gtk, Gdk
+from gi.repository import Gdk, Gtk
 
 INVERSE = False
 """Whether we are currently in an inverse type of theme (lite text on dark

--- a/virtaal/views/unitview.py
+++ b/virtaal/views/unitview.py
@@ -19,11 +19,12 @@
 import logging
 import re
 
-from gi.repository import GLib, GObject, Gtk, Gdk
+from gi.repository import Gdk, GLib, GObject, Gtk
 from gi.repository.GObject import TYPE_PYOBJECT
 from translate.lang import factory
 
 from virtaal.common import GObjectWrapper
+
 from . import rendering
 from .baseview import BaseView
 from .widgets.listnav import ListNavigator

--- a/virtaal/views/util.py
+++ b/virtaal/views/util.py
@@ -16,9 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-from gi.repository import GLib
-from gi.repository import Gtk
-from gi.repository import Gdk
+from gi.repository import Gdk, GLib, Gtk
 
 __all__ = ['pulse']
 

--- a/virtaal/views/welcomescreenview.py
+++ b/virtaal/views/welcomescreenview.py
@@ -21,6 +21,7 @@ from gi.repository import GLib, Gtk
 
 from virtaal.common.pan_app import get_abs_data_filename, ui_language
 from virtaal.views.widgets.welcomescreen import WelcomeScreen
+
 from .baseview import BaseView
 
 

--- a/virtaal/views/widgets/aboutdialog.py
+++ b/virtaal/views/widgets/aboutdialog.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-from gi.repository import Gtk, GdkPixbuf
+from gi.repository import GdkPixbuf, Gtk
 
 from virtaal import __version__
 from virtaal.common import pan_app

--- a/virtaal/views/widgets/cellrendererwidget.py
+++ b/virtaal/views/widgets/cellrendererwidget.py
@@ -20,9 +20,9 @@ import gi
 
 gi.require_version('Gtk', '3.0')
 
-from gi.repository import Gtk
-from gi.repository import Pango
-from gi.repository.GObject import ParamFlags, SignalFlags, TYPE_PYOBJECT
+from gi.repository import Gtk, Pango
+from gi.repository.GObject import TYPE_PYOBJECT, ParamFlags, SignalFlags
+
 PARAM_READWRITE = ParamFlags.READWRITE
 SIGNAL_RUN_FIRST = SignalFlags.RUN_FIRST
 

--- a/virtaal/views/widgets/label_expander.py
+++ b/virtaal/views/widgets/label_expander.py
@@ -17,8 +17,7 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 import Gtk.gdk
-from gi.repository import GObject
-from gi.repository import Gtk
+from gi.repository import GObject, Gtk
 
 from virtaal.views import markup
 

--- a/virtaal/views/widgets/langselectdialog.py
+++ b/virtaal/views/widgets/langselectdialog.py
@@ -18,8 +18,7 @@
 
 import locale
 
-from gi.repository import GObject
-from gi.repository import Gtk
+from gi.repository import GObject, Gtk
 
 from virtaal.views.baseview import BaseView
 

--- a/virtaal/views/widgets/listnav.py
+++ b/virtaal/views/widgets/listnav.py
@@ -24,7 +24,7 @@ options.
 
 import logging
 
-from gi.repository import Gtk, GObject, Gdk
+from gi.repository import Gdk, GObject, Gtk
 
 from .popupwidgetbutton import PopupWidgetButton
 

--- a/virtaal/views/widgets/popupmenubutton.py
+++ b/virtaal/views/widgets/popupmenubutton.py
@@ -16,8 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-from gi.repository import Gdk, Gtk, GObject
-
+from gi.repository import Gdk, GObject, Gtk
 
 # Positioning constants below:
 # POS_CENTER_BELOW: Centers the pop-up window below the button (default).

--- a/virtaal/views/widgets/popupwidgetbutton.py
+++ b/virtaal/views/widgets/popupwidgetbutton.py
@@ -21,9 +21,7 @@ PopupWidgetButton: Extends a C{Gtk.ToggleButton} to show a given widget in a
 pop-up window.
 """
 
-from gi.repository import Gdk
-from gi.repository import Gtk
-from gi.repository import GObject
+from gi.repository import Gdk, GObject, Gtk
 
 # XXX: Kudo's to Toms Bauģis <toms.baugis at gmail.com> who wrote the
 #      ActivityEntry widget for the hamster-applet project. A lot of this

--- a/virtaal/views/widgets/selectdialog.py
+++ b/virtaal/views/widgets/selectdialog.py
@@ -16,11 +16,11 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-from gi.repository import Gtk
-from gi.repository import GObject
+from gi.repository import GObject, Gtk
 from gi.repository.GObject import TYPE_PYOBJECT
 
 from virtaal.common import GObjectWrapper
+
 from .selectview import SelectView
 
 

--- a/virtaal/views/widgets/selectview.py
+++ b/virtaal/views/widgets/selectview.py
@@ -19,8 +19,7 @@
 
 from locale import strxfrm
 
-from gi.repository import Gtk
-from gi.repository import GObject
+from gi.repository import GObject, Gtk
 from gi.repository.GObject import TYPE_PYOBJECT
 
 from virtaal.common import GObjectWrapper

--- a/virtaal/views/widgets/storecellrenderer.py
+++ b/virtaal/views/widgets/storecellrenderer.py
@@ -16,9 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-from gi.repository import GObject
-from gi.repository import Gtk
-from gi.repository import Pango
+from gi.repository import GObject, Gtk, Pango
 from translate.lang import factory
 
 from virtaal.common import pan_app

--- a/virtaal/views/widgets/storetreemodel.py
+++ b/virtaal/views/widgets/storetreemodel.py
@@ -16,8 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-from gi.repository import GObject
-from gi.repository import Gtk
+from gi.repository import GObject, Gtk
 
 from virtaal.views import markup
 

--- a/virtaal/views/widgets/storetreeview.py
+++ b/virtaal/views/widgets/storetreeview.py
@@ -19,11 +19,10 @@
 
 import logging
 
-from gi.repository import GLib, GObject
-from gi.repository import Gtk
+from gi.repository import GLib, GObject, Gtk
 
 from .storecellrenderer import StoreCellRenderer
-from .storetreemodel import COLUMN_NOTE, COLUMN_UNIT, COLUMN_EDITABLE, StoreTreeModel
+from .storetreemodel import COLUMN_EDITABLE, COLUMN_NOTE, COLUMN_UNIT, StoreTreeModel
 
 
 class StoreTreeView(Gtk.TreeView):

--- a/virtaal/views/widgets/test_langadddialog.py
+++ b/virtaal/views/widgets/test_langadddialog.py
@@ -17,6 +17,7 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 import gi
+
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
 

--- a/virtaal/views/widgets/test_popupmenubutton.py
+++ b/virtaal/views/widgets/test_popupmenubutton.py
@@ -27,6 +27,7 @@ collect whenever and however it likes."""
 from unittest.mock import MagicMock
 
 import gi
+
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
 

--- a/virtaal/views/widgets/textbox.py
+++ b/virtaal/views/widgets/textbox.py
@@ -17,14 +17,14 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-from gi.repository import Gtk, Gdk
+from gi.repository import Gdk, Gtk
 from gi.repository.GObject import SignalFlags
-from translate.storage.placeables import StringElem, parse as elem_parse
+from translate.storage.placeables import StringElem
+from translate.storage.placeables import parse as elem_parse
 
 from virtaal.support.translate_compat import forceunicode
 from virtaal.views import placeablesguiinfo
 from virtaal.views.theme import current_theme
-
 
 
 def colors_equal(a, b):

--- a/virtaal/views/widgets/welcomescreen.py
+++ b/virtaal/views/widgets/welcomescreen.py
@@ -18,7 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-from gi.repository import GLib, GObject, Gtk, Gdk
+from gi.repository import Gdk, GLib, GObject, Gtk
 
 from virtaal.views.theme import current_theme
 


### PR DESCRIPTION
Mechanical ruff check --select I --fix - stdlib/first-party/relative import groups, alphabetized within each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)