### PR TITLE
Unify copyright headers, part 1: AUTHORS.md + license header template

### DIFF
--- a/.license.header.txt
+++ b/.license.header.txt
@@ -1,0 +1,13 @@
+Python
+
+#
+# Copyright (C) Virtaal contributors.
+#
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
+
+
+A `#!/usr/bin/env python` shebang may appear directly above this block,
+but only on a file that's actually run directly - most files here
+aren't.

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,46 @@
+# Virtaal Authors
+
+These are people and organisations that have contributed to Virtaal.
+
+More detailed contribution statistics can be found on GitHub's
+[contributors page](https://github.com/translate/virtaal/graphs/contributors).
+
+## Historical perspective
+
+Virtaal was initially created by Wynand Winterbach for Translate.org.za
+(the Zuza Software Foundation). Friedel Wolff, Dwayne Bailey and Walter
+Leibbrandt have been its long-term maintainers since.
+
+## Donors and funders
+
+- The International Development Research Centre (http://idrc.ca/)
+- Mozilla Corporation (http://mozilla.com/)
+
+## Contributors
+
+- Friedel Wolff
+- Dwayne Bailey
+- Walter Leibbrandt
+- Wynand Winterbach
+- Alaa Abd el Fattah
+- Stuart Prescott
+- licamla
+- Julen Ruiz Aizpuru
+- Alexander Dupuy
+- Khaled Hosny
+- Luiz Fernando Ranghetti
+- Leandro Regueiro
+- Rafael Fontenelle
+- Rail Aliev
+- GursharnjitSingh
+- Muhammad Taufiq Sumadi
+- Pavol Babincak
+- scootergrisen
+- Yaron Shahrabani
+- Adam Chainz
+- Charles Samborski
+- Jerome Leclanche
+- Vasco Almeida
+- VenusGirl
+- Dušan Kazik
+- Darío Hereñú


### PR DESCRIPTION
First of a 3-part chain splitting #3437 (part1 → part2 → part3), so the foundation, the About-dialog change, and the mechanical header rewrite land as separate reviewable steps.

Adds `AUTHORS.md` (a real top-level authors/donors file, Pootle's convention) and `.license.header.txt` (the template new `.py` files should use). No existing file's header changes yet - that's part3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)