### PR TITLE
fuzz_ui: actually show the main window

### DIFF
--- a/devsupport/testing/fuzz/fuzz_ui.py
+++ b/devsupport/testing/fuzz/fuzz_ui.py
@@ -96,6 +96,14 @@ class Fuzzer:
         pan_app.settings.translator['team'] = 'none'
 
         self._build_controllers()
+        # Real usage always has a mapped, realized top-level window -
+        # without it, every widget here is a bare in-memory GObject
+        # with no native window-server surface, which very plausibly
+        # can't reproduce the class of native teardown race this
+        # exists to catch at all. Go straight to the window itself,
+        # not MainView.show() - that also calls Gtk.main(), and this
+        # fuzzer already pumps its own loop manually in step().
+        self.main_controller.view.main_window.show()
         self.store_controller.open_file(self.rng.choice(self.testfiles))
         self._load_current_unit()
 


### PR DESCRIPTION
The fuzzer never called the one thing that maps/realizes a real top-level window (`MainController.run()`/`view.show()` - the only call site in the whole codebase) - every widget it touched had no native window-server surface at all. The native GTK object-teardown race this exists to catch may well need one; a prior investigation into the same crash class independently found no way to reproduce it via headless/programmatic automation, consistent with this gap.

Goes straight to `main_window.show()`, not `view.show()` - the latter also calls `Gtk.main()` itself, which hung every platform (Linux/macOS/Windows) for the full watchdog timeout on a first attempt, since this fuzzer already pumps its own loop manually in `step()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)