### PR TITLE
Warn and disable Save for unsupported-write formats like .qm

### DIFF
--- a/virtaal/support/store_capabilities.py
+++ b/virtaal/support/store_capabilities.py
@@ -1,0 +1,22 @@
+#
+# Copyright (C) Virtaal contributors.
+#
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
+
+import io
+
+
+def can_serialize(trans_store):
+    """Whether trans_store.serialize() actually works, checked by
+    attempting it into a throwaway buffer rather than hardcoding which
+    formats support it - translate-toolkit has no capability flag for
+    this, and a hardcoded list would need updating for every current
+    and future format that doesn't support writing (currently just
+    .qm, but not the only one that ever might)."""
+    try:
+        trans_store.serialize(io.BytesIO())
+        return True
+    except NotImplementedError:
+        return False

--- a/virtaal/support/test_store_capabilities.py
+++ b/virtaal/support/test_store_capabilities.py
@@ -1,0 +1,32 @@
+#
+# Copyright (C) Virtaal contributors.
+#
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
+
+from translate.storage import qm
+
+from virtaal.support.store_capabilities import can_serialize
+
+
+def test_can_serialize_is_true_for_a_writable_format():
+    from translate.storage import pypo
+    assert can_serialize(pypo.pofile()) is True
+
+
+def test_can_serialize_is_false_for_qm():
+    assert can_serialize(qm.qmfile()) is False
+
+
+def test_can_serialize_only_catches_notimplementederror():
+    class _Broken:
+        def serialize(self, out):
+            raise ValueError("not the kind of failure this checks for")
+
+    try:
+        can_serialize(_Broken())
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("expected ValueError to propagate")

--- a/virtaal/views/mainview.py
+++ b/virtaal/views/mainview.py
@@ -16,6 +16,7 @@ from gi.repository import Gdk, Gtk
 from virtaal.common import pan_app
 from virtaal.common.platform import platform
 from virtaal.common.utils import get_unicode
+from virtaal.support.store_capabilities import can_serialize
 from virtaal.views import theme
 
 from .baseview import BaseView
@@ -506,6 +507,10 @@ class MainView(BaseView):
         # bother redoing all of this.
         if value and self.modified:
             return
+        if getattr(self, '_store_unsavable', False):
+            # Editing (which normally re-enables Save) can't make a
+            # format like .qm any more saveable.
+            value = False
         menuitem = self.gui.get_object("mnu_save")
         menuitem.set_sensitive(value)
         menuitem = self.gui.get_object("mnu_revert")
@@ -861,6 +866,28 @@ class MainView(BaseView):
         vbox_main.pack_start(infobar, False, False, 0)
         vbox_main.reorder_child(infobar, 1)  # directly below the menu bar
 
+    def show_readonly_notice(self, message):
+        """A persistent (no close button) InfoBar, for a condition the
+        user can't dismiss away - e.g. a file format that can't be
+        saved. Replaces any existing one instead of stacking."""
+        self.hide_readonly_notice()
+        infobar = Gtk.InfoBar()
+        infobar.set_message_type(Gtk.MessageType.WARNING)
+        label = Gtk.Label(label=message)
+        label.set_line_wrap(True)
+        infobar.get_content_area().pack_start(label, True, True, 0)
+        infobar.show_all()
+        vbox_main = self.gui.get_object('vbox_main')
+        vbox_main.pack_start(infobar, False, False, 0)
+        vbox_main.reorder_child(infobar, 1)  # directly below the menu bar
+        self._readonly_infobar = infobar
+
+    def hide_readonly_notice(self):
+        infobar = getattr(self, '_readonly_infobar', None)
+        if infobar:
+            infobar.destroy()
+            self._readonly_infobar = None
+
     def _on_file_open(self, _widget):
         self.open_file()
 
@@ -938,9 +965,19 @@ class MainView(BaseView):
             self.gui.get_object(widget_name).set_sensitive(False)
         self.status_bar.set_sensitive(False)
         self.main_window.set_title(_('Virtaal'))
+        self.hide_readonly_notice()
+        self._store_unsavable = False
 
     def _on_store_loaded(self, store_controller):
-        self.gui.get_object('mnu_saveas').set_sensitive(True)
+        self._store_unsavable = not can_serialize(store_controller.store._trans_store)
+        if self._store_unsavable:
+            self.show_readonly_notice(
+                _('This file format cannot be saved - neither Save nor Save As will work.'))
+            self.gui.get_object('mnu_save').set_sensitive(False)
+        else:
+            self.hide_readonly_notice()
+
+        self.gui.get_object('mnu_saveas').set_sensitive(not self._store_unsavable)
         self.gui.get_object('mnu_close').set_sensitive(True)
         self.gui.get_object('mnu_update').set_sensitive(True)
         self.gui.get_object('mnu_properties').set_sensitive(True)

--- a/virtaal/views/test_mainview.py
+++ b/virtaal/views/test_mainview.py
@@ -103,3 +103,69 @@ def test_show_save_dialog_returns_none_on_cancel():
     view = _make_view_with_chooser(
         '_save_chooser', _FakeChooser(Gtk.ResponseType.CANCEL))
     assert view.show_save_dialog('Save', current_filename='/tmp/test.po') is None
+
+
+class _FakeWidget:
+    def __init__(self):
+        self.sensitive = None
+
+    def set_sensitive(self, value):
+        self.sensitive = value
+
+
+class _FakeGui:
+    """Only get_object('vbox_main') returns something real (for the
+    InfoBar packing calls) - everything else is a throwaway widget
+    that just records set_sensitive()."""
+
+    def __init__(self, vbox):
+        self._vbox = vbox
+        self._widgets = {}
+
+    def get_object(self, name):
+        if name == 'vbox_main':
+            return self._vbox
+        return self._widgets.setdefault(name, _FakeWidget())
+
+
+def _make_bare_view():
+    view = MainView.__new__(MainView)
+    view.gui = _FakeGui(Gtk.Box())
+    return view
+
+
+def test_show_readonly_notice_adds_a_non_dismissible_infobar():
+    view = _make_bare_view()
+    view.show_readonly_notice('cannot save')
+    assert view._readonly_infobar in view.gui._vbox.get_children()
+    assert view._readonly_infobar.get_show_close_button() is False
+
+
+def test_show_readonly_notice_replaces_rather_than_stacks():
+    view = _make_bare_view()
+    view.show_readonly_notice('first')
+    view.show_readonly_notice('second')
+    assert len(view.gui._vbox.get_children()) == 1
+
+
+def test_hide_readonly_notice_removes_it():
+    view = _make_bare_view()
+    view.show_readonly_notice('cannot save')
+    view.hide_readonly_notice()
+    assert view._readonly_infobar is None
+    assert view.gui._vbox.get_children() == []
+
+
+def test_hide_readonly_notice_is_a_noop_without_one():
+    view = _make_bare_view()
+    view.hide_readonly_notice()  # must not raise
+
+
+def test_set_saveable_stays_disabled_for_an_unsavable_store():
+    view = _make_bare_view()
+    view.modified = False
+    view._store_unsavable = True
+    view.controller = type('_C', (), {'get_store_filename': lambda self: None})()
+    view.set_saveable(True)
+    assert view.gui.get_object('mnu_save').sensitive is False
+    assert view.modified is False


### PR DESCRIPTION
.qm files can be opened but never saved - previously only discovered via an error dialog after real editing work (#2036). Now shown via a persistent banner at open time, with Save and Save As disabled for the session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)