### PR TITLE
Unify copyright headers, part 3: mechanical rewrite + pre-commit enforcement

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,3 +52,9 @@ repos:
         language: system
         pass_filenames: false
         files: ^devsupport/mac-bundle/(VirtaalDocumentIcon_.*\.svg|icons/VolumeIcon_virtaal\.svg)$
+      - id: check-copyright-header
+        name: check the unified copyright header (.license.header.txt)
+        entry: devsupport/check-copyright-header.sh
+        language: system
+        files: \.py$
+        pass_filenames: true

--- a/bin/virtaal
+++ b/bin/virtaal
@@ -1,22 +1,10 @@
 #!/usr/bin/env python
 #
-# Copyright 2007-2011 Zuza Software Foundation
-# Copyright 2013,2015 F Wolff
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 import sys
 from os import path

--- a/devsupport/__init__.py
+++ b/devsupport/__init__.py
@@ -1,17 +1,6 @@
 #
-# Copyright 2009 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.

--- a/devsupport/check-copyright-header.sh
+++ b/devsupport/check-copyright-header.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# Pre-commit hook: every .py file should carry the unified header
+# documented in .license.header.txt. Tolerates an optional shebang
+# line immediately above the block (only setup.py actually needs
+# one - see PR #3430), doesn't require its absence.
+#
+# Skips a small, fixed allowlist of files that deliberately don't
+# carry this header - either a genuine third-party notice sits above
+# it instead (locale.py, openmailto.py, sorted_set.py,
+# simplegeneric.py all still append it underneath their own, so they
+# pass), or the file is wholesale vendored code with no Virtaal
+# copyright to state at all (ipython_view.py, selector.py, statsdb.py,
+# tmdb.py, tmserver.py, translate_compat.py, wsgi.py).
+#
+# Doesn't touch files that never had a header at all before this
+# check existed (see FEATURE doc's own note - a real, separate,
+# not-yet-made decision) - only checks files that already do.
+set -eu
+
+HEADER='#
+# Copyright (C) Virtaal contributors.
+#
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.'
+
+ALLOWLIST='
+virtaal/support/libi18n/locale.py
+virtaal/support/openmailto.py
+virtaal/support/sorted_set.py
+virtaal/support/simplegeneric.py
+virtaal/plugins/_ipython_console/ipython_view.py
+virtaal/support/selector.py
+virtaal/support/statsdb.py
+virtaal/support/tmdb.py
+virtaal/support/tmserver.py
+virtaal/support/translate_compat.py
+virtaal/support/wsgi.py
+'
+
+changed=("$@")
+failed=()
+
+for f in "${changed[@]}"; do
+    case "$f" in
+        *.py) ;;
+        *) continue ;;
+    esac
+    [ -f "$f" ] || continue
+    case "$ALLOWLIST" in
+        *$'\n'"$f"$'\n'*) continue ;;
+    esac
+
+    # A file that never had a header before this check existed isn't
+    # this check's problem to fix - only files that already carry
+    # *some* header are held to the unified text.
+    if ! head -1 "$f" | grep -qE '^#(!/usr/bin/env python.*)?$'; then
+        continue
+    fi
+
+    actual=$(sed -n '1,6p' "$f")
+    if [ "${actual#\#!/usr/bin/env python}" != "$actual" ]; then
+        # Shebang present - the header starts one line later.
+        actual=$(sed -n '2,7p' "$f")
+    fi
+
+    if [ "$actual" != "$HEADER" ]; then
+        failed+=("$f")
+    fi
+done
+
+if [ "${#failed[@]}" -gt 0 ]; then
+    echo "These files don't carry the unified copyright header (see .license.header.txt):" >&2
+    printf '  %s\n' "${failed[@]}" >&2
+    exit 1
+fi

--- a/devsupport/debugging.py
+++ b/devsupport/debugging.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2009 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 
 

--- a/devsupport/packaging/macos/generate_info_plist.py
+++ b/devsupport/packaging/macos/generate_info_plist.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2026 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 """Generates Contents/Info.plist for the macOS .app bundle (see
 devsupport/packaging/macos/build.sh). Run with the same Python environment

--- a/devsupport/profiling.py
+++ b/devsupport/profiling.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2008-2009 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 def label(code):
     if isinstance(code, str):

--- a/devsupport/testing/fuzz/fuzz_ui.py
+++ b/devsupport/testing/fuzz/fuzz_ui.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2026 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 """In-process UI fuzzer - see FEATURE-CRASH-HARDENING.md for the design this
 implements.

--- a/devsupport/tmp_strings.py
+++ b/devsupport/tmp_strings.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2009 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 # This just contains some strings that are bugfixes that need to be translatable
 

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -20,3 +20,12 @@ checks themselves::
 That installs a git hook so the checks run automatically before each
 commit. ``pre-commit`` itself also still works unmodified against the
 same config file, if you'd rather use that.
+
+Copyright headers
+===================
+
+New ``.py`` files should carry the header documented in
+``.license.header.txt`` at the repo root - see ``AUTHORS.md`` for the
+full contributor list this points at. One of the pre-commit checks
+above verifies it on every changed file that already has some header;
+it doesn't require one on a file that never had one.

--- a/setup.py
+++ b/setup.py
@@ -1,22 +1,10 @@
 #!/usr/bin/env python
 #
-# Copyright 2008-2026 Zuza Software Foundation
-# Copyright 2013 F Wolff
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 """setup.py now only handles what pyproject.toml can't express
 declaratively: compiling .mo files from .po sources, and (on Linux)

--- a/virtaal/__init__.py
+++ b/virtaal/__init__.py
@@ -1,17 +1,6 @@
 #
-# Copyright 2008-2009 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.

--- a/virtaal/__version__.py
+++ b/virtaal/__version__.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2008-2009 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 """This file contains the version."""
 ver = "1.0.0-beta1"

--- a/virtaal/common/__init__.py
+++ b/virtaal/common/__init__.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2008-2009 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 from . import pan_app
 from .gobjectwrapper import GObjectWrapper

--- a/virtaal/common/gobjectwrapper.py
+++ b/virtaal/common/gobjectwrapper.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2008-2010 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 from gi.repository import GObject
 

--- a/virtaal/common/pan_app.py
+++ b/virtaal/common/pan_app.py
@@ -1,21 +1,9 @@
 #
-# Copyright 2007-2010 Zuza Software Foundation
-# Copyright 2013-2014 F Wolff
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 
 #XXX: main imports lower down

--- a/virtaal/common/platform.py
+++ b/virtaal/common/platform.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2026 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 """A single, testable place to ask "which platform is this?".
 

--- a/virtaal/common/test_pan_app.py
+++ b/virtaal/common/test_pan_app.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2026 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 import os
 

--- a/virtaal/common/test_platform.py
+++ b/virtaal/common/test_platform.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2026 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 import os
 import platform as platform_module

--- a/virtaal/controllers/__init__.py
+++ b/virtaal/controllers/__init__.py
@@ -1,17 +1,6 @@
 #
-# Copyright 2008-2010 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.

--- a/virtaal/controllers/basecontroller.py
+++ b/virtaal/controllers/basecontroller.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2008-2009 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 from virtaal.common import GObjectWrapper
 

--- a/virtaal/controllers/baseplugin.py
+++ b/virtaal/controllers/baseplugin.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2008-2009 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 import os
 

--- a/virtaal/controllers/checkscontroller.py
+++ b/virtaal/controllers/checkscontroller.py
@@ -1,21 +1,9 @@
 #
-# Copyright 2010-2011 Zuza Software Foundation
-# Copyright 2015-2016 F Wolff
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 import logging
 

--- a/virtaal/controllers/cursor.py
+++ b/virtaal/controllers/cursor.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2008-2009 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 import logging
 from bisect import bisect_left

--- a/virtaal/controllers/langcontroller.py
+++ b/virtaal/controllers/langcontroller.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2009-2011 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 import os
 

--- a/virtaal/controllers/maincontroller.py
+++ b/virtaal/controllers/maincontroller.py
@@ -1,21 +1,9 @@
 #
-# Copyright 2008-2010 Zuza Software Foundation
-# Copyright 2013 F Wolff
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 import gi
 

--- a/virtaal/controllers/modecontroller.py
+++ b/virtaal/controllers/modecontroller.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2008-2009 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 from gi.repository import GObject
 

--- a/virtaal/controllers/placeablescontroller.py
+++ b/virtaal/controllers/placeablescontroller.py
@@ -1,21 +1,9 @@
 #
-# Copyright 2009-2010 Zuza Software Foundation
-# Copyright 2016 F Wolff
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 from gi.repository import GObject
 from translate.storage.placeables import StringElem, general

--- a/virtaal/controllers/plugincontroller.py
+++ b/virtaal/controllers/plugincontroller.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2008-2011 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 import logging
 import os

--- a/virtaal/controllers/prefscontroller.py
+++ b/virtaal/controllers/prefscontroller.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2008-2009 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 from virtaal.common import GObjectWrapper, pan_app
 

--- a/virtaal/controllers/propertiescontroller.py
+++ b/virtaal/controllers/propertiescontroller.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2011 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 from virtaal.common import GObjectWrapper
 

--- a/virtaal/controllers/storecontroller.py
+++ b/virtaal/controllers/storecontroller.py
@@ -1,21 +1,9 @@
 #
-# Copyright 2008-2010 Zuza Software Foundation
-# Copyright 2014 F Wolff
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 import os
 

--- a/virtaal/controllers/test_plugincontroller.py
+++ b/virtaal/controllers/test_plugincontroller.py
@@ -1,21 +1,10 @@
 #!/usr/bin/env python
 #
-# Copyright 2026 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 import os
 

--- a/virtaal/controllers/test_welcomescreencontroller.py
+++ b/virtaal/controllers/test_welcomescreencontroller.py
@@ -1,21 +1,10 @@
 #!/usr/bin/env python
 #
-# Copyright 2026 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 from virtaal.controllers.welcomescreencontroller import WelcomeScreenController
 

--- a/virtaal/controllers/undocontroller.py
+++ b/virtaal/controllers/undocontroller.py
@@ -1,21 +1,9 @@
 #
-# Copyright 2008-2011 Zuza Software Foundation
-# Copyright 2013,2015 F Wolff
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 from gi.repository import Gdk, GLib, Gtk
 from translate.storage.placeables import StringElem

--- a/virtaal/controllers/unitcontroller.py
+++ b/virtaal/controllers/unitcontroller.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2008-2011 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 from gi.repository.GLib import timeout_add
 from gi.repository.GObject import SignalFlags

--- a/virtaal/controllers/welcomescreencontroller.py
+++ b/virtaal/controllers/welcomescreencontroller.py
@@ -1,21 +1,9 @@
 #
-# Copyright 2008-2011 Zuza Software Foundation
-# Copyright 2014 F Wolff
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 from virtaal.common.utils import get_unicode
 

--- a/virtaal/main.py
+++ b/virtaal/main.py
@@ -1,21 +1,9 @@
 #
-# Copyright 2008-2011 Zuza Software Foundation
-# Copyright 2013-2014 F Wolff
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 
 # This is the main loader for Virtaal. We want the GUI to show really quickly,

--- a/virtaal/models/__init__.py
+++ b/virtaal/models/__init__.py
@@ -1,17 +1,6 @@
 #
-# Copyright 2008-2009 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.

--- a/virtaal/models/basemodel.py
+++ b/virtaal/models/basemodel.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2008-2009 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 from gi.repository import GObject
 

--- a/virtaal/models/langmodel.py
+++ b/virtaal/models/langmodel.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2009 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 import logging
 

--- a/virtaal/models/storemodel.py
+++ b/virtaal/models/storemodel.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2008-2011 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 import os
 

--- a/virtaal/models/undomodel.py
+++ b/virtaal/models/undomodel.py
@@ -1,21 +1,9 @@
 #
-# Copyright 2008-2009 Zuza Software Foundation
-# Copyright 2013 F Wolff
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 from .basemodel import BaseModel
 

--- a/virtaal/modes/__init__.py
+++ b/virtaal/modes/__init__.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2008-2010 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 from .defaultmode import DefaultMode
 from .qualitycheckmode import QualityCheckMode

--- a/virtaal/modes/basemode.py
+++ b/virtaal/modes/basemode.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2008-2009 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 
 class BaseMode:

--- a/virtaal/modes/defaultmode.py
+++ b/virtaal/modes/defaultmode.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2008-2009 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 from .basemode import BaseMode
 

--- a/virtaal/modes/qualitycheckmode.py
+++ b/virtaal/modes/qualitycheckmode.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2010-2011 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 import locale
 

--- a/virtaal/modes/quicktransmode.py
+++ b/virtaal/modes/quicktransmode.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2008-2009 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 from virtaal.support.set_enumerator import UnionSetEnumerator
 from virtaal.support.sorted_set import SortedSet

--- a/virtaal/modes/searchmode.py
+++ b/virtaal/modes/searchmode.py
@@ -1,21 +1,9 @@
 #
-# Copyright 2008-2011 Zuza Software Foundation
-# Copyright 2013,2015,2016 F Wolff
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 import logging
 

--- a/virtaal/modes/test_searchmode.py
+++ b/virtaal/modes/test_searchmode.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2026 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 from types import SimpleNamespace
 

--- a/virtaal/modes/workflowmode.py
+++ b/virtaal/modes/workflowmode.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2010-2011 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 from gi.repository import GLib, Gtk
 

--- a/virtaal/plugins/__init__.py
+++ b/virtaal/plugins/__init__.py
@@ -1,17 +1,6 @@
 #
-# Copyright 2008-2009 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.

--- a/virtaal/plugins/_helloworld.py
+++ b/virtaal/plugins/_helloworld.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2008-2009 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 """example plugin."""
 

--- a/virtaal/plugins/autocompletor.py
+++ b/virtaal/plugins/autocompletor.py
@@ -1,21 +1,9 @@
 #
-# Copyright 2008-2010 Zuza Software Foundation
-# Copyright 2013 F Wolff
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 """Contains the AutoCompletor class."""
 

--- a/virtaal/plugins/autocorrector.py
+++ b/virtaal/plugins/autocorrector.py
@@ -1,21 +1,9 @@
 #
-# Copyright 2008-2009 Zuza Software Foundation
-# Copyright 2013 F Wolff
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 """Contains the AutoCorrector class."""
 

--- a/virtaal/plugins/lookup/__init__.py
+++ b/virtaal/plugins/lookup/__init__.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2009 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 """Performs external look-ups on selected text."""
 

--- a/virtaal/plugins/lookup/lookupcontroller.py
+++ b/virtaal/plugins/lookup/lookupcontroller.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2009 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 import os
 

--- a/virtaal/plugins/lookup/lookupview.py
+++ b/virtaal/plugins/lookup/lookupview.py
@@ -1,21 +1,9 @@
 #
-# Copyright 2010 Zuza Software Foundation
-# Copyright 2016 F Wolff
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 import logging
 

--- a/virtaal/plugins/lookup/models/__init__.py
+++ b/virtaal/plugins/lookup/models/__init__.py
@@ -1,17 +1,6 @@
 #
-# Copyright 2009 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.

--- a/virtaal/plugins/lookup/models/baselookupmodel.py
+++ b/virtaal/plugins/lookup/models/baselookupmodel.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2009 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 
 class BaseLookupModel:

--- a/virtaal/plugins/lookup/models/weblookup.py
+++ b/virtaal/plugins/lookup/models/weblookup.py
@@ -1,21 +1,9 @@
 #
-# Copyright 2009 Zuza Software Foundation
-# Copyright 2014 F Wolff
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 from os import path
 from urllib import parse

--- a/virtaal/plugins/migration.py
+++ b/virtaal/plugins/migration.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2008-2009 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 """Plugin to import data from other applications.
 

--- a/virtaal/plugins/spellchecker.py
+++ b/virtaal/plugins/spellchecker.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2010-2011 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 import logging
 import os

--- a/virtaal/plugins/terminology/__init__.py
+++ b/virtaal/plugins/terminology/__init__.py
@@ -1,21 +1,9 @@
 #
-# Copyright 2009 Zuza Software Foundation
-# Copyright 2014 F Wolff
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 from virtaal.controllers.baseplugin import BasePlugin
 

--- a/virtaal/plugins/terminology/models/__init__.py
+++ b/virtaal/plugins/terminology/models/__init__.py
@@ -1,17 +1,6 @@
 #
-# Copyright 2009 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.

--- a/virtaal/plugins/terminology/models/autoterm.py
+++ b/virtaal/plugins/terminology/models/autoterm.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2009-2010 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 import logging
 import os

--- a/virtaal/plugins/terminology/models/basetermmodel.py
+++ b/virtaal/plugins/terminology/models/basetermmodel.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2009 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 import os
 

--- a/virtaal/plugins/terminology/models/localfile/__init__.py
+++ b/virtaal/plugins/terminology/models/localfile/__init__.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2009 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 import logging
 import os

--- a/virtaal/plugins/terminology/models/localfile/localfileview.py
+++ b/virtaal/plugins/terminology/models/localfile/localfileview.py
@@ -1,21 +1,9 @@
 #
-# Copyright 2009-2011 Zuza Software Foundation
-# Copyright 2016 F Wolff
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 import locale
 

--- a/virtaal/plugins/terminology/models/pontoon.py
+++ b/virtaal/plugins/terminology/models/pontoon.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2009-2010 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 import logging
 import os

--- a/virtaal/plugins/terminology/models/test_pontoon.py
+++ b/virtaal/plugins/terminology/models/test_pontoon.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2026 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 import configparser
 import io

--- a/virtaal/plugins/terminology/termcontroller.py
+++ b/virtaal/plugins/terminology/termcontroller.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2009-2010 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 import os.path
 

--- a/virtaal/plugins/terminology/termview.py
+++ b/virtaal/plugins/terminology/termview.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2009-2011 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 import logging
 

--- a/virtaal/plugins/test_autocorrector.py
+++ b/virtaal/plugins/test_autocorrector.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2026 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 """Tests for AutoCorrector's load_dictionary()/_read_document_list()
 and autocorrect() - the plain data logic, no real GTK widgets

--- a/virtaal/plugins/test_spellchecker.py
+++ b/virtaal/plugins/test_spellchecker.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2026 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 """Tests for the spellchecker plugin.
 

--- a/virtaal/plugins/tm/__init__.py
+++ b/virtaal/plugins/tm/__init__.py
@@ -1,21 +1,9 @@
 #
-# Copyright 2008-2009 Zuza Software Foundation
-# Copyright 2014 F Wolff
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 from virtaal.controllers.baseplugin import BasePlugin
 

--- a/virtaal/plugins/tm/models/__init__.py
+++ b/virtaal/plugins/tm/models/__init__.py
@@ -1,17 +1,6 @@
 #
-# Copyright 2008-2009 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.

--- a/virtaal/plugins/tm/models/_dummytm.py
+++ b/virtaal/plugins/tm/models/_dummytm.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2008-2009 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 from .basetmmodel import BaseTMModel
 

--- a/virtaal/plugins/tm/models/amagama.py
+++ b/virtaal/plugins/tm/models/amagama.py
@@ -1,21 +1,9 @@
 #
-# Copyright 2010 Zuza Software Foundation
-# Copyright 2016 F Wolff
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 from . import remotetm
 from .basetmmodel import BaseTMModel

--- a/virtaal/plugins/tm/models/apertium.py
+++ b/virtaal/plugins/tm/models/apertium.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2009-2010 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 """A TM provider that can query the web service for the Apertium software for
 Machine Translation.

--- a/virtaal/plugins/tm/models/basetmmodel.py
+++ b/virtaal/plugins/tm/models/basetmmodel.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2008-2009 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 import os
 import re

--- a/virtaal/plugins/tm/models/currentfile.py
+++ b/virtaal/plugins/tm/models/currentfile.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2008-2011 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 from translate.search import match
 

--- a/virtaal/plugins/tm/models/google_translate.py
+++ b/virtaal/plugins/tm/models/google_translate.py
@@ -1,21 +1,9 @@
 #
-# Copyright 2009 Zuza Software Foundation
-# Copyright 2014 F Wolff
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 import json
 import logging

--- a/virtaal/plugins/tm/models/localtm.py
+++ b/virtaal/plugins/tm/models/localtm.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2008-2009,2011 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 import logging
 import os

--- a/virtaal/plugins/tm/models/moses.py
+++ b/virtaal/plugins/tm/models/moses.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2009-2011 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 
 from .basetmmodel import BaseTMModel

--- a/virtaal/plugins/tm/models/remotetm.py
+++ b/virtaal/plugins/tm/models/remotetm.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2008-2011 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 from virtaal.common.utils import get_unicode
 

--- a/virtaal/plugins/tm/models/test_basetmmodel.py
+++ b/virtaal/plugins/tm/models/test_basetmmodel.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2009 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 from .basetmmodel import unescape_html_entities
 

--- a/virtaal/plugins/tm/tmcontroller.py
+++ b/virtaal/plugins/tm/tmcontroller.py
@@ -1,21 +1,9 @@
 #
-# Copyright 2008-2011 Zuza Software Foundation
-# Copyright 2016 F Wolff
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 import os.path
 

--- a/virtaal/plugins/tm/tmview.py
+++ b/virtaal/plugins/tm/tmview.py
@@ -1,21 +1,9 @@
 #
-# Copyright 2008-2011 Zuza Software Foundation
-# Copyright 2016 F Wolff
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 import logging
 

--- a/virtaal/plugins/tm/tmwidgets.py
+++ b/virtaal/plugins/tm/tmwidgets.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2008-2010 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 
 from gi.repository import GObject, Gtk, Pango

--- a/virtaal/support/__init__.py
+++ b/virtaal/support/__init__.py
@@ -1,17 +1,6 @@
 #
-# Copyright 2008-2009 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.

--- a/virtaal/support/autocorrect_downloader.py
+++ b/virtaal/support/autocorrect_downloader.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2026 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 """Downloads a missing autocorrect DocumentList.xml in the background,
 via the app's own async HTTPClient - the non-blocking counterpart to

--- a/virtaal/support/autocorrect_source.py
+++ b/virtaal/support/autocorrect_source.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2026 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 """Source autocorrect data directly from LibreOffice's own core repo
 (github.com/LibreOffice/core, extras/source/autocorr/lang) - just the

--- a/virtaal/support/bug_report.py
+++ b/virtaal/support/bug_report.py
@@ -1,21 +1,10 @@
 #!/usr/bin/env python
 #
-# Copyright 2026 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 """Builds a GitHub "New issue" URL pre-filled with what Virtaal can
 tell about itself - version, OS, install method - using GitHub's own

--- a/virtaal/support/depcheck.py
+++ b/virtaal/support/depcheck.py
@@ -1,21 +1,9 @@
 #
-# Copyright 2009-2010 Zuza Software Foundation
-# Copyright 2013,2015 F Wolff
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 import importlib.util
 

--- a/virtaal/support/dictionary_download_watcher.py
+++ b/virtaal/support/dictionary_download_watcher.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2026 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 """Downloads a missing spell-check dictionary in the background the
 first time a target language is selected that enchant has no

--- a/virtaal/support/dictionary_downloader.py
+++ b/virtaal/support/dictionary_downloader.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2026 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 """Downloads a missing spell-check dictionary in the background, via
 the app's own async HTTPClient - the non-blocking counterpart to

--- a/virtaal/support/dictionary_source.py
+++ b/virtaal/support/dictionary_source.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2026 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 """Source hunspell spell-check dictionaries directly from LibreOffice's
 own dictionaries repo (github.com/LibreOffice/dictionaries) - LibreOffice

--- a/virtaal/support/httpclient.py
+++ b/virtaal/support/httpclient.py
@@ -1,21 +1,9 @@
 #
-# Copyright 2008-2011 Zuza Software Foundation
-# 2013,2015,2016 Friedel Wolff
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 import logging
 from io import BytesIO

--- a/virtaal/support/libi18n/locale.py
+++ b/virtaal/support/libi18n/locale.py
@@ -16,6 +16,9 @@
 #
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library; If not, see <http://www.gnu.org/licenses/>.
+#
+# Later modifications: Copyright (C) Virtaal contributors. See the
+# AUTHORS.md file for copyright and authorship information.
 
 
 import os

--- a/virtaal/support/match_compat.py
+++ b/virtaal/support/match_compat.py
@@ -1,19 +1,9 @@
-# Copyright 2026 Zuza Software Foundation
 #
-# This file is part of Virtaal.
+# Copyright (C) Virtaal contributors.
 #
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 """Compatibility shim around translate-toolkit's search.match.matcher.
 

--- a/virtaal/support/mosesclient.py
+++ b/virtaal/support/mosesclient.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2011 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 import logging
 import xmlrpc.client as xmlrpclib

--- a/virtaal/support/openmailto.py
+++ b/virtaal/support/openmailto.py
@@ -22,6 +22,9 @@
 #   Copyright (c) 2007, Antonio Valentino
 #   Obtained from http://aspn.activestate.com/ASPN/Cookbook/Python/Recipe/511443
 #   which is licensed under the Python license.
+#
+# Later modifications: Copyright (C) Virtaal contributors. See the
+# AUTHORS.md file for copyright and authorship information.
 
 """Utilities for opening files or URLs in the registered default application
 and for sending e-mail using the user's preferred composer."""

--- a/virtaal/support/pogrep_compat.py
+++ b/virtaal/support/pogrep_compat.py
@@ -1,19 +1,9 @@
-# Copyright 2026 Zuza Software Foundation
 #
-# This file is part of Virtaal.
+# Copyright (C) Virtaal contributors.
 #
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 """Compatibility shim around translate-toolkit's pogrep.GrepFilter.
 

--- a/virtaal/support/set_enumerator.py
+++ b/virtaal/support/set_enumerator.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2007-2009,2011 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 from bisect import bisect_left
 

--- a/virtaal/support/sorted_set.py
+++ b/virtaal/support/sorted_set.py
@@ -18,6 +18,9 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Later modifications: Copyright (C) Virtaal contributors. See the
+# AUTHORS.md file for copyright and authorship information.
 
 """ altsets.py -- An alternate implementation of Sets.py
 

--- a/virtaal/support/test_autocorrect_downloader.py
+++ b/virtaal/support/test_autocorrect_downloader.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2026 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 """Tests for AutocorrectDownloader's callback-chain orchestration - a
 _FakeClient records each .get() call instead of doing real network

--- a/virtaal/support/test_autocorrect_source.py
+++ b/virtaal/support/test_autocorrect_source.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2026 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 """Tests for autocorrect_source's pure enumerate/match logic - the raw
 network calls (fetch_autocorrect_folders/fetch_document_list) are

--- a/virtaal/support/test_bug_report.py
+++ b/virtaal/support/test_bug_report.py
@@ -1,21 +1,10 @@
 #!/usr/bin/env python
 #
-# Copyright 2026 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 from urllib.parse import parse_qs, urlsplit
 

--- a/virtaal/support/test_dictionary_download_watcher.py
+++ b/virtaal/support/test_dictionary_download_watcher.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2026 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 from virtaal.support.dictionary_download_watcher import DictionaryDownloadWatcher
 

--- a/virtaal/support/test_dictionary_downloader.py
+++ b/virtaal/support/test_dictionary_downloader.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2026 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 """Tests for DictionaryDownloader's callback-chain orchestration - a
 _FakeClient records each .get() call instead of doing real network

--- a/virtaal/support/test_dictionary_source.py
+++ b/virtaal/support/test_dictionary_source.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2026 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 """Tests for dictionary_source's pure enumerate/parse/match logic - the
 raw network calls (fetch_dictionary_tree/fetch_xcu/fetch_dictionary_file)

--- a/virtaal/support/test_tmclient.py
+++ b/virtaal/support/test_tmclient.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2026 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 from virtaal.support.tmclient import TMClient
 

--- a/virtaal/support/test_update_check.py
+++ b/virtaal/support/test_update_check.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2026 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 """Tests for update_check's pure version-comparison logic - the one
 part of the update check that's cheaply, deterministically testable

--- a/virtaal/support/tmclient.py
+++ b/virtaal/support/tmclient.py
@@ -1,21 +1,9 @@
 #
-# Copyright 2008-2010 Zuza Software Foundation
-# Copyright 2013 F Wolff
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 # These two json modules are API compatible
 try:

--- a/virtaal/support/tutorial.py
+++ b/virtaal/support/tutorial.py
@@ -1,21 +1,9 @@
 #
-# Copyright 2013 Zuza Software Foundation
-# Copyright 2012 Leandro Regueiro Iglesias
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 import os.path
 from tempfile import mkdtemp

--- a/virtaal/support/update_check.py
+++ b/virtaal/support/update_check.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2026 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 """Checks GitHub for a newer release than the one currently running.
 

--- a/virtaal/test/test_langmodel.py
+++ b/virtaal/test/test_langmodel.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2026 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 from virtaal.models.langmodel import LanguageModel
 

--- a/virtaal/test/test_maincontroller.py
+++ b/virtaal/test/test_maincontroller.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2008-2009 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 from test_scaffolding import TestScaffolding
 

--- a/virtaal/test/test_modecontroller.py
+++ b/virtaal/test/test_modecontroller.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2008-2009 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 from unittest.mock import MagicMock
 

--- a/virtaal/test/test_scaffolding.py
+++ b/virtaal/test/test_scaffolding.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2008-2009 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 import os
 import tempfile

--- a/virtaal/test/test_storecontroller.py
+++ b/virtaal/test/test_storecontroller.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2008-2009 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 from test_scaffolding import TestScaffolding
 

--- a/virtaal/test/test_storecursor.py
+++ b/virtaal/test/test_storecursor.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2008-2009 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 from test_scaffolding import TestScaffolding
 

--- a/virtaal/test/test_storemodel.py
+++ b/virtaal/test/test_storemodel.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2008-2009 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 from test_scaffolding import TestScaffolding
 

--- a/virtaal/test/test_unitcontroller.py
+++ b/virtaal/test/test_unitcontroller.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2008-2009 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 import os
 import tempfile

--- a/virtaal/test_version.py
+++ b/virtaal/test_version.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2026 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 from virtaal import __version__
 

--- a/virtaal/tips.py
+++ b/virtaal/tips.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2007-2009 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 """These are some tips that are displayed to the user."""
 

--- a/virtaal/views/__init__.py
+++ b/virtaal/views/__init__.py
@@ -1,17 +1,6 @@
 #
-# Copyright 2008-2009 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.

--- a/virtaal/views/baseview.py
+++ b/virtaal/views/baseview.py
@@ -1,21 +1,9 @@
 #
-# Copyright 2008-2009 Zuza Software Foundation
-# Copyright 2013 F Wolff
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 from gi.repository.Gtk import Builder
 

--- a/virtaal/views/checksprojview.py
+++ b/virtaal/views/checksprojview.py
@@ -1,21 +1,9 @@
 #
-# Copyright 2010 Zuza Software Foundation
-# Copyright 2016 F Wolff
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 import locale
 

--- a/virtaal/views/checksunitview.py
+++ b/virtaal/views/checksunitview.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2010 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 import locale
 

--- a/virtaal/views/langview.py
+++ b/virtaal/views/langview.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2009-2011 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 import locale
 import logging

--- a/virtaal/views/mainview.py
+++ b/virtaal/views/mainview.py
@@ -1,21 +1,9 @@
 #
-# Copyright 2008-2010 Zuza Software Foundation
-# Copyright 2013-2015 F Wolff
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 import locale
 import os

--- a/virtaal/views/markup.py
+++ b/virtaal/views/markup.py
@@ -1,21 +1,9 @@
 #
-# Copyright 2007-2011 Zuza Software Foundation
-# Copyright 2014 F Wolff
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 import re
 

--- a/virtaal/views/modeview.py
+++ b/virtaal/views/modeview.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2008-2009 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 from gi.repository import GObject, Gtk
 

--- a/virtaal/views/placeablesguiinfo.py
+++ b/virtaal/views/placeablesguiinfo.py
@@ -1,21 +1,9 @@
 #
-# Copyright 2009-2010 Zuza Software Foundation
-# Copyright 2013,2016 F Wolff
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 from gi.repository import Gdk, Gtk, Pango
 from translate.storage.placeables import StringElem, base, general, xliff

--- a/virtaal/views/prefsview.py
+++ b/virtaal/views/prefsview.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2008-2009 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 from gi.repository import Gdk, GObject, Gtk, Pango
 

--- a/virtaal/views/propertiesview.py
+++ b/virtaal/views/propertiesview.py
@@ -1,21 +1,9 @@
 #
-# Copyright 2011 Zuza Software Foundation
-# Copyright 2016 F Wolff
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 import logging
 

--- a/virtaal/views/recent.py
+++ b/virtaal/views/recent.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2008-2009 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 from gi.repository import Gtk
 from translate.storage import factory

--- a/virtaal/views/rendering.py
+++ b/virtaal/views/rendering.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2008-2009 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 from gi.repository import Pango
 

--- a/virtaal/views/storeview.py
+++ b/virtaal/views/storeview.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2008-2011 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 from gi.repository import Gdk, Gtk
 

--- a/virtaal/views/test_mainview.py
+++ b/virtaal/views/test_mainview.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2026 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 """Regression tests for MainView's native file dialogs.
 

--- a/virtaal/views/test_markup.py
+++ b/virtaal/views/test_markup.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2026 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 """Tests for markuptext(), the function behind escape/XML/diff highlighting
 in translation text - previously untested despite being used by

--- a/virtaal/views/test_modeview.py
+++ b/virtaal/views/test_modeview.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2026 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 import pytest
 

--- a/virtaal/views/test_propertiesview.py
+++ b/virtaal/views/test_propertiesview.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2026 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 import logging
 

--- a/virtaal/views/theme.py
+++ b/virtaal/views/theme.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2010 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 
 """This module contains some theme dependent colors.

--- a/virtaal/views/unitview.py
+++ b/virtaal/views/unitview.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2008-2011 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 import logging
 import re

--- a/virtaal/views/util.py
+++ b/virtaal/views/util.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2009 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 from gi.repository import Gdk, GLib, Gtk
 

--- a/virtaal/views/welcomescreenview.py
+++ b/virtaal/views/welcomescreenview.py
@@ -1,21 +1,9 @@
 #
-# Copyright 2008-2011 Zuza Software Foundation
-# Copyright 2013 F Wolff
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 from gi.repository import GLib, Gtk
 

--- a/virtaal/views/widgets/__init__.py
+++ b/virtaal/views/widgets/__init__.py
@@ -1,17 +1,6 @@
 #
-# Copyright 2008-2009 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.

--- a/virtaal/views/widgets/aboutdialog.py
+++ b/virtaal/views/widgets/aboutdialog.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2008-2010 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 from gi.repository import GdkPixbuf, Gtk
 

--- a/virtaal/views/widgets/cellrendererwidget.py
+++ b/virtaal/views/widgets/cellrendererwidget.py
@@ -1,21 +1,10 @@
 #
-# Copyright 2009 Zuza Software Foundation
-# Copyright 2016 F Wolff
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
+
 import gi
 
 gi.require_version('Gtk', '3.0')

--- a/virtaal/views/widgets/demo_selectdialog.py
+++ b/virtaal/views/widgets/demo_selectdialog.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2009 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 from .selectdialog import SelectDialog
 

--- a/virtaal/views/widgets/demo_selectview.py
+++ b/virtaal/views/widgets/demo_selectview.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2009 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 """Manual, interactive demo for SelectView - opens a real window for a
 human to eyeball, not an automated test. Run directly:

--- a/virtaal/views/widgets/demo_textbox.py
+++ b/virtaal/views/widgets/demo_textbox.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2009 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 """Manual, interactive demo for TextBox - opens a real window for a human
 to eyeball, not an automated test. Run directly: python demo_textbox.py

--- a/virtaal/views/widgets/label_expander.py
+++ b/virtaal/views/widgets/label_expander.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2008-2009 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 import Gtk.gdk
 from gi.repository import GObject, Gtk

--- a/virtaal/views/widgets/langadddialog.py
+++ b/virtaal/views/widgets/langadddialog.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2009 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 
 from gi.repository import Gtk

--- a/virtaal/views/widgets/langselectdialog.py
+++ b/virtaal/views/widgets/langselectdialog.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2009 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 import locale
 

--- a/virtaal/views/widgets/listnav.py
+++ b/virtaal/views/widgets/listnav.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2010-2011 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 """
 ListNavigator: A composite widget for navigating in a list of "states" by using

--- a/virtaal/views/widgets/popupmenubutton.py
+++ b/virtaal/views/widgets/popupmenubutton.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2008-2011 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 from gi.repository import Gdk, GObject, Gtk
 

--- a/virtaal/views/widgets/popupwidgetbutton.py
+++ b/virtaal/views/widgets/popupwidgetbutton.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2010 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 """
 PopupWidgetButton: Extends a C{Gtk.ToggleButton} to show a given widget in a

--- a/virtaal/views/widgets/selectdialog.py
+++ b/virtaal/views/widgets/selectdialog.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2009-2011 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 from gi.repository import GObject, Gtk
 from gi.repository.GObject import TYPE_PYOBJECT

--- a/virtaal/views/widgets/selectview.py
+++ b/virtaal/views/widgets/selectview.py
@@ -1,21 +1,9 @@
 #
-# Copyright 2009-2010 Zuza Software Foundation
-# Copyright 2016 F Wolff
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 from locale import strxfrm
 

--- a/virtaal/views/widgets/shortcutswindow.py
+++ b/virtaal/views/widgets/shortcutswindow.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2026 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 from gi.repository import Gtk
 

--- a/virtaal/views/widgets/storecellrenderer.py
+++ b/virtaal/views/widgets/storecellrenderer.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2008-2010 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 import functools
 

--- a/virtaal/views/widgets/storetreemodel.py
+++ b/virtaal/views/widgets/storetreemodel.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2008-2011 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 from gi.repository import GObject, Gtk
 

--- a/virtaal/views/widgets/storetreeview.py
+++ b/virtaal/views/widgets/storetreeview.py
@@ -1,21 +1,9 @@
 #
-# Copyright 2008-2010 Zuza Software Foundation
-# Copyright 2016 F Wolff
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 import logging
 

--- a/virtaal/views/widgets/test_langadddialog.py
+++ b/virtaal/views/widgets/test_langadddialog.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2026 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 import gi
 

--- a/virtaal/views/widgets/test_popupmenubutton.py
+++ b/virtaal/views/widgets/test_popupmenubutton.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2026 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 """Regression tests for Release Blocker #8 (a native segfault from popup-menu
 teardown racing Python's GC - see WorkflowMode/QualityCheckMode's own

--- a/virtaal/views/widgets/textbox.py
+++ b/virtaal/views/widgets/textbox.py
@@ -1,21 +1,9 @@
 #
-# Copyright 2009-2011 Zuza Software Foundation
-# Copyright 2013-2015 F Wolff
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 from gi.repository import Gdk, Gtk
 from gi.repository.GObject import SignalFlags

--- a/virtaal/views/widgets/util.py
+++ b/virtaal/views/widgets/util.py
@@ -1,20 +1,9 @@
 #
-# Copyright 2008-2009 Zuza Software Foundation
+# Copyright (C) Virtaal contributors.
 #
-# This file is part of Virtaal.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 __all__ = ['forall_widgets']
 

--- a/virtaal/views/widgets/welcomescreen.py
+++ b/virtaal/views/widgets/welcomescreen.py
@@ -1,22 +1,9 @@
-# -*- coding: UTF-8 -*-
-# Copyright
-#   2010-2011 Zuza Software Foundation
-#   2015 F Wolff
 #
-# This file is part of Virtaal.
+# Copyright (C) Virtaal contributors.
 #
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
 
 from gi.repository import Gdk, GLib, GObject, Gtk
 


### PR DESCRIPTION
Rebuilt directly against `main` (previously based on the now-defunct `part2-copyright-headers` chain, which predated #3442/#3444 landing) - regenerated fresh rather than rebased, since `main` had drifted enough that the old diff no longer applied cleanly.

Three commits:
1. The mechanical rewrite - 171 files, replacing 30 distinct copyright-line variants and each file's own GPL disclaimer copy with one fixed block pointing at LICENSE/AUTHORS.md, matching Pootle's convention. Eight carve-outs untouched (five wholesale-vendored files, three handled in the next commit).
2. Appends a 'later modifications' note underneath three files' genuine third-party notices (`libi18n/locale.py`, `support/openmailto.py`, `support/sorted_set.py`) rather than replacing them.
3. Adds a pre-commit check (`devsupport/check-copyright-header.sh`) enforcing the header on any changed `.py` file that already carries one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)