### PR TITLE
Recover from a corrupt/unreadable .ini file instead of crashing

### DIFF
--- a/po/virtaal.pot
+++ b/po/virtaal.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Virtaal 1.0.0-beta1\n"
 "Report-Msgid-Bugs-To: translate-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2026-09-10 09:02+0100\n"
+"POT-Creation-Date: 2026-09-11 12:51+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #: ../share/applications/virtaal.desktop.in.h:1
-#: ../share/virtaal/virtaal.ui.h:18 ../virtaal/views/mainview.py:891
+#: ../share/virtaal/virtaal.ui.h:18 ../virtaal/views/mainview.py:961
 msgid "Virtaal"
 msgstr ""
 
@@ -689,7 +689,7 @@ msgid ""
 msgstr ""
 
 #: ../virtaal/controllers/maincontroller.py:227
-#: ../virtaal/views/mainview.py:338
+#: ../virtaal/views/mainview.py:342
 msgid "Save"
 msgstr ""
 
@@ -1217,12 +1217,12 @@ msgid "Add Files"
 msgstr ""
 
 #: ../virtaal/plugins/terminology/models/localfile/localfileview.py:174
-#: ../virtaal/views/mainview.py:285
+#: ../virtaal/views/mainview.py:289
 msgid "All Supported Files"
 msgstr ""
 
 #: ../virtaal/plugins/terminology/models/localfile/localfileview.py:200
-#: ../virtaal/views/mainview.py:326
+#: ../virtaal/views/mainview.py:330
 msgid "All Files"
 msgstr ""
 
@@ -1391,26 +1391,26 @@ msgid "Select the sources that should be queried for translation memory"
 msgstr ""
 
 #. l10n: match quality column label
-#: ../virtaal/plugins/tm/tmwidgets.py:50
+#: ../virtaal/plugins/tm/tmwidgets.py:52
 msgid "%"
 msgstr ""
 
-#: ../virtaal/plugins/tm/tmwidgets.py:52
+#: ../virtaal/plugins/tm/tmwidgets.py:54
 msgid "Matches"
 msgstr ""
 
-#: ../virtaal/plugins/tm/tmwidgets.py:54
+#: ../virtaal/plugins/tm/tmwidgets.py:56
 msgid "TM Source"
 msgstr ""
 
 #. l10n: This message allows you to customize the appearance of the match percentage. Most languages can probably leave it unchanged.
-#: ../virtaal/plugins/tm/tmwidgets.py:130
+#: ../virtaal/plugins/tm/tmwidgets.py:136
 #, python-format
 msgid "%(match_quality)s%%"
 msgstr ""
 
 #. l10n: This indicates a suggestion from machine translation. It is displayed instead of the match percentage.
-#: ../virtaal/plugins/tm/tmwidgets.py:140
+#: ../virtaal/plugins/tm/tmwidgets.py:146
 msgid "?"
 msgstr ""
 
@@ -1791,21 +1791,21 @@ msgstr ""
 msgid "_New Language Pair..."
 msgstr ""
 
-#: ../virtaal/views/mainview.py:247
+#: ../virtaal/views/mainview.py:251
 msgid "Error"
 msgstr ""
 
-#: ../virtaal/views/mainview.py:279
+#: ../virtaal/views/mainview.py:283
 msgid "Choose a Translation File"
 msgstr ""
 
-#: ../virtaal/views/mainview.py:356
+#: ../virtaal/views/mainview.py:360
 msgid ""
 "The current file has been modified.\n"
 "Do you want to save your changes?"
 msgstr ""
 
-#: ../virtaal/views/mainview.py:359
+#: ../virtaal/views/mainview.py:363
 msgid "_Discard"
 msgstr ""
 
@@ -1813,26 +1813,33 @@ msgstr ""
 #. %(modified_marker)s is a star that is displayed if the file is modified, and should be at the start of the window title
 #. %(current_file)s is the file name of the current file
 #. most languages will not need to change this
-#: ../virtaal/views/mainview.py:482
+#: ../virtaal/views/mainview.py:523
 #, python-format
 msgid "%(modified_marker)s%(current_file)s - Virtaal"
 msgstr ""
 
-#: ../virtaal/views/mainview.py:507
+#: ../virtaal/views/mainview.py:548
 msgid "Please enter the number of noun forms (plurals) to use"
 msgstr ""
 
-#: ../virtaal/views/mainview.py:513
+#: ../virtaal/views/mainview.py:554
 msgid "Please enter the plural equation to use"
 msgstr ""
 
-#: ../virtaal/views/mainview.py:799
+#: ../virtaal/views/mainview.py:848
 #, python-format
 msgid "Virtaal %s is available (you have %s)"
 msgstr ""
 
-#: ../virtaal/views/mainview.py:801
+#: ../virtaal/views/mainview.py:850
 msgid "Download"
+msgstr ""
+
+#: ../virtaal/views/mainview.py:871
+#, python-format
+msgid ""
+"Your settings file could not be read, so Virtaal started with default "
+"settings. The old file was kept at: %s"
 msgstr ""
 
 #. l10n: This refers to the 'mode' that determines how Virtaal moves
@@ -1903,15 +1910,15 @@ msgstr ""
 msgid "Preview failed"
 msgstr ""
 
-#: ../virtaal/views/unitview.py:609
+#: ../virtaal/views/unitview.py:638
 msgid "Move one step back in the workflow (Ctrl+Shift+Enter)"
 msgstr ""
 
-#: ../virtaal/views/unitview.py:610
+#: ../virtaal/views/unitview.py:639
 msgid "Click to move to a specific state in the workflow"
 msgstr ""
 
-#: ../virtaal/views/unitview.py:611
+#: ../virtaal/views/unitview.py:640
 msgid "Move one step forward in the workflow (Ctrl+Enter)"
 msgstr ""
 
@@ -2144,11 +2151,11 @@ msgstr ""
 msgid "Many plugins and options for customization"
 msgstr ""
 
-#: ../virtaal/models/storemodel.py:125
+#: ../virtaal/models/storemodel.py:126
 msgid "The file does not exist."
 msgstr ""
 
-#: ../virtaal/models/storemodel.py:127
+#: ../virtaal/models/storemodel.py:128
 msgid "Not a valid file."
 msgstr ""
 

--- a/virtaal/common/pan_app.py
+++ b/virtaal/common/pan_app.py
@@ -22,6 +22,34 @@ from .platform import platform
 from .utils import get_unicode
 
 
+def _read_ini_recovering(parser, filename):
+    """Read filename into parser, recovering from a corrupt/unreadable
+    file instead of crashing - it may be a user's own hand-edited file
+    they'd want back, so back it up rather than overwriting or
+    discarding it silently, and leave parser empty so the caller falls
+    back to its own defaults.
+
+    Returns the backup path, or None if the file was fine (or absent)."""
+    try:
+        parser.read(filename)
+        return None
+    except (ConfigParser.Error, UnicodeDecodeError) as e:
+        for section in parser.sections():
+            parser.remove_section(section)
+        backup_path = filename + '.broken'
+        n = 1
+        while os.path.exists(backup_path):
+            n += 1
+            backup_path = '%s.broken.%d' % (filename, n)
+        try:
+            os.replace(filename, backup_path)
+        except OSError:
+            backup_path = None
+        import logging
+        logging.warning("%r is corrupt (%s) - backed up to %r and starting fresh", filename, e, backup_path)
+        return backup_path
+
+
 def get_config_dir():
     if platform.is_windows:
         confdir = os.path.join(os.environ['APPDATA'], 'Virtaal')
@@ -230,11 +258,12 @@ class Settings:
 
         self.language["targetlang"] = data.simplify_to_common(get_locale_lang())
         self.config = ConfigParser.RawConfigParser()
+        self.config_recovery_backup = None
         self.read()
 
     def read(self):
         """Read the configuration file and set the dictionaries up."""
-        self.config.read(self.filename)
+        self.config_recovery_backup = _read_ini_recovering(self.config, self.filename)
         for section in self.sections:
             if not self.config.has_section(section):
                 self.config.add_section(section)
@@ -397,7 +426,7 @@ def load_config(filename, section=None):
             section was specified. Otherwise a simple dictionary representing
             the given configuration section."""
     parser = ConfigParser.RawConfigParser()
-    parser.read(filename)
+    _read_ini_recovering(parser, filename)
 
     if section:
         if section not in parser.sections():
@@ -418,7 +447,7 @@ def save_config(filename, config, section=None):
             specified, it should be a 2D-dictionary representing the entire
             configuration file."""
     parser = ConfigParser.ConfigParser()
-    parser.read(filename)
+    _read_ini_recovering(parser, filename)
 
     if section:
         config = {section: config}

--- a/virtaal/common/test_pan_app.py
+++ b/virtaal/common/test_pan_app.py
@@ -13,6 +13,7 @@ from virtaal.common import pan_app
 from virtaal.common.pan_app import (
     _build_launch_marker,
     _open_frozen_log,
+    _read_ini_recovering,
     _set_enchant_env_vars,
     _trim_log_to_last_launches,
 )
@@ -99,6 +100,55 @@ def test_trim_log_to_last_launches_leaves_a_short_log_alone(tmp_path):
 
 def test_trim_log_to_last_launches_tolerates_a_missing_file(tmp_path):
     _trim_log_to_last_launches(str(tmp_path / "missing.log"), keep=2)  # doesn't raise
+
+
+def test_read_ini_recovering_leaves_a_valid_file_alone(tmp_path):
+    path = tmp_path / "settings.ini"
+    path.write_text("[general]\nlastdir = /tmp\n")
+
+    parser = pan_app.ConfigParser.RawConfigParser()
+    backup_path = _read_ini_recovering(parser, str(path))
+
+    assert backup_path is None
+    assert parser.get("general", "lastdir") == "/tmp"
+    assert path.exists()
+
+
+def test_read_ini_recovering_backs_up_a_corrupt_file(tmp_path):
+    # Real Windows crash (#3327): a user's virtaal.ini got zero-filled,
+    # raising configparser.MissingSectionHeaderError unhandled at
+    # startup, before any window could even be drawn.
+    path = tmp_path / "settings.ini"
+    path.write_bytes(b"\x00" * 200)
+
+    parser = pan_app.ConfigParser.RawConfigParser()
+    backup_path = _read_ini_recovering(parser, str(path))
+
+    assert backup_path == str(path) + ".broken"
+    assert not path.exists()
+    assert open(backup_path, 'rb').read() == b"\x00" * 200
+    assert parser.sections() == []
+
+
+def test_read_ini_recovering_does_not_clobber_an_existing_backup(tmp_path):
+    path = tmp_path / "settings.ini"
+    path.write_bytes(b"\x00" * 10)
+    (tmp_path / "settings.ini.broken").write_text("earlier backup")
+
+    parser = pan_app.ConfigParser.RawConfigParser()
+    backup_path = _read_ini_recovering(parser, str(path))
+
+    assert backup_path == str(path) + ".broken.2"
+
+
+def test_settings_recovers_from_a_corrupt_virtaal_ini(tmp_path):
+    path = tmp_path / "virtaal.ini"
+    path.write_bytes(b"\x00" * 200)
+
+    settings = pan_app.Settings(str(path))
+
+    assert settings.config_recovery_backup == str(path) + ".broken"
+    assert settings.config.sections() == settings.sections  # all empty, none lost
 
 
 def test_open_frozen_log_trims_before_appending(tmp_path):

--- a/virtaal/main.py
+++ b/virtaal/main.py
@@ -147,12 +147,20 @@ class Virtaal:
         defer(PropertiesController, main_controller)
         defer(DictionaryDownloadWatcher, main_controller)
         defer(main_controller.load_plugins)
+        defer(self._check_for_config_recovery)
 
         # Only bundled builds (macOS .app, Windows installer) can't
         # already control their own updates the way a checkout/pip
         # install can.
         if platform.is_frozen:
             defer(self._check_for_update)
+
+    def _check_for_config_recovery(self):
+        from virtaal.common import pan_app
+
+        backup_path = pan_app.settings.config_recovery_backup
+        if backup_path:
+            self.main_controller.view.show_config_recovery_notice(backup_path)
 
     def _check_for_update(self):
         from virtaal.__version__ import ver

--- a/virtaal/views/mainview.py
+++ b/virtaal/views/mainview.py
@@ -861,6 +861,27 @@ class MainView(BaseView):
         vbox_main.pack_start(infobar, False, False, 0)
         vbox_main.reorder_child(infobar, 1)  # directly below the menu bar
 
+    def show_config_recovery_notice(self, backup_path):
+        """Called at most once per session, if pan_app.Settings found
+            virtaal.ini unreadable and started fresh with defaults."""
+        infobar = Gtk.InfoBar()
+        infobar.set_message_type(Gtk.MessageType.WARNING)
+        infobar.set_show_close_button(True)
+        label = Gtk.Label(label=_(
+            "Your settings file could not be read, so Virtaal started with "
+            "default settings. The old file was kept at: %s") % backup_path)
+        label.set_line_wrap(True)
+        infobar.get_content_area().pack_start(label, True, True, 0)
+
+        def on_response(infobar, response_id):
+            infobar.destroy()
+        infobar.connect('response', on_response)
+
+        infobar.show_all()
+        vbox_main = self.gui.get_object('vbox_main')
+        vbox_main.pack_start(infobar, False, False, 0)
+        vbox_main.reorder_child(infobar, 1)  # directly below the menu bar
+
     def _on_file_open(self, _widget):
         self.open_file()
 


### PR DESCRIPTION
Fixes #3327.

A zero-filled `virtaal.ini` raised an uncaught `configparser.MissingSectionHeaderError` before any window could open. The same unguarded `parser.read()` is shared by every other `.ini` file Virtaal uses (`tm.ini`, `plugins.ini`, `terminology.ini`, `weblookup.ini`, `langs.ini`).

- Back the broken file up (`<file>.broken`, never overwriting an existing backup) instead of discarding it - the user may have hand-edited it.
- Start fresh with defaults rather than crashing.
- Warn the user via an info bar once the main window is up, naming where their old file went.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017KayAA91cuhe4xCpDYBg9K