### PR TITLE
CI: track Python 3.15 (rc) as a non-blocking matrix job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,10 +112,17 @@ jobs:
 
   test:
     runs-on: ubuntu-24.04
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        experimental: [false]
+        include:
+          # 3.15 is still pre-release (rc, due 2026-10-01) - tracked so
+          # a real incompatibility surfaces early, but doesn't block CI.
+          - python-version: "3.15"
+            experimental: true
 
     steps:
       - uses: actions/checkout@v7
@@ -125,6 +132,7 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
 
       - name: Install system dependencies
         run: |


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017KayAA91cuhe4xCpDYBg9K