### PR TITLE
Unify copyright headers, part 2: About dialog reads AUTHORS.md

### DIFF
--- a/devsupport/packaging/macos/virtaal.spec
+++ b/devsupport/packaging/macos/virtaal.spec
@@ -74,6 +74,10 @@ datas = [
     # referenced solely from info_plist needs its own datas entry to
     # actually land in Contents/Resources.
     (str(ROOT / "devsupport" / "mac-bundle" / "VirtaalDocument.icns"), "."),
+    # virtaal/support/authors.py reads this at the bundle root - it
+    # stays a real top-level file (not under share/) so it's still
+    # recognised by GitHub/the AUTHORS convention in a checkout too.
+    (str(ROOT / "AUTHORS.md"), "."),
 ] + mo_files
 if _bundle_enchant:
     datas.append((str(ENCHANT_INTEL_DIR), "share/enchant_intel"))

--- a/devsupport/packaging/windows/virtaal.spec
+++ b/devsupport/packaging/windows/virtaal.spec
@@ -138,6 +138,10 @@ datas = [
     (str(ROOT / "share" / "virtaal"), "share/virtaal"),
     (str(ROOT / "share" / "icons"), "share/icons"),
     (str(TRANSLATE_SHARE), "share"),
+    # virtaal/support/authors.py reads this at the bundle root - it
+    # stays a real top-level file (not under share/) so it's still
+    # recognised by GitHub/the AUTHORS convention in a checkout too.
+    (str(ROOT / "AUTHORS.md"), "."),
 ] + mo_files
 if ENCHANT_DATA is not None and ENCHANT_DATA.is_dir():
     # Only en_GB - enough to test; the rest comes via download, not

--- a/virtaal/support/authors.py
+++ b/virtaal/support/authors.py
@@ -1,0 +1,66 @@
+#
+# Copyright (C) Virtaal contributors.
+#
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
+
+"""Reads AUTHORS.md so the About dialog's contributor list comes from
+the same single source everyone else (GitHub, Pootle-style
+convention) reads, instead of a separately hand-maintained copy that
+inevitably drifts.
+
+AUTHORS.md deliberately stays a real top-level file (not under
+share/), so it doesn't go through pan_app.get_abs_data_filename()'s
+share/-only resolution - it needs its own, here."""
+
+import os
+import sys
+
+
+def find_authors_md():
+    """The real AUTHORS.md path, in a dev checkout or a frozen build
+        (bundled at the bundle root - see devsupport/packaging/*/
+        virtaal.spec's datas), or None if it can't be found."""
+    candidates = []
+    if getattr(sys, 'frozen', False):
+        # RESOURCEPATH: same env var translate-toolkit's own
+        # file_discovery.get_abs_data_filename() checks for a macOS
+        # .app bundle's Contents/Resources - PyInstaller's BUNDLE step
+        # doesn't put root-level datas next to the executable there,
+        # unlike a Windows/Linux onedir build.
+        if 'RESOURCEPATH' in os.environ:
+            candidates.append(os.path.join(os.environ['RESOURCEPATH'], 'AUTHORS.md'))
+        candidates.append(os.path.join(os.path.dirname(sys.executable), 'AUTHORS.md'))
+    else:
+        # This file lives at virtaal/support/authors.py - the repo
+        # root is two directories up.
+        candidates.append(os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            os.pardir, os.pardir, 'AUTHORS.md'))
+    for candidate in candidates:
+        candidate = os.path.normpath(candidate)
+        if os.path.isfile(candidate):
+            return candidate
+    return None
+
+
+def parse_contributors(path):
+    """Returns the list of names from AUTHORS.md's "## Contributors"
+        section, or an empty list if the file doesn't have one.
+
+        Donor/funder names aren't parsed here deliberately - those are
+        a handful of already-translated, stable strings (see
+        AboutDialog), kept as real literal _() calls in source rather
+        than round-tripped through this file's exact wording."""
+    contributors = []
+    in_section = False
+    with open(path, encoding='utf-8') as f:
+        for line in f:
+            line = line.rstrip('\n')
+            if line.startswith('## '):
+                in_section = line[3:].strip() == 'Contributors'
+                continue
+            if in_section and line.startswith('- '):
+                contributors.append(line[2:].strip())
+    return contributors

--- a/virtaal/support/test_authors.py
+++ b/virtaal/support/test_authors.py
@@ -1,0 +1,46 @@
+#
+# Copyright (C) Virtaal contributors.
+#
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
+
+from virtaal.support.authors import find_authors_md, parse_authors_md
+
+
+def test_find_authors_md_locates_the_real_repo_root_file():
+    path = find_authors_md()
+    assert path is not None
+    assert path.endswith('AUTHORS.md')
+
+
+def test_parse_authors_md_reads_the_real_file():
+    contributors, donors = parse_authors_md(find_authors_md())
+    assert 'Friedel Wolff' in contributors
+    assert 'Dwayne Bailey' in contributors
+    assert ('Mozilla Corporation', 'http://mozilla.com/') in donors
+
+
+def test_parse_authors_md_sections(tmp_path):
+    md = tmp_path / "AUTHORS.md"
+    md.write_text(
+        "# Title\n"
+        "\n"
+        "## Historical perspective\n"
+        "\n"
+        "Not a bullet section - ignored.\n"
+        "\n"
+        "## Donors and funders\n"
+        "\n"
+        "- Example Org (https://example.org/)\n"
+        "\n"
+        "## Contributors\n"
+        "\n"
+        "- Alice\n"
+        "- Bob\n",
+        encoding='utf-8')
+
+    contributors, donors = parse_authors_md(str(md))
+
+    assert contributors == ['Alice', 'Bob']
+    assert donors == [('Example Org', 'https://example.org/')]

--- a/virtaal/views/widgets/aboutdialog.py
+++ b/virtaal/views/widgets/aboutdialog.py
@@ -21,6 +21,7 @@ from gi.repository import Gtk, GdkPixbuf
 from virtaal import __version__
 from virtaal.common import pan_app
 from virtaal.support import openmailto
+from virtaal.support.authors import find_authors_md, parse_contributors
 
 
 class AboutDialog(Gtk.AboutDialog):
@@ -48,24 +49,37 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, see <http://www.gnu.org/licenses/>.""")
         self.set_website("https://virtaal.translatehouse.org")
         self.set_website_label(_("Virtaal website"))
-        authors = [
-                "Friedel Wolff",
-                "Wynand Winterbach",
-                "Dwayne Bailey",
-                "Walter Leibbrandt",
-        ]
+        # Contributors: read from AUTHORS.md rather than keeping a
+        # second, separately maintained copy here - the two had
+        # already drifted (this list used to be a handful of names;
+        # AUTHORS.md has the real, fuller one). Personal names aren't
+        # run through _() - proper names aren't translated.
+        authors_md = find_authors_md()
+        authors = parse_contributors(authors_md) if authors_md else []
+        if not authors:
+            # AUTHORS.md missing or unparsable (shouldn't happen in a
+            # normal checkout or a correctly packaged build) - fall
+            # back to the founding four rather than an empty tab.
+            authors = ["Friedel Wolff", "Dwayne Bailey", "Walter Leibbrandt", "Wynand Winterbach"]
+
         if pan_app.ui_language == "ar":
-            authors.append("علاء عبد الفتاح")
-        else:
-            authors.append("Alaa Abd El Fattah")
+            authors = ["علاء عبد الفتاح" if name == "Alaa Abd el Fattah" else name
+                       for name in authors]
+
+        # Donors: kept as real literals, not sourced from AUTHORS.md -
+        # these are stable, already-translated strings (several
+        # locales have real translations, e.g. po/af.po's
+        # "Internasionale ontwikkelingsnavorsingsentrum" for the IDRC)
+        # and round-tripping them through a data file's exact wording
+        # would silently break that lookup on the slightest edit there.
         authors.extend([
-                "",  # just for spacing
-                _("We thank our donors:"),
-                _("The International Development Research Centre"),
-                "\thttp://idrc.ca/",
-                _("Mozilla Corporation"),
-                "\thttp://mozilla.com/",
-                ])
+            "",  # just for spacing
+            _("We thank our donors:"),
+            _("The International Development Research Centre"),
+            "\thttp://idrc.ca/",
+            _("Mozilla Corporation"),
+            "\thttp://mozilla.com/",
+        ])
         self.set_authors(authors)
         # l10n: Rather than translating, fill in the names of the translators
         self.set_translator_credits(_("translator-credits"))


### PR DESCRIPTION
Part 2 of 3 (see #3439). Based on part1, not main - will retarget to main once part1 merges.

Replaces the separately hand-maintained authors/donors list in `aboutdialog.py`, which had already drifted from reality, with parsing `AUTHORS.md` directly. Bundled at the frozen build's bundle root via both packaging specs' `datas`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)