### PR TITLE
macOS: new menu items from a plugin never actually appeared

### DIFF
--- a/virtaal/views/mainview.py
+++ b/virtaal/views/mainview.py
@@ -509,8 +509,11 @@ class MainView(BaseView):
         else:
             after_index = parent_menu.get_children().index(after) + 1
             parent_menu.insert(menuitem, after_index)
-        if self.menu_structure.get_property('visible'):
-            self.menu_structure.show_all()
+        # Not gated on self.menu_structure's own visibility - on macOS
+        # that's self.menubar, permanently hidden once handed off to
+        # the native menu bar, so a plugin's own menu item never
+        # showed there at all.
+        menuitem.show()
         return menuitem
 
     def find_menu(self, label):


### PR DESCRIPTION
`append_menu_item()` only called `show_all()` on the whole menu bar if that menu bar was itself visible - true almost everywhere, but never true on macOS, where the original `GtkMenuBar` is permanently hidden once handed off to the native menu bar. The Terminology plugin's Edit-menu entries ("Add Term..."/"Terminology Files...") were silently invisible as a result, though the same code works fine on Windows/Linux.

Verified live on this Mac: launched the real app, confirmed both entries now show in the Edit menu and clicking "Add Term..." opens the real dialog.

**Separate, not fixed here**: Ctrl+T (and Cmd+T) still don't open the dialog even with the menu fix - the menu item works fine when clicked directly, so this is a distinct accelerator-registration issue, not the same bug. Filing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)