### PR TITLE
Add a Jekyll build check for the gh-pages branch

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,17 @@
+name: Validate Jekyll build
+
+on:
+  push:
+    branches: [gh-pages]
+  pull_request:
+    branches: [gh-pages]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./
+          destination: ./_site


### PR DESCRIPTION
Catches a broken build before it reaches the live site - GitHub Pages otherwise just silently keeps serving the last successful build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)