### PR TITLE
fuzz.yml: bump the job timeout to 75 minutes

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -27,7 +27,7 @@ jobs:
     # should always fire first and leave a real stack trace; this just
     # bounds the worst case if that somehow doesn't fire, rather than
     # running for hours (GitHub's default job timeout).
-    timeout-minutes: 45
+    timeout-minutes: 75
     steps:
       - uses: actions/checkout@v7
         with:
@@ -85,7 +85,7 @@ jobs:
   fuzz-macos:
     runs-on: macos-latest
     # See fuzz-linux's own comment on this - same backstop reasoning.
-    timeout-minutes: 45
+    timeout-minutes: 75
     steps:
       - uses: actions/checkout@v7
         with:
@@ -144,7 +144,7 @@ jobs:
   fuzz-windows:
     runs-on: windows-latest
     # See fuzz-linux's own comment on this - same backstop reasoning.
-    timeout-minutes: 45
+    timeout-minutes: 75
     # See test-windows in ci.yml for why gvsbuild/MSVC, not MSYS2.
     env:
       gvsbuild_version: "2026.8.0"


### PR DESCRIPTION
Based on #3445 (fixes the window-realization hang first) - a 75-minute job timeout is needed to actually support a dispatched run longer than ~35 minutes via its own graceful watchdog, rather than GitHub's own job timeout cutting it off mid-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)