### PR TITLE
bug_report.yml: OS/install-method dropdowns to input fields

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -30,29 +30,19 @@ body:
     validations:
       required: true
 
-  - type: dropdown
+  - type: input
     id: install-method
     attributes:
       label: How did you install Virtaal?
-      options:
-        - Windows installer
-        - macOS .dmg
-        - Flatpak
-        - pip install / from source checkout
-        - Linux distro package
-        - Other (please describe below)
+      placeholder: e.g. Windows installer, macOS .dmg, Flatpak, pip install, Linux distro package
     validations:
       required: true
 
-  - type: dropdown
+  - type: input
     id: os
     attributes:
       label: Operating system
-      options:
-        - Windows
-        - macOS
-        - Linux
-        - Other
+      placeholder: e.g. Windows, macOS, Linux
     validations:
       required: true
 

--- a/virtaal/support/bug_report.py
+++ b/virtaal/support/bug_report.py
@@ -19,7 +19,6 @@ from virtaal.common.platform import platform as _platform
 
 REPO_URL = "https://github.com/translate/virtaal"
 
-# GitHub's "os" dropdown only prefills on an exact option-text match.
 _OS_LABELS = (
     ('is_windows', 'Windows'),
     ('is_mac', 'macOS'),


### PR DESCRIPTION
GitHub's issue-forms URL prefill only works on `input`/`textarea` fields, never dropdowns, so Virtaal's Report a Bug link left "Operating system" and "How did you install" blank.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017KayAA91cuhe4xCpDYBg9K