### PR TITLE
Terminology: Enter submits the Add Term dialog

### DIFF
--- a/share/virtaal/virtaal.ui
+++ b/share/virtaal/virtaal.ui
@@ -1951,6 +1951,7 @@ If you are translating from English to French then French would be your translat
                 <property name="label">gtk-add</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
+                <property name="can_default">True</property>
                 <property name="receives_default">True</property>
                 <property name="use_action_appearance">False</property>
                 <property name="use_stock">True</property>
@@ -1992,6 +1993,7 @@ If you are translating from English to French then French would be your translat
               <object class="GtkEntry" id="ent_source">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
+                <property name="activates_default">True</property>
                 <property name="invisible_char">●</property>
                 <property name="width_chars">45</property>
                 <property name="primary_icon_activatable">False</property>
@@ -2024,6 +2026,7 @@ If you are translating from English to French then French would be your translat
               <object class="GtkEntry" id="ent_target">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
+                <property name="activates_default">True</property>
                 <property name="invisible_char">●</property>
                 <property name="width_chars">45</property>
                 <property name="primary_icon_activatable">False</property>

--- a/virtaal/plugins/terminology/models/localfile/localfileview.py
+++ b/virtaal/plugins/terminology/models/localfile/localfileview.py
@@ -323,6 +323,7 @@ class TermAddDialog:
             setattr(self, name, self.gui.get_object(name))
 
         self.dialog = self.gui.get_object('TermAddDlg')
+        self.dialog.set_default_response(Gtk.ResponseType.OK)
 
         cellr = Gtk.CellRendererText()
         cellr.props.ellipsize = Pango.EllipsizeMode.MIDDLE


### PR DESCRIPTION
btn_add_term had `receives_default` but not `can_default`, and the dialog never set a default response - Enter in `ent_source`/`ent_target` did nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017KayAA91cuhe4xCpDYBg9K