### PR TITLE
Trim the frozen-build log to the last few launches

### DIFF
--- a/virtaal/common/pan_app.py
+++ b/virtaal/common/pan_app.py
@@ -13,6 +13,7 @@
 # packaged windows build. This has to happen as early as possible, otherwise
 # error messages will not be available for inspection.
 import os
+import re
 import sys
 
 from virtaal.__version__ import version_string
@@ -36,19 +37,41 @@ def get_config_dir():
 
     return confdir
 
-def _open_frozen_log(path):
-    """Open a frozen-build log file for append.
-
-    No explicit encoding defaults to the system locale's codepage on
-    Windows (e.g. cp1252), which can't represent arbitrary translated
-    text - logging.debug() itself could then raise UnicodeEncodeError."""
-    return open(path, 'a', buffering=1, encoding='utf-8', errors='backslashreplace')
-
 def _build_launch_marker(timestamp):
     """The separator line written to a frozen build's log at each
     launch - a single file can span several runs, so this both marks
     where one starts and identifies which build produced it."""
     return '=== launch %s | Virtaal %s ===\n' % (timestamp, version_string())
+
+_LAUNCH_MARKER_RE = re.compile(r'^=== launch .*? \| Virtaal .* ===$', re.MULTILINE)
+KEEP_LAST_N_LAUNCHES = 2
+
+def _trim_log_to_last_launches(path, keep=KEEP_LAST_N_LAUNCHES):
+    """Keep only the last `keep` launches of an existing frozen log,
+    splitting on its own launch-marker line rather than a raw byte
+    count - a byte cut risks starting mid-launch with nothing to
+    orient from, a launch-count cut always leaves complete records."""
+    try:
+        with open(path, encoding='utf-8', errors='backslashreplace') as f:
+            content = f.read()
+    except OSError:
+        return
+    markers = [m.start() for m in _LAUNCH_MARKER_RE.finditer(content)]
+    if len(markers) <= keep:
+        return
+    with open(path, 'w', encoding='utf-8', errors='backslashreplace') as f:
+        f.write(content[markers[-keep]:])
+
+def _open_frozen_log(path):
+    """Open a frozen-build log file for append, trimmed to its last
+    few launches first - unbounded growth was fine for an occasional
+    --debug run, not as a default for every launch.
+
+    No explicit encoding defaults to the system locale's codepage on
+    Windows (e.g. cp1252), which can't represent arbitrary translated
+    text - logging.debug() itself could then raise UnicodeEncodeError."""
+    _trim_log_to_last_launches(path)
+    return open(path, 'a', buffering=1, encoding='utf-8', errors='backslashreplace')
 
 # Only for the packaged (frozen/PyInstaller) build - a windowed
 # subsystem executable has no console, so this is the only way to get

--- a/virtaal/common/test_pan_app.py
+++ b/virtaal/common/test_pan_app.py
@@ -14,6 +14,7 @@ from virtaal.common.pan_app import (
     _build_launch_marker,
     _open_frozen_log,
     _set_enchant_env_vars,
+    _trim_log_to_last_launches,
 )
 
 
@@ -66,3 +67,51 @@ def test_open_frozen_log_survives_characters_a_locale_codepage_cant(tmp_path):
 
     with open(path, encoding='utf-8') as f:
         assert message in f.read()
+
+
+def _launch(n):
+    return '=== launch 2026-09-%02d 00:00:00 | Virtaal 1.0.0-beta1 (abc%04d) ===\ncontent %d\n' % (n, n, n)
+
+
+def test_trim_log_to_last_launches_keeps_only_the_tail(tmp_path):
+    path = str(tmp_path / "test.log")
+    with open(path, 'w', encoding='utf-8') as f:
+        f.write(''.join(_launch(n) for n in range(1, 6)))
+
+    _trim_log_to_last_launches(path, keep=2)
+
+    with open(path, encoding='utf-8') as f:
+        kept = f.read()
+    assert kept == _launch(4) + _launch(5)
+
+
+def test_trim_log_to_last_launches_leaves_a_short_log_alone(tmp_path):
+    path = str(tmp_path / "test.log")
+    original = _launch(1) + _launch(2)
+    with open(path, 'w', encoding='utf-8') as f:
+        f.write(original)
+
+    _trim_log_to_last_launches(path, keep=2)
+
+    with open(path, encoding='utf-8') as f:
+        assert f.read() == original
+
+
+def test_trim_log_to_last_launches_tolerates_a_missing_file(tmp_path):
+    _trim_log_to_last_launches(str(tmp_path / "missing.log"), keep=2)  # doesn't raise
+
+
+def test_open_frozen_log_trims_before_appending(tmp_path):
+    path = str(tmp_path / "test.log")
+    with open(path, 'w', encoding='utf-8') as f:
+        f.write(''.join(_launch(n) for n in range(1, 4)))
+
+    f = _open_frozen_log(path)
+    try:
+        f.write(_launch(4))
+    finally:
+        f.close()
+
+    with open(path, encoding='utf-8') as f:
+        kept = f.read()
+    assert kept == _launch(2) + _launch(3) + _launch(4)


### PR DESCRIPTION
Unbounded append meant months of accumulated history in `stdout_virtaal.log`/`stderr_virtaal.log`, found because a Windows test harness's own "no unexpected output" check was reading all of it, not just the current run's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017KayAA91cuhe4xCpDYBg9K