### PR TITLE
Add code coverage tracking via Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,7 +171,23 @@ jobs:
         run: find . -name "*.py" -exec python -m py_compile {} +
 
       - name: Run tests
-        run: xvfb-run -a --server-args="-screen 0 1024x768x24" pytest -rvxs virtaal
+        # Coverage only collected/uploaded once, on one matrix version -
+        # every version already runs the same tests, so N uploads would
+        # just be redundant, not N times the information.
+        run: |
+          if [ "${{ matrix.python-version }}" = "3.13" ]; then
+            xvfb-run -a --server-args="-screen 0 1024x768x24" pytest -rvxs --cov=virtaal --cov-report=xml virtaal
+          else
+            xvfb-run -a --server-args="-screen 0 1024x768x24" pytest -rvxs virtaal
+          fi
+
+      - name: Upload coverage to Codecov
+        if: matrix.python-version == '3.13'
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.xml
+          fail_ci_if_error: false
 
       - name: Smoke test the CLI
         run: xvfb-run -a --server-args="-screen 0 1024x768x24" virtaal --help

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 /MANIFEST.in
 /mo
 *.egg-info/
+/.coverage
+/coverage.xml
 
 # /docs/
 /docs/_build/

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,6 @@
+.. image:: https://codecov.io/gh/translate/virtaal/branch/main/graph/badge.svg
+   :target: https://codecov.io/gh/translate/virtaal
+
 Introduction
 ------------
 Virtaal is a graphical program for doing translation. It is meant to be easy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
 
 [project.optional-dependencies]
 spellcheck = ["pyenchant"]
-test = ["pytest"]
+test = ["pytest", "pytest-cov"]
 docs = ["Sphinx"]
 
 [project.urls]


### PR DESCRIPTION
Adds `pytest-cov`, collects coverage on one matrix job (Python 3.13 - arbitrary choice, every version runs the same tests so uploading from more than one would just be redundant), and uploads via `codecov/codecov-action`. Adds a README badge.

Confirmed working tokenless (CI run for this PR shows `codecov/patch`/`codecov/project` both green) - a public repo's uploads don't need a `CODECOV_TOKEN` secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)