### PR TITLE
Terminology: wire up the Add Term accel group and native menu sync

### DIFF
--- a/virtaal/plugins/terminology/models/localfile/localfileview.py
+++ b/virtaal/plugins/terminology/models/localfile/localfileview.py
@@ -56,9 +56,10 @@ class LocalFileView:
         accel_group = self.menu.get_accel_group()
         if accel_group is None:
             accel_group = Gtk.AccelGroup()
-            self.menu.set_accel_group(accel_group)
+            self.mainview.add_accel_group(accel_group)
         self.mnu_add_term.set_accel_path("<Virtaal>/Terminology/Add Term")
         self.menu.set_accel_group(accel_group)
+        self.mainview.sync_menubar()
 
     def destroy(self):
         for gobj, signal_id in self._signal_ids:

--- a/virtaal/views/mainview.py
+++ b/virtaal/views/mainview.py
@@ -416,6 +416,16 @@ class MainView(BaseView):
             @type accel_group: Gtk.AccelGroup"""
         self.main_window.add_accel_group(accel_group)
 
+    def sync_menubar(self):
+        """On macOS, push a plugin's own accelerator (added to the
+            native menu bar after GtkosxApplication.ready() already
+            ran) into the native menu items' key equivalents - without
+            this, the accelerator's GtkAccelGroup entry exists but
+            never actually fires. No-op elsewhere."""
+        osxapp = getattr(self, '_osxapp', None)
+        if osxapp is not None:
+            osxapp.sync_menubar()
+
     def set_saveable(self, value):
         # Repeatedly doing all of this is unnecessary, and can make the window
         # title flash slightly. So if the file is already modified, don't


### PR DESCRIPTION
Every sibling plugin (`tmview`, `unitview`, `prefsview`, `propertiesview`) adds its accel group to the window; this one only set it on the submenu, so Ctrl+T never fired.

That alone isn't enough on macOS: GtkosxApplication only pushes a menu item's accelerator into the native menu's key equivalent at the point the menu is converted, not for one added afterwards - needs an explicit `sync_menubar()` call too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017KayAA91cuhe4xCpDYBg9K