### PR TITLE
Guard against a None unit.source when caching stats

### DIFF
--- a/virtaal/support/statsdb.py
+++ b/virtaal/support/statsdb.py
@@ -467,7 +467,7 @@ class StatsCache:
                 # what about plurals in .source and .target?
                 unit_state_for_db = statefordb(unit)
                 unitvalues.append((unit.getid(), fileid, index,
-                                   unit.source, unit.target,
+                                   unit.source or "", unit.target,
                                    sourcewords, targetwords,
                                    unit_state_for_db,
                                    unit.get_state_id()))

--- a/virtaal/support/test_statsdb.py
+++ b/virtaal/support/test_statsdb.py
@@ -1,0 +1,29 @@
+#
+# Copyright (C) Virtaal contributors.
+#
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
+
+from virtaal.models.storemodel import StoreModel
+
+
+def test_load_file_with_an_empty_source_string(tmp_path):
+    # translate/virtaal#3249: an empty <source></source> in a .ts file
+    # parses with unit.source == None, which used to crash statsdb's
+    # own "source VARCHAR NOT NULL" constraint on load.
+    ts_file = tmp_path / "empty_source.ts"
+    ts_file.write_text("""<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS language="da">
+<context>
+<name>Test</name>
+<message>
+<source></source>
+<translation>foo</translation>
+</message>
+</context>
+</TS>
+""")
+    model = StoreModel(str(ts_file), None)
+    assert len(model) == 1


### PR DESCRIPTION
An empty <source></source> in a .ts file parses with unit.source == None (#3249) - statsdb's own units table has source VARCHAR NOT NULL, so loading such a file crashed instantly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)