### PR TITLE
Windows: bundle only en_US and en_GB dictionaries

### DIFF
--- a/devsupport/packaging/windows/pyinstaller-hooks/hook-enchant.py
+++ b/devsupport/packaging/windows/pyinstaller-hooks/hook-enchant.py
@@ -1,0 +1,21 @@
+#
+# Copyright (C) Virtaal contributors.
+#
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
+
+"""Overrides pyinstaller-hooks-contrib's own hook-enchant.py, which
+collects the entire pyenchant wheel's data (all bundled dictionaries)
+unconditionally via collect_data_files('enchant') - undermining
+virtaal.spec's own deliberate dictionary filtering regardless of it,
+since PyInstaller merges every hook's contributions. hookspath puts
+this file ahead of the contributed one. Binaries (the actual enchant
+backend DLLs) still need collecting; data doesn't - virtaal.spec's
+own datas loop already adds exactly the dictionaries wanted."""
+
+from PyInstaller.utils.hooks import collect_dynamic_libs
+
+binaries = collect_dynamic_libs('enchant')
+datas = []
+excludedimports = ['enchant.tests']

--- a/devsupport/packaging/windows/virtaal.spec
+++ b/devsupport/packaging/windows/virtaal.spec
@@ -144,12 +144,15 @@ datas = [
     (str(ROOT / "AUTHORS.md"), "."),
 ] + mo_files
 if ENCHANT_DATA is not None and ENCHANT_DATA.is_dir():
-    # Only en_GB - enough to test; the rest comes via download, not
-    # bundled (~20MB of unused dictionaries otherwise).
+    # Only en_US (the traditional software source language) and en_GB
+    # (checks.po's own target language, exercised by ci.yml's bundle-
+    # launch check) - the rest comes via download, not bundled (~20MB
+    # of unused dictionaries otherwise).
+    BUNDLED_DICTS = ("en_US", "en_GB")
     for p in ENCHANT_DATA.rglob("*"):
         if p.is_dir():
             continue
-        if p.parent.name == "hunspell" and p.stem != "en_GB":
+        if p.parent.name == "hunspell" and p.stem not in BUNDLED_DICTS:
             continue
         datas.append((str(p), str(Path("enchant/data") / p.relative_to(ENCHANT_DATA).parent)))
 
@@ -158,6 +161,10 @@ a = Analysis(  # noqa: F821
     pathex=[str(ROOT)],
     binaries=binaries,
     datas=datas,
+    # Overrides pyinstaller-hooks-contrib's own hook-enchant.py, which
+    # bundles every dictionary in the wheel regardless of the en_GB
+    # filtering above - see that file's own docstring.
+    hookspath=[str(ROOT / "devsupport" / "packaging" / "windows" / "pyinstaller-hooks")],
     hiddenimports=(
         collect_submodules("virtaal")
         + collect_submodules("translate.storage")


### PR DESCRIPTION
pyinstaller-hooks-contrib's own hook-enchant.py collects the whole pyenchant wheel's data unconditionally via collect_data_files('enchant') - undermining virtaal.spec's own filtering regardless of it, since PyInstaller merges every hook's contributions. hookspath overrides it with a binaries-only version; user-supplied hooks there outrank contributed ones by design.

Bundles en_US (traditional software source language) and en_GB (checks.po's own target language, exercised by ci.yml's bundle-launch check) - everything else comes via download, not bundled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017KayAA91cuhe4xCpDYBg9K