### PR TITLE
Fix 3 GTK3 deprecation warnings

### DIFF
--- a/virtaal/views/unitview.py
+++ b/virtaal/views/unitview.py
@@ -66,7 +66,9 @@ class UnitView(Gtk.EventBox, GObjectWrapper, Gtk.CellEditable, BaseView):
         # to show our own custom one to not have a tooltip obscuring things
         invisible_tooltip = Gtk.Window(type=Gtk.WindowType.POPUP)
         invisible_tooltip.resize(1,1)
-        invisible_tooltip.set_opacity(0)
+        # Gtk.Window.set_opacity is deprecated; the inherited
+        # Gtk.Widget one isn't, so call that overload explicitly.
+        Gtk.Widget.set_opacity(invisible_tooltip, 0)
         self.set_tooltip_window(invisible_tooltip)
         self.connect('query-tooltip', self._on_query_tooltip)
 
@@ -78,7 +80,11 @@ class UnitView(Gtk.EventBox, GObjectWrapper, Gtk.CellEditable, BaseView):
             'targets': []
         }
         self._get_widgets()
-        self._widgets['vbox_editor'].reparent(self)
+        # Gtk.Widget.reparent is deprecated with no direct replacement;
+        # this is the documented manual equivalent.
+        vbox_editor = self._widgets['vbox_editor']
+        vbox_editor.get_parent().remove(vbox_editor)
+        self.add(vbox_editor)
         self._setup_menus()
         self.unit = None
 

--- a/virtaal/views/widgets/storetreeview.py
+++ b/virtaal/views/widgets/storetreeview.py
@@ -58,7 +58,6 @@ class StoreTreeView(Gtk.TreeView):
     def _enable_tooltips(self):
         if hasattr(self, "set_tooltip_column"):
             self.set_tooltip_column(COLUMN_NOTE)
-        self.set_rules_hint(True)
 
     def _install_callbacks(self):
         self.connect('key-press-event', self._on_key_press)


### PR DESCRIPTION
Cleans up 3 of the remaining PyGObject/GTK3 deprecation warnings surfaced in the test run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017KayAA91cuhe4xCpDYBg9K