### PR TITLE
macOS: also bundle the en_US dictionary

### DIFF
--- a/devsupport/packaging/macos/build_standalone.sh
+++ b/devsupport/packaging/macos/build_standalone.sh
@@ -41,10 +41,12 @@ if [ "$(uname -m)" = "x86_64" ]; then
     curl -sL -o /tmp/pyenchant-2.0.0-mac.whl \
         "https://files.pythonhosted.org/packages/4f/c5/5c18df3c5dbf2ce1e6fc8b0fcce1a5dfe7c4ec5ab33b76722fcca9cbfff5/pyenchant-2.0.0-py2.py3.cp27.cp32.cp33.cp34.cp35.cp36.pp27.pp33.pp35-none-macosx_10_6_intel.macosx_10_9_intel.whl"
     mkdir -p build/enchant_intel
-    # Only en_GB (checks.po's own target language) - enough to prove
-    # spell checking works; every other dictionary comes via download
+    # en_US (traditional software source language) and en_GB (checks.po's
+    # own target language) - everything else comes via download
     # (dictionary_source.py), not bundled.
     unzip -q /tmp/pyenchant-2.0.0-mac.whl 'enchant/lib/*' \
+        'enchant/share/enchant/myspell/en_US.aff' \
+        'enchant/share/enchant/myspell/en_US.dic' \
         'enchant/share/enchant/myspell/en_GB.aff' \
         'enchant/share/enchant/myspell/en_GB.dic' \
         -d build/enchant_intel


### PR DESCRIPTION
Only en_GB was bundled (checks.po's own target language) - en_US is the more traditional software source language, worth having too. Both en_US.aff/en_US.dic exist in the pinned pyenchant 2.0.0 wheel at the exact unzip path used, distinct from the larger en_US-large variant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017KayAA91cuhe4xCpDYBg9K