### PR TITLE
po/virtaal.pot: drop line numbers from #: location comments

### DIFF
--- a/po/check-pot-freshness.sh
+++ b/po/check-pot-freshness.sh
@@ -7,13 +7,13 @@
 # test that happened not to show it. That line is stripped out before
 # comparing, so only real content changes trip this.
 #
-# `#:` location comments (source file:line references) are also
-# ignored by default - they drift on their own as unrelated code
-# elsewhere shifts line numbers, with no effect on what translators
-# actually see, so routine commits shouldn't have to regenerate the
-# whole file just to keep them current. Set POT_STRICT_LOCATIONS=1 to
-# also require these be current - the real check to run before a
-# release, where accurate source references matter.
+# `#:` location comments are filename-only (po/intltool-update passes
+# xgettext --add-location=file), so unrelated line-number shifts
+# elsewhere in a file no longer touch them at all. They're still
+# ignored here by default, belt-and-braces, since a string moving to a
+# different file entirely is still possible - it has no effect on what
+# translators actually see either way. Set POT_STRICT_LOCATIONS=1 to
+# also require these be current.
 #
 # Requires `intltool-update` on PATH (`brew install intltool` /
 # `apt install intltool`). Not everyone doing a routine commit will have

--- a/po/intltool-update
+++ b/po/intltool-update
@@ -5,6 +5,7 @@ package=$(egrep "^DOMAIN" Makevars | sed "s/DOMAIN = //g")
 
 XGETTEXT_ARGS='\
 --add-comments=l10n \
+--add-location=file \
 --copyright-holder="Zuza Software Foundation (Translate.org.za)" \
 --package-name "'$packagename'" \
 --package-version `egrep "^ver " ../'$package'/__version__.py | sed "s/ver = //;s/\"//g"` \

--- a/po/intltool-update
+++ b/po/intltool-update
@@ -1,22 +1,28 @@
 #!/bin/bash
 
-packagename=$(egrep "^X-PACKAGENAME" Makevars | sed "s/X-PACKAGENAME = //g")
-package=$(egrep "^DOMAIN" Makevars | sed "s/DOMAIN = //g")
+packagename=$(grep -E "^X-PACKAGENAME" Makevars | sed "s/X-PACKAGENAME = //g")
+package=$(grep -E "^DOMAIN" Makevars | sed "s/DOMAIN = //g")
 
+# shellcheck disable=SC2089,SC2090
+# Deliberately a flat string, not an array: this is exported as an
+# environment variable for intltool-update's own Perl script to read
+# and splice into a shell command it builds itself - a bash array
+# can't cross that process boundary.
 XGETTEXT_ARGS='\
 --add-comments=l10n \
 --add-location=file \
 --copyright-holder="Zuza Software Foundation (Translate.org.za)" \
 --package-name "'$packagename'" \
---package-version `egrep "^ver " ../'$package'/__version__.py | sed "s/ver = //;s/\"//g"` \
+--package-version `grep -E "^ver " ../'$package'/__version__.py | sed "s/ver = //;s/\"//g"` \
 '
+# shellcheck disable=SC2090
 export XGETTEXT_ARGS
 
 # Hack around the fact that intltool-update does not do --previous
-if [ $# -eq 1 -a -f $1.po ]; then
+if [ "$#" -eq 1 ] && [ -f "$1.po" ]; then
 	# We are trying to update an existing translation
 	# intltool-update xy ==> intltool-update --pot && intltool-update --dist xy
-	intltool-update --pot && msgmerge --previous --update $1.po $package.pot
+	intltool-update --pot && msgmerge --previous --update "$1.po" "$package.pot"
 else
-	intltool-update $*
+	intltool-update "$@"
 fi

--- a/po/virtaal.pot
+++ b/po/virtaal.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Virtaal 1.0.0-beta1\n"
 "Report-Msgid-Bugs-To: translate-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2026-09-11 13:18+0100\n"
+"POT-Creation-Date: 2026-09-12 09:23+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,30 +17,30 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ../share/applications/virtaal.desktop.in.h:1
-#: ../share/virtaal/virtaal.ui.h:18 ../virtaal/views/mainview.py:985
+#: ../share/applications/virtaal.desktop.in.h ../share/virtaal/virtaal.ui.h
+#: ../virtaal/views/mainview.py
 msgid "Virtaal"
 msgstr ""
 
-#: ../share/applications/virtaal.desktop.in.h:2
+#: ../share/applications/virtaal.desktop.in.h
 msgid "Translation Tool"
 msgstr ""
 
 #. l10n: The summary should be less than 100 characters
-#: ../share/applications/virtaal.desktop.in.h:3
-#: ../share/metainfo/virtaal.metainfo.xml.in.h:4
+#: ../share/applications/virtaal.desktop.in.h
+#: ../share/metainfo/virtaal.metainfo.xml.in.h
 msgid ""
 "A translation tool to help a human translator translate files into other "
 "languages"
 msgstr ""
 
 #. l10n: The name should be less than 30 characters
-#: ../share/metainfo/virtaal.metainfo.xml.in.h:2
+#: ../share/metainfo/virtaal.metainfo.xml.in.h
 msgid "Virtaal Translation Tool"
 msgstr ""
 
 #. l10n: Paragraphs should be less than 600 characters
-#: ../share/metainfo/virtaal.metainfo.xml.in.h:6
+#: ../share/metainfo/virtaal.metainfo.xml.in.h
 msgid ""
 "Virtaal is a program for doing translation. It aims for a delightful "
 "combination of simplicity and power. It integrates with selected online "
@@ -48,82 +48,82 @@ msgid ""
 "quality."
 msgstr ""
 
-#: ../share/metainfo/virtaal.metainfo.xml.in.h:7
+#: ../share/metainfo/virtaal.metainfo.xml.in.h
 msgid ""
 "The initial focus is on software translation (localization or l10n), but is "
 "definitely meant to be useful as a general purpose tool for Computer Aided "
 "Translation (CAT)."
 msgstr ""
 
-#: ../share/metainfo/virtaal.metainfo.xml.in.h:8
+#: ../share/metainfo/virtaal.metainfo.xml.in.h
 msgid "Some features:"
 msgstr ""
 
 #. l10n: These list items should be less than 100 characters
-#: ../share/metainfo/virtaal.metainfo.xml.in.h:10
+#: ../share/metainfo/virtaal.metainfo.xml.in.h
 msgid "Translation reuse (translation memory)"
 msgstr ""
 
-#: ../share/metainfo/virtaal.metainfo.xml.in.h:11
-#: ../virtaal/views/widgets/welcomescreen.py:84
+#: ../share/metainfo/virtaal.metainfo.xml.in.h
+#: ../virtaal/views/widgets/welcomescreen.py
 msgid "Terminology assistance"
 msgstr ""
 
-#: ../share/metainfo/virtaal.metainfo.xml.in.h:12
+#: ../share/metainfo/virtaal.metainfo.xml.in.h
 msgid "AutoCompletor and AutoCorrector"
 msgstr ""
 
-#: ../share/metainfo/virtaal.metainfo.xml.in.h:13
+#: ../share/metainfo/virtaal.metainfo.xml.in.h
 msgid "Quality checks with customization for many languages"
 msgstr ""
 
 #. l10n: Captions should be shorter than 50 characters
-#: ../share/metainfo/virtaal.metainfo.xml.in.h:15
+#: ../share/metainfo/virtaal.metainfo.xml.in.h
 msgid "Easy access to recent files and documentation"
 msgstr ""
 
-#: ../share/metainfo/virtaal.metainfo.xml.in.h:16
+#: ../share/metainfo/virtaal.metainfo.xml.in.h
 msgid "Recognized elements don't need to be typed"
 msgstr ""
 
-#: ../share/metainfo/virtaal.metainfo.xml.in.h:17
+#: ../share/metainfo/virtaal.metainfo.xml.in.h
 msgid "Quality checks while you type"
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:1
+#: ../share/virtaal/virtaal.ui.h
 msgid "Add Missing Language"
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:2
+#: ../share/virtaal/virtaal.ui.h
 msgid "Language name:"
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:3
+#: ../share/virtaal/virtaal.ui.h
 msgid "ISO code:"
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:4
+#: ../share/virtaal/virtaal.ui.h
 msgid "Plural expression:"
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:5
+#: ../share/virtaal/virtaal.ui.h
 msgid "Number of plurals:"
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:6
+#: ../share/virtaal/virtaal.ui.h
 msgid ""
 "Depending on the translation task, the plural information might be optional."
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:7
+#: ../share/virtaal/virtaal.ui.h
 msgid "<b>Language Information</b>"
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:8
+#: ../share/virtaal/virtaal.ui.h
 msgid "New Language Pair"
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:9
+#: ../share/virtaal/virtaal.ui.h
 msgid ""
 "The <b>Original</b> is the language from which you are translating, also "
 "called the source language.\n"
@@ -132,11 +132,11 @@ msgid ""
 "original or source language."
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:12
+#: ../share/virtaal/virtaal.ui.h
 msgid "<b>Original</b>"
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:13
+#: ../share/virtaal/virtaal.ui.h
 msgid ""
 "The <b>Translation</b> is the language into which you are translating, also "
 "called the target language.\n"
@@ -145,540 +145,534 @@ msgid ""
 "translation or target language."
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:16
+#: ../share/virtaal/virtaal.ui.h
 msgid "<b>Translation</b>"
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:17
+#: ../share/virtaal/virtaal.ui.h
 msgid "_Add Missing Language..."
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:19
+#: ../share/virtaal/virtaal.ui.h
 msgid "_File"
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:20
+#: ../share/virtaal/virtaal.ui.h
 msgid "_Update from Template"
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:21
+#: ../share/virtaal/virtaal.ui.h
 msgid "_Export"
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:22
+#: ../share/virtaal/virtaal.ui.h
 msgid "_Recent Files"
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:23
+#: ../share/virtaal/virtaal.ui.h
 msgid "_Edit"
 msgstr ""
 
 #. l10n: Activating this menu item copies the whole source (or part thereof) to the target. The "copy" is not necessarily the same as the source: terminology placeables are translated when copied and language-specific punctionation changes are made automatically.
-#: ../share/virtaal/virtaal.ui.h:25
+#: ../share/virtaal/virtaal.ui.h
 msgid "Transfer From Source"
 msgstr ""
 
 #. l10n: More information about placeables: http://translate.sourceforge.net/wiki/virtaal/placeables
-#: ../share/virtaal/virtaal.ui.h:27
+#: ../share/virtaal/virtaal.ui.h
 msgid "P_revious Placeable"
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:28
+#: ../share/virtaal/virtaal.ui.h
 msgid "_Next Placeable"
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:29
+#: ../share/virtaal/virtaal.ui.h
 msgid "_View"
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:30
+#: ../share/virtaal/virtaal.ui.h
 msgid "_Full Screen"
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:31
+#: ../share/virtaal/virtaal.ui.h
 msgid "_Quality Checks"
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:32
+#: ../share/virtaal/virtaal.ui.h
 msgid "_Navigation"
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:33
+#: ../share/virtaal/virtaal.ui.h
 msgid "P_age Up"
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:34
+#: ../share/virtaal/virtaal.ui.h
 msgid "_Page Down"
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:35
+#: ../share/virtaal/virtaal.ui.h
 msgid "_Help"
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:36
+#: ../share/virtaal/virtaal.ui.h
 msgid "_Online Help"
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:37
+#: ../share/virtaal/virtaal.ui.h
 msgid "_Tutorial"
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:38
+#: ../share/virtaal/virtaal.ui.h
 msgid "_Localization Guide"
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:39
+#: ../share/virtaal/virtaal.ui.h
 msgid "Report a _Bug"
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:40
+#: ../share/virtaal/virtaal.ui.h
 msgid "Keyboard _Shortcuts"
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:41
+#: ../share/virtaal/virtaal.ui.h
 msgid "Virtaal Preferences"
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:42
+#: ../share/virtaal/virtaal.ui.h
 msgid "The name stored in the file header"
 msgstr ""
 
 #. l10n: This label is for the name of the translator
-#: ../share/virtaal/virtaal.ui.h:44
+#: ../share/virtaal/virtaal.ui.h
 msgid "Name:"
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:45
+#: ../share/virtaal/virtaal.ui.h
 msgid "The e-mail address stored in the file header"
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:46
+#: ../share/virtaal/virtaal.ui.h
 msgid "E-mail address:"
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:47
+#: ../share/virtaal/virtaal.ui.h
 msgid ""
 "The team information stored in the file header. This can be an e-mail "
 "address or a URL, for example."
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:48
+#: ../share/virtaal/virtaal.ui.h
 msgid "Team:"
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:49
+#: ../share/virtaal/virtaal.ui.h
 msgid "<b>Translator Information</b>"
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:50
+#: ../share/virtaal/virtaal.ui.h
 msgid "Source text:"
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:51
+#: ../share/virtaal/virtaal.ui.h
 msgid "Target text:"
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:52
+#: ../share/virtaal/virtaal.ui.h
 msgid "Use _Default Fonts"
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:53
+#: ../share/virtaal/virtaal.ui.h
 msgid "<b>Fonts</b>"
 msgstr ""
 
 #. l10n: This tab label refers to the general preferences
-#: ../share/virtaal/virtaal.ui.h:55
+#: ../share/virtaal/virtaal.ui.h
 msgid "General"
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:56
+#: ../share/virtaal/virtaal.ui.h
 msgid ""
 "Placeables are special parts of the text that can be automatically "
 "highlighted and easily inserted into the translation."
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:57
+#: ../share/virtaal/virtaal.ui.h
 msgid "Placeables"
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:58
-#: ../virtaal/views/widgets/shortcutswindow.py:44
+#: ../share/virtaal/virtaal.ui.h ../virtaal/views/widgets/shortcutswindow.py
 msgid "Plug-ins"
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:59
+#: ../share/virtaal/virtaal.ui.h
 msgid "Properties"
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:60
+#: ../share/virtaal/virtaal.ui.h
 msgid "<b>Words</b> (total):"
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:61
+#: ../share/virtaal/virtaal.ui.h
 msgid "<b>Strings</b> (total):"
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:62
+#: ../share/virtaal/virtaal.ui.h
 msgid "File type:"
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:63
+#: ../share/virtaal/virtaal.ui.h
 msgid "File size:"
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:64
+#: ../share/virtaal/virtaal.ui.h
 msgid "Location:"
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:65
+#: ../share/virtaal/virtaal.ui.h
 msgid "Add Term"
 msgstr ""
 
 #. l10n: This label refers to comments about a new term that is added
-#: ../share/virtaal/virtaal.ui.h:67
+#: ../share/virtaal/virtaal.ui.h
 msgid "C_omments"
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:68
+#: ../share/virtaal/virtaal.ui.h
 msgid "Terminology _file:"
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:69
+#: ../share/virtaal/virtaal.ui.h
 msgid "Terminology Files"
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:70
+#: ../share/virtaal/virtaal.ui.h
 msgid "Add URL"
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:71
+#: ../share/virtaal/virtaal.ui.h
 msgid "URL:"
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:72
+#: ../share/virtaal/virtaal.ui.h
 msgid "Put queries in quotes"
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:73
+#: ../share/virtaal/virtaal.ui.h
 msgid "<b>Options</b>"
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:74
+#: ../share/virtaal/virtaal.ui.h
 msgid "Web Look-ups"
 msgstr ""
 
 #. l10n: Remove the tags if underlining is unsuitable for your language. Most languages will not need to change this. Translate the word Open normally.
-#: ../share/virtaal/virtaal.ui.h:76
+#: ../share/virtaal/virtaal.ui.h
 msgid "<u>Open</u>"
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:77
+#: ../share/virtaal/virtaal.ui.h
 msgid "<b><big>Recent Files</big></b>"
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:78
+#: ../share/virtaal/virtaal.ui.h
 msgid "<u>Tutorial</u>"
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:79
+#: ../share/virtaal/virtaal.ui.h
 msgid "<u>Cheat Sheet</u>"
 msgstr ""
 
 #. l10n: Only change this URL if there is a translated version in your language, or if the default English is really unsuitable for users in your language
-#: ../share/virtaal/virtaal.ui.h:81
-#: ../virtaal/controllers/welcomescreencontroller.py:25
+#: ../share/virtaal/virtaal.ui.h
+#: ../virtaal/controllers/welcomescreencontroller.py
 msgid ""
 "https://docs.translatehouse.org/projects/virtaal/en/latest/features.html"
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:82
+#: ../share/virtaal/virtaal.ui.h
 msgid "<u>More...</u>"
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:83
+#: ../share/virtaal/virtaal.ui.h
 msgid "<u>Features</u>"
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:84
+#: ../share/virtaal/virtaal.ui.h
 msgid "<b><big>Getting Started</big></b>"
 msgstr ""
 
 #. l10n: Only change this URL if there is a translated version in your language, or if the default English is really unsuitable for users in your language
-#: ../share/virtaal/virtaal.ui.h:86
-#: ../virtaal/controllers/welcomescreencontroller.py:22
+#: ../share/virtaal/virtaal.ui.h
+#: ../virtaal/controllers/welcomescreencontroller.py
 msgid ""
 "https://docs.translatehouse.org/projects/virtaal/en/latest/using_virtaal.html"
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:87
+#: ../share/virtaal/virtaal.ui.h
 msgid "<u>Manual</u>"
 msgstr ""
 
 #. l10n: Only change this URL if there is a translated version in your language, or if the default English is really unsuitable for users in your language
-#: ../share/virtaal/virtaal.ui.h:89
-#: ../virtaal/controllers/welcomescreencontroller.py:23
+#: ../share/virtaal/virtaal.ui.h
+#: ../virtaal/controllers/welcomescreencontroller.py
 msgid "https://docs.translatehouse.org/projects/localization-guide/en/"
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:90
+#: ../share/virtaal/virtaal.ui.h
 msgid "<u>Localization Guide</u>"
 msgstr ""
 
 #. l10n: Only change this URL if there is a translated version in your language, or if the default English is really unsuitable for users in your language
-#: ../share/virtaal/virtaal.ui.h:92
-#: ../virtaal/controllers/welcomescreencontroller.py:24
+#: ../share/virtaal/virtaal.ui.h
+#: ../virtaal/controllers/welcomescreencontroller.py
 msgid ""
 "https://docs.translatehouse.org/projects/virtaal/en/latest/index.html#contact"
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:93
+#: ../share/virtaal/virtaal.ui.h
 msgid "<u>Feedback</u>"
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:94
+#: ../share/virtaal/virtaal.ui.h
 msgid "Report a bug on GitHub"
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:95
+#: ../share/virtaal/virtaal.ui.h
 msgid "<u>Report a Bug</u>"
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h:96
+#: ../share/virtaal/virtaal.ui.h
 msgid "<b><big>Support</big></b>"
 msgstr ""
 
-#: ../virtaal/controllers/checkscontroller.py:17
+#: ../virtaal/controllers/checkscontroller.py
 msgid "Fuzzy"
 msgstr ""
 
-#: ../virtaal/controllers/checkscontroller.py:18
-#: ../virtaal/controllers/unitcontroller.py:72
+#: ../virtaal/controllers/checkscontroller.py
+#: ../virtaal/controllers/unitcontroller.py
 msgid "Untranslated"
 msgstr ""
 
-#: ../virtaal/controllers/checkscontroller.py:19
+#: ../virtaal/controllers/checkscontroller.py
 msgid "Accelerators"
 msgstr ""
 
-#: ../virtaal/controllers/checkscontroller.py:20
+#: ../virtaal/controllers/checkscontroller.py
 msgid "Acronyms"
 msgstr ""
 
-#: ../virtaal/controllers/checkscontroller.py:21
+#: ../virtaal/controllers/checkscontroller.py
 msgid "Blank"
 msgstr ""
 
-#: ../virtaal/controllers/checkscontroller.py:22
+#: ../virtaal/controllers/checkscontroller.py
 msgid "Brackets"
 msgstr ""
 
-#: ../virtaal/controllers/checkscontroller.py:23
+#: ../virtaal/controllers/checkscontroller.py
 msgid "Compendium conflict"
 msgstr ""
 
-#: ../virtaal/controllers/checkscontroller.py:24
+#: ../virtaal/controllers/checkscontroller.py
 msgid "Translator credits"
 msgstr ""
 
-#: ../virtaal/controllers/checkscontroller.py:25
+#: ../virtaal/controllers/checkscontroller.py
 msgid "Double quotes"
 msgstr ""
 
-#: ../virtaal/controllers/checkscontroller.py:26
+#: ../virtaal/controllers/checkscontroller.py
 msgid "Double spaces"
 msgstr ""
 
-#: ../virtaal/controllers/checkscontroller.py:27
+#: ../virtaal/controllers/checkscontroller.py
 msgid "Repeated word"
 msgstr ""
 
-#: ../virtaal/controllers/checkscontroller.py:28
-#: ../virtaal/controllers/placeablescontroller.py:86
+#: ../virtaal/controllers/checkscontroller.py
+#: ../virtaal/controllers/placeablescontroller.py
 msgid "E-mail"
 msgstr ""
 
-#: ../virtaal/controllers/checkscontroller.py:29
+#: ../virtaal/controllers/checkscontroller.py
 msgid "Ending punctuation"
 msgstr ""
 
-#: ../virtaal/controllers/checkscontroller.py:30
+#: ../virtaal/controllers/checkscontroller.py
 msgid "Ending whitespace"
 msgstr ""
 
-#: ../virtaal/controllers/checkscontroller.py:31
+#: ../virtaal/controllers/checkscontroller.py
 msgid "Escapes"
 msgstr ""
 
-#: ../virtaal/controllers/checkscontroller.py:32
+#: ../virtaal/controllers/checkscontroller.py
 msgid "File paths"
 msgstr ""
 
-#: ../virtaal/controllers/checkscontroller.py:33
+#: ../virtaal/controllers/checkscontroller.py
 msgid "Functions"
 msgstr ""
 
-#: ../virtaal/controllers/checkscontroller.py:34
+#: ../virtaal/controllers/checkscontroller.py
 msgid "GConf values"
 msgstr ""
 
-#: ../virtaal/controllers/checkscontroller.py:35
+#: ../virtaal/controllers/checkscontroller.py
 msgid "Old KDE comment"
 msgstr ""
 
-#: ../virtaal/controllers/checkscontroller.py:36
+#: ../virtaal/controllers/checkscontroller.py
 msgid "Long"
 msgstr ""
 
-#: ../virtaal/controllers/checkscontroller.py:37
+#: ../virtaal/controllers/checkscontroller.py
 msgid "Must translate words"
 msgstr ""
 
-#: ../virtaal/controllers/checkscontroller.py:38
+#: ../virtaal/controllers/checkscontroller.py
 msgid "Newlines"
 msgstr ""
 
-#: ../virtaal/controllers/checkscontroller.py:39
+#: ../virtaal/controllers/checkscontroller.py
 msgid "Number of plurals"
 msgstr ""
 
-#: ../virtaal/controllers/checkscontroller.py:40
+#: ../virtaal/controllers/checkscontroller.py
 msgid "Don't translate words"
 msgstr ""
 
-#: ../virtaal/controllers/checkscontroller.py:41
-#: ../virtaal/controllers/placeablescontroller.py:110
+#: ../virtaal/controllers/checkscontroller.py
+#: ../virtaal/controllers/placeablescontroller.py
 msgid "Numbers"
 msgstr ""
 
-#: ../virtaal/controllers/checkscontroller.py:42
+#: ../virtaal/controllers/checkscontroller.py
 msgid "Options"
 msgstr ""
 
-#: ../virtaal/controllers/checkscontroller.py:43
+#: ../virtaal/controllers/checkscontroller.py
 msgid "printf()"
 msgstr ""
 
-#: ../virtaal/controllers/checkscontroller.py:44
+#: ../virtaal/controllers/checkscontroller.py
 msgid "Punctuation spacing"
 msgstr ""
 
-#: ../virtaal/controllers/checkscontroller.py:45
+#: ../virtaal/controllers/checkscontroller.py
 msgid "Pure punctuation"
 msgstr ""
 
-#: ../virtaal/controllers/checkscontroller.py:46
+#: ../virtaal/controllers/checkscontroller.py
 msgid "Number of sentences"
 msgstr ""
 
-#: ../virtaal/controllers/checkscontroller.py:47
+#: ../virtaal/controllers/checkscontroller.py
 msgid "Short"
 msgstr ""
 
-#: ../virtaal/controllers/checkscontroller.py:48
+#: ../virtaal/controllers/checkscontroller.py
 msgid "Simple capitalization"
 msgstr ""
 
-#: ../virtaal/controllers/checkscontroller.py:49
+#: ../virtaal/controllers/checkscontroller.py
 msgid "Simple plural(s)"
 msgstr ""
 
-#: ../virtaal/controllers/checkscontroller.py:50
+#: ../virtaal/controllers/checkscontroller.py
 msgid "Single quotes"
 msgstr ""
 
-#: ../virtaal/controllers/checkscontroller.py:51
+#: ../virtaal/controllers/checkscontroller.py
 msgid "Spelling"
 msgstr ""
 
-#: ../virtaal/controllers/checkscontroller.py:52
+#: ../virtaal/controllers/checkscontroller.py
 msgid "Starting capitalization"
 msgstr ""
 
-#: ../virtaal/controllers/checkscontroller.py:53
+#: ../virtaal/controllers/checkscontroller.py
 msgid "Starting punctuation"
 msgstr ""
 
-#: ../virtaal/controllers/checkscontroller.py:54
+#: ../virtaal/controllers/checkscontroller.py
 msgid "Starting whitespace"
 msgstr ""
 
-#: ../virtaal/controllers/checkscontroller.py:55
+#: ../virtaal/controllers/checkscontroller.py
 msgid "Tabs"
 msgstr ""
 
-#: ../virtaal/controllers/checkscontroller.py:56
+#: ../virtaal/controllers/checkscontroller.py
 msgid "Unchanged"
 msgstr ""
 
-#: ../virtaal/controllers/checkscontroller.py:57
-#: ../virtaal/controllers/placeablescontroller.py:119
+#: ../virtaal/controllers/checkscontroller.py
+#: ../virtaal/controllers/placeablescontroller.py
 msgid "URLs"
 msgstr ""
 
-#: ../virtaal/controllers/checkscontroller.py:58
+#: ../virtaal/controllers/checkscontroller.py
 msgid "Valid characters"
 msgstr ""
 
-#: ../virtaal/controllers/checkscontroller.py:59
+#: ../virtaal/controllers/checkscontroller.py
 msgid "Placeholders"
 msgstr ""
 
-#: ../virtaal/controllers/checkscontroller.py:60
+#: ../virtaal/controllers/checkscontroller.py
 msgid "XML tags"
 msgstr ""
 
-#: ../virtaal/controllers/checkscontroller.py:99
+#: ../virtaal/controllers/checkscontroller.py
 msgid "Default"
 msgstr ""
 
-#: ../virtaal/controllers/checkscontroller.py:102
+#: ../virtaal/controllers/checkscontroller.py
 msgid "LibreOffice"
 msgstr ""
 
-#: ../virtaal/controllers/checkscontroller.py:103
+#: ../virtaal/controllers/checkscontroller.py
 msgid "Mozilla"
 msgstr ""
 
-#: ../virtaal/controllers/checkscontroller.py:104
+#: ../virtaal/controllers/checkscontroller.py
 msgid "KDE"
 msgstr ""
 
-#: ../virtaal/controllers/checkscontroller.py:105
+#: ../virtaal/controllers/checkscontroller.py
 msgid "GNOME"
 msgstr ""
 
-#: ../virtaal/controllers/checkscontroller.py:106
+#: ../virtaal/controllers/checkscontroller.py
 msgid "Drupal"
 msgstr ""
 
-#: ../virtaal/controllers/maincontroller.py:69
-#: ../virtaal/controllers/maincontroller.py:78
-#: ../virtaal/controllers/maincontroller.py:87
+#: ../virtaal/controllers/maincontroller.py
 msgid "Header information"
 msgstr ""
 
-#: ../virtaal/controllers/maincontroller.py:70
+#: ../virtaal/controllers/maincontroller.py
 msgid "Please enter your name"
 msgstr ""
 
-#: ../virtaal/controllers/maincontroller.py:79
+#: ../virtaal/controllers/maincontroller.py
 msgid "Please enter your e-mail address"
 msgstr ""
 
-#: ../virtaal/controllers/maincontroller.py:88
+#: ../virtaal/controllers/maincontroller.py
 msgid "Please enter your team's information"
 msgstr ""
 
-#: ../virtaal/controllers/maincontroller.py:192
-#: ../virtaal/controllers/maincontroller.py:333
+#: ../virtaal/controllers/maincontroller.py
 msgid ""
 "You selected the currently open file for opening. Do you want to reload the "
 "file?"
 msgstr ""
 
-#: ../virtaal/controllers/maincontroller.py:204
-#: ../virtaal/controllers/maincontroller.py:317
-#: ../virtaal/controllers/maincontroller.py:345
+#: ../virtaal/controllers/maincontroller.py
 #, python-format
 msgid ""
 "Could not open file.\n"
@@ -688,12 +682,11 @@ msgid ""
 "Try opening a different file."
 msgstr ""
 
-#: ../virtaal/controllers/maincontroller.py:227
-#: ../virtaal/views/mainview.py:342
+#: ../virtaal/controllers/maincontroller.py ../virtaal/views/mainview.py
 msgid "Save"
 msgstr ""
 
-#: ../virtaal/controllers/maincontroller.py:250
+#: ../virtaal/controllers/maincontroller.py
 #, python-format
 msgid ""
 "Could not save file.\n"
@@ -703,7 +696,7 @@ msgid ""
 "Try saving to a different location."
 msgstr ""
 
-#: ../virtaal/controllers/maincontroller.py:256
+#: ../virtaal/controllers/maincontroller.py
 #, python-format
 msgid ""
 "Could not save file.\n"
@@ -711,15 +704,15 @@ msgid ""
 "%(error_message)s"
 msgstr ""
 
-#: ../virtaal/controllers/maincontroller.py:267
+#: ../virtaal/controllers/maincontroller.py
 msgid "Can only export Gettext PO files"
 msgstr ""
 
-#: ../virtaal/controllers/maincontroller.py:276
+#: ../virtaal/controllers/maincontroller.py
 msgid "Export"
 msgstr ""
 
-#: ../virtaal/controllers/maincontroller.py:284
+#: ../virtaal/controllers/maincontroller.py
 #, python-format
 msgid ""
 "Could not export file.\n"
@@ -729,7 +722,7 @@ msgid ""
 "Try saving to a different location."
 msgstr ""
 
-#: ../virtaal/controllers/maincontroller.py:290
+#: ../virtaal/controllers/maincontroller.py
 #, python-format
 msgid ""
 "Could not export file.\n"
@@ -737,240 +730,239 @@ msgid ""
 "%(error_message)s"
 msgstr ""
 
-#: ../virtaal/controllers/maincontroller.py:306
+#: ../virtaal/controllers/maincontroller.py
 msgid "Reload File"
 msgstr ""
 
-#: ../virtaal/controllers/maincontroller.py:306
+#: ../virtaal/controllers/maincontroller.py
 msgid "Reload file from last saved copy and lose all changes?"
 msgstr ""
 
 #. l10n: See http://en.wikipedia.org/wiki/CamelCase
-#: ../virtaal/controllers/placeablescontroller.py:73
+#: ../virtaal/controllers/placeablescontroller.py
 msgid "CamelCase"
 msgstr ""
 
-#: ../virtaal/controllers/placeablescontroller.py:74
+#: ../virtaal/controllers/placeablescontroller.py
 msgid ""
 "Words with internal capitalization, such as some brand names and WikiWords"
 msgstr ""
 
-#: ../virtaal/controllers/placeablescontroller.py:77
+#: ../virtaal/controllers/placeablescontroller.py
 msgid "Capitals"
 msgstr ""
 
 #. l10n: this refers to "UPPERCASE" / "CAPITAL" letters
-#: ../virtaal/controllers/placeablescontroller.py:79
+#: ../virtaal/controllers/placeablescontroller.py
 msgid "Words containing uppercase letters only"
 msgstr ""
 
-#: ../virtaal/controllers/placeablescontroller.py:82
+#: ../virtaal/controllers/placeablescontroller.py
 msgid "Command Line Options"
 msgstr ""
 
-#: ../virtaal/controllers/placeablescontroller.py:83
+#: ../virtaal/controllers/placeablescontroller.py
 msgid "Application command line options, such as --help, -h and -I"
 msgstr ""
 
-#: ../virtaal/controllers/placeablescontroller.py:87
+#: ../virtaal/controllers/placeablescontroller.py
 msgid "E-mail addresses"
 msgstr ""
 
-#: ../virtaal/controllers/placeablescontroller.py:90
+#: ../virtaal/controllers/placeablescontroller.py
 msgid "File Names"
 msgstr ""
 
-#: ../virtaal/controllers/placeablescontroller.py:91
+#: ../virtaal/controllers/placeablescontroller.py
 msgid "Paths referring to file locations"
 msgstr ""
 
-#: ../virtaal/controllers/placeablescontroller.py:94
+#: ../virtaal/controllers/placeablescontroller.py
 msgid "Placeholders (printf)"
 msgstr ""
 
-#: ../virtaal/controllers/placeablescontroller.py:95
+#: ../virtaal/controllers/placeablescontroller.py
 msgid "Placeholders used in \"printf\" strings"
 msgstr ""
 
-#: ../virtaal/controllers/placeablescontroller.py:98
+#: ../virtaal/controllers/placeablescontroller.py
 msgid "Placeholders (Python)"
 msgstr ""
 
-#: ../virtaal/controllers/placeablescontroller.py:99
+#: ../virtaal/controllers/placeablescontroller.py
 msgid "Placeholders in Python strings"
 msgstr ""
 
-#: ../virtaal/controllers/placeablescontroller.py:102
+#: ../virtaal/controllers/placeablescontroller.py
 msgid "Placeholders (Java)"
 msgstr ""
 
-#: ../virtaal/controllers/placeablescontroller.py:103
+#: ../virtaal/controllers/placeablescontroller.py
 msgid "Placeholders in Java strings"
 msgstr ""
 
-#: ../virtaal/controllers/placeablescontroller.py:106
+#: ../virtaal/controllers/placeablescontroller.py
 msgid "Placeholders (Qt)"
 msgstr ""
 
-#: ../virtaal/controllers/placeablescontroller.py:107
+#: ../virtaal/controllers/placeablescontroller.py
 msgid "Placeholders in Qt strings"
 msgstr ""
 
 #. l10n: 'decimal fractions' refer to numbers like 0.2 or 499,99
-#: ../virtaal/controllers/placeablescontroller.py:112
+#: ../virtaal/controllers/placeablescontroller.py
 msgid "Integer numbers and decimal fractions"
 msgstr ""
 
-#: ../virtaal/controllers/placeablescontroller.py:115
+#: ../virtaal/controllers/placeablescontroller.py
 msgid "Punctuation"
 msgstr ""
 
-#: ../virtaal/controllers/placeablescontroller.py:116
+#: ../virtaal/controllers/placeablescontroller.py
 msgid "Symbols and less frequently used punctuation marks"
 msgstr ""
 
-#: ../virtaal/controllers/placeablescontroller.py:120
+#: ../virtaal/controllers/placeablescontroller.py
 msgid "URLs, hostnames and IP addresses"
 msgstr ""
 
 #. l10n: see http://en.wikipedia.org/wiki/Character_entity_reference
-#: ../virtaal/controllers/placeablescontroller.py:124
+#: ../virtaal/controllers/placeablescontroller.py
 msgid "XML Entities"
 msgstr ""
 
-#: ../virtaal/controllers/placeablescontroller.py:125
+#: ../virtaal/controllers/placeablescontroller.py
 msgid "Entity references, such as &amp; and &#169;"
 msgstr ""
 
-#: ../virtaal/controllers/placeablescontroller.py:128
+#: ../virtaal/controllers/placeablescontroller.py
 msgid "XML Tags"
 msgstr ""
 
-#: ../virtaal/controllers/placeablescontroller.py:129
+#: ../virtaal/controllers/placeablescontroller.py
 msgid "XML tags, such as <b> and </i>"
 msgstr ""
 
-#: ../virtaal/controllers/placeablescontroller.py:143
+#: ../virtaal/controllers/placeablescontroller.py
 msgid "Spaces"
 msgstr ""
 
-#: ../virtaal/controllers/placeablescontroller.py:144
+#: ../virtaal/controllers/placeablescontroller.py
 msgid "Double spaces and spaces in unexpected positions"
 msgstr ""
 
-#: ../virtaal/controllers/placeablescontroller.py:145
+#: ../virtaal/controllers/placeablescontroller.py
 msgid "\"alt\" Attributes"
 msgstr ""
 
-#: ../virtaal/controllers/placeablescontroller.py:146
+#: ../virtaal/controllers/placeablescontroller.py
 msgid "Placeable for \"alt\" attributes (as found in HTML)"
 msgstr ""
 
-#: ../virtaal/controllers/placeablescontroller.py:147
+#: ../virtaal/controllers/placeablescontroller.py
 msgid "Placeholders (Drupal)"
 msgstr ""
 
-#: ../virtaal/controllers/placeablescontroller.py:148
+#: ../virtaal/controllers/placeablescontroller.py
 msgid "Placeholders in Drupal strings"
 msgstr ""
 
-#: ../virtaal/controllers/storecontroller.py:194
+#: ../virtaal/controllers/storecontroller.py
 msgid "No source or translatable files in bundle"
 msgstr ""
 
-#: ../virtaal/controllers/storecontroller.py:226
+#: ../virtaal/controllers/storecontroller.py
 msgid "The file contains nothing to translate."
 msgstr ""
 
 #. l10n: The heading of statistics before updating to the new template
-#: ../virtaal/controllers/storecontroller.py:433
+#: ../virtaal/controllers/storecontroller.py
 msgid "Before:"
 msgstr ""
 
 #. l10n: The heading of statistics after updating to the new template
-#: ../virtaal/controllers/storecontroller.py:435
+#: ../virtaal/controllers/storecontroller.py
 msgid "After:"
 msgstr ""
 
-#: ../virtaal/controllers/storecontroller.py:436
+#: ../virtaal/controllers/storecontroller.py
 #, python-format
 msgid "Translated: %d"
 msgstr ""
 
-#: ../virtaal/controllers/storecontroller.py:437
+#: ../virtaal/controllers/storecontroller.py
 #, python-format
 msgid "Fuzzy: %d"
 msgstr ""
 
-#: ../virtaal/controllers/storecontroller.py:438
+#: ../virtaal/controllers/storecontroller.py
 #, python-format
 msgid "Untranslated: %d"
 msgstr ""
 
-#: ../virtaal/controllers/storecontroller.py:439
+#: ../virtaal/controllers/storecontroller.py
 #, python-format
 msgid "Total: %d"
 msgstr ""
 
 #. l10n: this refers to updating a file to a new template (POT file)
-#: ../virtaal/controllers/storecontroller.py:457
+#: ../virtaal/controllers/storecontroller.py
 msgid "File Updated"
 msgstr ""
 
-#: ../virtaal/controllers/unitcontroller.py:73
+#: ../virtaal/controllers/unitcontroller.py
 msgid "Needs work"
 msgstr ""
 
-#: ../virtaal/controllers/unitcontroller.py:74
+#: ../virtaal/controllers/unitcontroller.py
 msgid "Rejected"
 msgstr ""
 
-#: ../virtaal/controllers/unitcontroller.py:75
+#: ../virtaal/controllers/unitcontroller.py
 msgid "Needs review"
 msgstr ""
 
-#: ../virtaal/controllers/unitcontroller.py:76
+#: ../virtaal/controllers/unitcontroller.py
 msgid "Translated"
 msgstr ""
 
-#: ../virtaal/controllers/unitcontroller.py:77
+#: ../virtaal/controllers/unitcontroller.py
 msgid "Reviewed"
 msgstr ""
 
-#: ../virtaal/modes/defaultmode.py:15
+#: ../virtaal/modes/defaultmode.py
 msgid "All"
 msgstr ""
 
-#: ../virtaal/modes/qualitycheckmode.py:21
+#: ../virtaal/modes/qualitycheckmode.py
 msgid "Quality Checks"
 msgstr ""
 
 #. l10n: This is the button where the user can select units by failing quality checks
-#: ../virtaal/modes/qualitycheckmode.py:140
+#: ../virtaal/modes/qualitycheckmode.py
 msgid "Select Checks"
 msgstr ""
 
 #. l10n: This refers to quality checks
-#: ../virtaal/modes/qualitycheckmode.py:143
+#: ../virtaal/modes/qualitycheckmode.py
 msgid "All Checks"
 msgstr ""
 
-#: ../virtaal/modes/quicktransmode.py:18
+#: ../virtaal/modes/quicktransmode.py
 msgid "Incomplete"
 msgstr ""
 
-#: ../virtaal/modes/searchmode.py:22 ../virtaal/modes/searchmode.py:55
-#: ../virtaal/views/widgets/shortcutswindow.py:31
+#: ../virtaal/modes/searchmode.py ../virtaal/views/widgets/shortcutswindow.py
 msgid "Search"
 msgstr ""
 
-#: ../virtaal/modes/searchmode.py:57
+#: ../virtaal/modes/searchmode.py
 msgid "_Case sensitive"
 msgstr ""
 
 #. l10n: To read about what regular expressions are, see
 #. http://en.wikipedia.org/wiki/Regular_expression
-#: ../virtaal/modes/searchmode.py:61
+#: ../virtaal/modes/searchmode.py
 msgid "_Regular expression"
 msgstr ""
 
@@ -978,260 +970,258 @@ msgstr ""
 #. text is typed. Keep in mind that the text box will appear after this text.
 #. If this sentence construction is hard to use, consider translating this as
 #. "Replacement"
-#: ../virtaal/modes/searchmode.py:69
+#: ../virtaal/modes/searchmode.py
 msgid "Replace with"
 msgstr ""
 
 #. l10n: Button text
-#: ../virtaal/modes/searchmode.py:72
+#: ../virtaal/modes/searchmode.py
 msgid "Replace"
 msgstr ""
 
 #. l10n: Check box
-#: ../virtaal/modes/searchmode.py:75
+#: ../virtaal/modes/searchmode.py
 msgid "Replace _All"
 msgstr ""
 
-#: ../virtaal/modes/workflowmode.py:20
+#: ../virtaal/modes/workflowmode.py
 msgid "Workflow"
 msgstr ""
 
 #. l10n: This is the button where the user can select units by workflow state
-#: ../virtaal/modes/workflowmode.py:113
+#: ../virtaal/modes/workflowmode.py
 msgid "Select States"
 msgstr ""
 
 #. l10n: This refers to workflow states
-#: ../virtaal/modes/workflowmode.py:116
+#: ../virtaal/modes/workflowmode.py
 msgid "All States"
 msgstr ""
 
-#: ../virtaal/plugins/autocompletor.py:190
+#: ../virtaal/plugins/autocompletor.py
 msgid "Automatically complete long words while you type"
 msgstr ""
 
-#: ../virtaal/plugins/autocompletor.py:191
+#: ../virtaal/plugins/autocompletor.py
 msgid "AutoCompletor"
 msgstr ""
 
-#: ../virtaal/plugins/autocorrector.py:241
+#: ../virtaal/plugins/autocorrector.py
 msgid "Automatically correct text while you type"
 msgstr ""
 
-#: ../virtaal/plugins/autocorrector.py:242
+#: ../virtaal/plugins/autocorrector.py
 msgid "AutoCorrector"
 msgstr ""
 
-#: ../virtaal/plugins/spellchecker.py:25
+#: ../virtaal/plugins/spellchecker.py
 msgid "Spell Checker"
 msgstr ""
 
-#: ../virtaal/plugins/spellchecker.py:26
+#: ../virtaal/plugins/spellchecker.py
 msgid "Check spelling and provide suggestions"
 msgstr ""
 
 #. l10n: This refers to spell checking
-#: ../virtaal/plugins/spellchecker.py:223
+#: ../virtaal/plugins/spellchecker.py
 msgid "<i>(no suggestions)</i>"
 msgstr ""
 
 #. l10n: This refers to spell checking
-#: ../virtaal/plugins/spellchecker.py:227
+#: ../virtaal/plugins/spellchecker.py
 msgid "Ignore All"
 msgstr ""
 
 #. l10n: This refers to spelling suggestions
-#: ../virtaal/plugins/spellchecker.py:231
+#: ../virtaal/plugins/spellchecker.py
 msgid "More..."
 msgstr ""
 
 #. l10n: This refers to the spell checking dictionary
-#: ../virtaal/plugins/spellchecker.py:237
+#: ../virtaal/plugins/spellchecker.py
 #, python-format
 msgid "Add \"%s\" to Dictionary"
 msgstr ""
 
-#: ../virtaal/plugins/spellchecker.py:240
+#: ../virtaal/plugins/spellchecker.py
 msgid "Languages"
 msgstr ""
 
-#: ../virtaal/plugins/lookup/__init__.py:16
+#: ../virtaal/plugins/lookup/__init__.py
 msgid "Perform look-ups on selected text"
 msgstr ""
 
-#: ../virtaal/plugins/lookup/__init__.py:17
+#: ../virtaal/plugins/lookup/__init__.py
 msgid "External Look-up"
 msgstr ""
 
 #. l10n: The 'services' here refer to different look-up plugins,
 #. such as web look-up, etc.
-#: ../virtaal/plugins/lookup/lookupview.py:59
+#: ../virtaal/plugins/lookup/lookupview.py
 msgid "Select Look-up Services"
 msgstr ""
 
-#: ../virtaal/plugins/lookup/lookupview.py:60
+#: ../virtaal/plugins/lookup/lookupview.py
 msgid "Select the services that should be used to perform look-ups"
 msgstr ""
 
 #. l10n: The menu entry when looking up a very long selection of text. Here start and end are snippets from the start and end of the long selection.
-#: ../virtaal/plugins/lookup/lookupview.py:120
+#: ../virtaal/plugins/lookup/lookupview.py
 #, python-format
 msgid "Look-up \"%(start)s … %(end)s\""
 msgstr ""
 
-#: ../virtaal/plugins/lookup/lookupview.py:122
+#: ../virtaal/plugins/lookup/lookupview.py
 #, python-format
 msgid "Look-up \"%(selection)s\""
 msgstr ""
 
 #. l10n: plugin name
-#: ../virtaal/plugins/lookup/models/weblookup.py:27
+#: ../virtaal/plugins/lookup/models/weblookup.py
 msgid "Web Look-up"
 msgstr ""
 
-#: ../virtaal/plugins/lookup/models/weblookup.py:28
+#: ../virtaal/plugins/lookup/models/weblookup.py
 msgid "Look-up the selected text on a web site"
 msgstr ""
 
 #. l10n: Try to keep this as short as possible. Feel free to transliterate.
-#: ../virtaal/plugins/lookup/models/weblookup.py:32
-#: ../virtaal/plugins/tm/models/google_translate.py:127
+#: ../virtaal/plugins/lookup/models/weblookup.py
+#: ../virtaal/plugins/tm/models/google_translate.py
 msgid "Google"
 msgstr ""
 
-#: ../virtaal/plugins/lookup/models/weblookup.py:37
+#: ../virtaal/plugins/lookup/models/weblookup.py
 msgid "Wikipedia"
 msgstr ""
 
-#: ../virtaal/plugins/lookup/models/weblookup.py:42
+#: ../virtaal/plugins/lookup/models/weblookup.py
 msgid "Wiktionary"
 msgstr ""
 
-#: ../virtaal/plugins/lookup/models/weblookup.py:158
-#: ../virtaal/views/widgets/selectview.py:71
+#: ../virtaal/plugins/lookup/models/weblookup.py
+#: ../virtaal/views/widgets/selectview.py
 msgid "Name"
 msgstr ""
 
-#: ../virtaal/plugins/lookup/models/weblookup.py:167
+#: ../virtaal/plugins/lookup/models/weblookup.py
 msgid "URL"
 msgstr ""
 
 #. l10n: Whether the selected text should be surrounded by "quotes"
-#: ../virtaal/plugins/lookup/models/weblookup.py:178
+#: ../virtaal/plugins/lookup/models/weblookup.py
 msgid "Quote Query"
 msgstr ""
 
-#: ../virtaal/plugins/migration.py:29
+#: ../virtaal/plugins/migration.py
 msgid "Migrate settings from KBabel, Lokalize and/or Poedit to Virtaal."
 msgstr ""
 
-#: ../virtaal/plugins/migration.py:30
+#: ../virtaal/plugins/migration.py
 msgid "Migration Assistant"
 msgstr ""
 
-#: ../virtaal/plugins/migration.py:67
+#: ../virtaal/plugins/migration.py
 msgid "Should Virtaal try to import settings and data from other applications?"
 msgstr ""
 
-#: ../virtaal/plugins/migration.py:68
+#: ../virtaal/plugins/migration.py
 msgid "Import data from other applications?"
 msgstr ""
 
-#: ../virtaal/plugins/migration.py:82
+#: ../virtaal/plugins/migration.py
 msgid "Migration was successfully completed"
 msgstr ""
 
-#: ../virtaal/plugins/migration.py:83
+#: ../virtaal/plugins/migration.py
 msgid "The following items were migrated:"
 msgstr ""
 
-#: ../virtaal/plugins/migration.py:86
+#: ../virtaal/plugins/migration.py
 msgid "Migration completed"
 msgstr ""
 
-#: ../virtaal/plugins/migration.py:88
+#: ../virtaal/plugins/migration.py
 msgid "Virtaal was not able to migrate any settings or data"
 msgstr ""
 
-#: ../virtaal/plugins/migration.py:89
+#: ../virtaal/plugins/migration.py
 msgid "Nothing migrated"
 msgstr ""
 
-#: ../virtaal/plugins/migration.py:189
+#: ../virtaal/plugins/migration.py
 msgid "Poedit settings"
 msgstr ""
 
-#: ../virtaal/plugins/migration.py:218
+#: ../virtaal/plugins/migration.py
 msgid "Lokalize settings"
 msgstr ""
 
-#: ../virtaal/plugins/migration.py:275
+#: ../virtaal/plugins/migration.py
 #, python-format
 msgid "Lokalize's Translation Memory: %(database_name)s"
 msgstr ""
 
-#: ../virtaal/plugins/terminology/__init__.py:14
+#: ../virtaal/plugins/terminology/__init__.py
 msgid "Terminology Help"
 msgstr ""
 
-#: ../virtaal/plugins/terminology/__init__.py:15
+#: ../virtaal/plugins/terminology/__init__.py
 msgid "Terminology suggestions"
 msgstr ""
 
-#: ../virtaal/plugins/terminology/models/autoterm.py:29
+#: ../virtaal/plugins/terminology/models/autoterm.py
 msgid "Localization Terminology"
 msgstr ""
 
-#: ../virtaal/plugins/terminology/models/autoterm.py:30
+#: ../virtaal/plugins/terminology/models/autoterm.py
 msgid "Selected localization terminology"
 msgstr ""
 
-#: ../virtaal/plugins/terminology/models/localfile/__init__.py:31
+#: ../virtaal/plugins/terminology/models/localfile/__init__.py
 msgid "Local Files"
 msgstr ""
 
-#: ../virtaal/plugins/terminology/models/localfile/__init__.py:32
+#: ../virtaal/plugins/terminology/models/localfile/__init__.py
 msgid "Local terminology files"
 msgstr ""
 
-#: ../virtaal/plugins/terminology/models/localfile/localfileview.py:39
-#: ../virtaal/plugins/terminology/models/localfile/localfileview.py:41
+#: ../virtaal/plugins/terminology/models/localfile/localfileview.py
 msgid "Terminology _Files..."
 msgstr ""
 
-#: ../virtaal/plugins/terminology/models/localfile/localfileview.py:47
-#: ../virtaal/plugins/terminology/models/localfile/localfileview.py:49
+#: ../virtaal/plugins/terminology/models/localfile/localfileview.py
 msgid "Add _Term..."
 msgstr ""
 
-#: ../virtaal/plugins/terminology/models/localfile/localfileview.py:133
+#: ../virtaal/plugins/terminology/models/localfile/localfileview.py
 msgid "File"
 msgstr ""
 
-#: ../virtaal/plugins/terminology/models/localfile/localfileview.py:143
+#: ../virtaal/plugins/terminology/models/localfile/localfileview.py
 msgid "Extendable"
 msgstr ""
 
-#: ../virtaal/plugins/terminology/models/localfile/localfileview.py:168
+#: ../virtaal/plugins/terminology/models/localfile/localfileview.py
 msgid "Add Files"
 msgstr ""
 
-#: ../virtaal/plugins/terminology/models/localfile/localfileview.py:174
-#: ../virtaal/views/mainview.py:289
+#: ../virtaal/plugins/terminology/models/localfile/localfileview.py
+#: ../virtaal/views/mainview.py
 msgid "All Supported Files"
 msgstr ""
 
-#: ../virtaal/plugins/terminology/models/localfile/localfileview.py:200
-#: ../virtaal/views/mainview.py:330
+#: ../virtaal/plugins/terminology/models/localfile/localfileview.py
+#: ../virtaal/views/mainview.py
 msgid "All Files"
 msgstr ""
 
-#: ../virtaal/plugins/terminology/models/localfile/localfileview.py:240
+#: ../virtaal/plugins/terminology/models/localfile/localfileview.py
 #, python-format
 msgid "\"%s\" is not a usable file."
 msgstr ""
 
-#: ../virtaal/plugins/terminology/models/localfile/localfileview.py:245
+#: ../virtaal/plugins/terminology/models/localfile/localfileview.py
 #, python-format
 msgid ""
 "Unable to load %(filename)s:\n"
@@ -1239,202 +1229,198 @@ msgid ""
 "%(errormsg)s"
 msgstr ""
 
-#: ../virtaal/plugins/terminology/models/localfile/localfileview.py:246
+#: ../virtaal/plugins/terminology/models/localfile/localfileview.py
 msgid "Error opening file"
 msgstr ""
 
-#: ../virtaal/plugins/terminology/models/localfile/localfileview.py:390
+#: ../virtaal/plugins/terminology/models/localfile/localfileview.py
 #, python-format
 msgid "_Source term — %(langname)s"
 msgstr ""
 
-#: ../virtaal/plugins/terminology/models/localfile/localfileview.py:391
+#: ../virtaal/plugins/terminology/models/localfile/localfileview.py
 #, python-format
 msgid "_Target term — %(langname)s"
 msgstr ""
 
-#: ../virtaal/plugins/terminology/models/localfile/localfileview.py:435
+#: ../virtaal/plugins/terminology/models/localfile/localfileview.py
 msgid "Identical entry already exists."
 msgstr ""
 
 #. l10n: The variable is an existing term formatted for emphasis. The default is bold formatting, but you can remove/change the markup if needed. Leave it unchanged if you are unsure.
-#: ../virtaal/plugins/terminology/models/localfile/localfileview.py:451
+#: ../virtaal/plugins/terminology/models/localfile/localfileview.py
 #, python-format
 msgid "<b>%s</b>"
 msgstr ""
 
-#: ../virtaal/plugins/terminology/models/localfile/localfileview.py:452
+#: ../virtaal/plugins/terminology/models/localfile/localfileview.py
 #, python-format
 msgid "Existing translations: %(translations)s"
 msgstr ""
 
-#: ../virtaal/plugins/terminology/models/pontoon.py:48
+#: ../virtaal/plugins/terminology/models/pontoon.py
 msgid "Mozilla Pontoon"
 msgstr ""
 
-#: ../virtaal/plugins/terminology/models/pontoon.py:49
+#: ../virtaal/plugins/terminology/models/pontoon.py
 msgid "Community localization terminology from Mozilla Pontoon"
 msgstr ""
 
-#: ../virtaal/plugins/terminology/termview.py:154
+#: ../virtaal/plugins/terminology/termview.py
 msgid "Select Terminology Sources"
 msgstr ""
 
-#: ../virtaal/plugins/terminology/termview.py:155
+#: ../virtaal/plugins/terminology/termview.py
 msgid "Select the sources of terminology suggestions"
 msgstr ""
 
-#: ../virtaal/plugins/tm/__init__.py:14
+#: ../virtaal/plugins/tm/__init__.py
 msgid "Translation Memory"
 msgstr ""
 
-#: ../virtaal/plugins/tm/__init__.py:15
+#: ../virtaal/plugins/tm/__init__.py
 msgid "Translation memory suggestions"
 msgstr ""
 
 #. l10n: Try to keep this as short as possible.
-#: ../virtaal/plugins/tm/models/amagama.py:16
-#: ../virtaal/plugins/tm/models/amagama.py:19
+#: ../virtaal/plugins/tm/models/amagama.py
 msgid "Amagama"
 msgstr ""
 
-#: ../virtaal/plugins/tm/models/amagama.py:17
+#: ../virtaal/plugins/tm/models/amagama.py
 msgid "Previous translations for Free and Open Source Software"
 msgstr ""
 
-#: ../virtaal/plugins/tm/models/currentfile.py:19
+#: ../virtaal/plugins/tm/models/currentfile.py
 msgid "Current File"
 msgstr ""
 
-#: ../virtaal/plugins/tm/models/currentfile.py:20
+#: ../virtaal/plugins/tm/models/currentfile.py
 msgid "Translated units from the currently open file"
 msgstr ""
 
 #. l10n: Try to keep this as short as possible.
-#: ../virtaal/plugins/tm/models/currentfile.py:86
-#: ../virtaal/plugins/tm/models/currentfile.py:106
+#: ../virtaal/plugins/tm/models/currentfile.py
 msgid "This file"
 msgstr ""
 
 #. l10n: The name of Google Translate in your language (translated in most languages). See http://translate.google.com/
-#: ../virtaal/plugins/tm/models/google_translate.py:39
+#: ../virtaal/plugins/tm/models/google_translate.py
 msgid "Google Translate"
 msgstr ""
 
-#: ../virtaal/plugins/tm/models/google_translate.py:40
+#: ../virtaal/plugins/tm/models/google_translate.py
 msgid "Unreviewed machine translations from Google's translation service"
 msgstr ""
 
-#: ../virtaal/plugins/tm/models/localtm.py:24
+#: ../virtaal/plugins/tm/models/localtm.py
 msgid "Local Translation Memory"
 msgstr ""
 
-#: ../virtaal/plugins/tm/models/localtm.py:25
+#: ../virtaal/plugins/tm/models/localtm.py
 msgid "Previous translations you have made"
 msgstr ""
 
 #. l10n: Try to keep this as short as possible.
-#: ../virtaal/plugins/tm/models/localtm.py:27
+#: ../virtaal/plugins/tm/models/localtm.py
 msgid "Local TM"
 msgstr ""
 
 #. l10n: Try to keep this as short as possible. Feel free to transliterate in CJK languages for vertical display optimization.
-#: ../virtaal/plugins/tm/models/moses.py:19
-#: ../virtaal/plugins/tm/models/moses.py:69
+#: ../virtaal/plugins/tm/models/moses.py
 msgid "Moses"
 msgstr ""
 
-#: ../virtaal/plugins/tm/models/moses.py:20
+#: ../virtaal/plugins/tm/models/moses.py
 msgid "Unreviewed machine translations from a Moses server"
 msgstr ""
 
-#: ../virtaal/plugins/tm/models/remotetm.py:17
+#: ../virtaal/plugins/tm/models/remotetm.py
 msgid "Remote Server"
 msgstr ""
 
-#: ../virtaal/plugins/tm/models/remotetm.py:18
+#: ../virtaal/plugins/tm/models/remotetm.py
 msgid "A translation memory server"
 msgstr ""
 
 #. l10n: Try to keep this as short as possible.
-#: ../virtaal/plugins/tm/models/remotetm.py:20
+#: ../virtaal/plugins/tm/models/remotetm.py
 msgid "Remote TM"
 msgstr ""
 
 #. l10n: Try to keep this as short as possible. Feel free to transliterate in CJK languages for optimal vertical display.
-#: ../virtaal/plugins/tm/models/apertium.py:31
-#: ../virtaal/plugins/tm/models/apertium.py:108
+#: ../virtaal/plugins/tm/models/apertium.py
 msgid "Apertium"
 msgstr ""
 
-#: ../virtaal/plugins/tm/models/apertium.py:32
+#: ../virtaal/plugins/tm/models/apertium.py
 msgid "Unreviewed machine translations from Apertium"
 msgstr ""
 
-#: ../virtaal/plugins/tm/tmview.py:96
+#: ../virtaal/plugins/tm/tmview.py
 msgid "Translation _Suggestions"
 msgstr ""
 
-#: ../virtaal/plugins/tm/tmview.py:137
+#: ../virtaal/plugins/tm/tmview.py
 #, python-format
 msgid "Ctrl+%(number_key)d"
 msgstr ""
 
 #. l10n: The 'sources' here refer to different translation memory plugins,
 #. such as local tm, open-tran.eu, the current file, etc.
-#: ../virtaal/plugins/tm/tmview.py:161
+#: ../virtaal/plugins/tm/tmview.py
 msgid "Select sources of Translation Memory"
 msgstr ""
 
-#: ../virtaal/plugins/tm/tmview.py:162
+#: ../virtaal/plugins/tm/tmview.py
 msgid "Select the sources that should be queried for translation memory"
 msgstr ""
 
 #. l10n: match quality column label
-#: ../virtaal/plugins/tm/tmwidgets.py:52
+#: ../virtaal/plugins/tm/tmwidgets.py
 msgid "%"
 msgstr ""
 
-#: ../virtaal/plugins/tm/tmwidgets.py:54
+#: ../virtaal/plugins/tm/tmwidgets.py
 msgid "Matches"
 msgstr ""
 
-#: ../virtaal/plugins/tm/tmwidgets.py:56
+#: ../virtaal/plugins/tm/tmwidgets.py
 msgid "TM Source"
 msgstr ""
 
 #. l10n: This message allows you to customize the appearance of the match percentage. Most languages can probably leave it unchanged.
-#: ../virtaal/plugins/tm/tmwidgets.py:136
+#: ../virtaal/plugins/tm/tmwidgets.py
 #, python-format
 msgid "%(match_quality)s%%"
 msgstr ""
 
 #. l10n: This indicates a suggestion from machine translation. It is displayed instead of the match percentage.
-#: ../virtaal/plugins/tm/tmwidgets.py:146
+#: ../virtaal/plugins/tm/tmwidgets.py
 msgid "?"
 msgstr ""
 
-#: ../virtaal/support/tutorial.py:24
+#: ../virtaal/support/tutorial.py
 msgid ""
 "Welcome to the Virtaal tutorial. You can do the first translation by typing "
 "just the translation for \"Welcome\". Then press Enter."
 msgstr ""
 
-#: ../virtaal/support/tutorial.py:29
+#: ../virtaal/support/tutorial.py
 msgid ""
 "Translate this slightly longer message. If a spell checker is available, "
 "spelling mistakes are indicated similarly to word processors. Make sure the "
 "correct language is selected in the bottom right of the window."
 msgstr ""
 
-#: ../virtaal/support/tutorial.py:36
+#: ../virtaal/support/tutorial.py
 msgid ""
 "This tutorial will show you some of the things you might want to pay "
 "attention to while translating software programs. It will help you to avoid "
 "some problems and produce translations of a higher quality."
 msgstr ""
 
-#: ../virtaal/support/tutorial.py:43
+#: ../virtaal/support/tutorial.py
 msgid ""
 "Some of the advice will only be relevant to some languages. For example, if "
 "your language does not use the Latin alphabet, some of the advice might not "
@@ -1442,14 +1428,14 @@ msgid ""
 "established translation rules."
 msgstr ""
 
-#: ../virtaal/support/tutorial.py:50
+#: ../virtaal/support/tutorial.py
 msgid ""
 "The correct use of capital letters are important in many languages. "
 "Translate this message with careful attention to write \"Virtaal\" with a "
 "capital letter."
 msgstr ""
 
-#: ../virtaal/support/tutorial.py:56
+#: ../virtaal/support/tutorial.py
 msgid ""
 "In this message the English uses a capital letter for almost every word. "
 "Almost no other language uses this style. Unless your language definitely "
@@ -1458,7 +1444,7 @@ msgid ""
 "language does not use capital letters, simply translate it normally."
 msgstr ""
 
-#: ../virtaal/support/tutorial.py:65
+#: ../virtaal/support/tutorial.py
 msgid ""
 "If you translated the previous message you should see a window with that "
 "translation and a percentage indicating how similar the source strings "
@@ -1467,74 +1453,74 @@ msgid ""
 "always review suggestions before you use them."
 msgstr ""
 
-#: ../virtaal/support/tutorial.py:74
+#: ../virtaal/support/tutorial.py
 msgid ""
 "This is a simple message that starts with a capital letter in English. If "
 "your language uses capital letters, you almost definitely want to start your "
 "translation with a capital letter as well."
 msgstr ""
 
-#: ../virtaal/support/tutorial.py:81
+#: ../virtaal/support/tutorial.py
 msgid ""
 "This is a simple message that starts with a lower case letter in English. If "
 "your language uses capital letters, you almost definitely want to start your "
 "translation with a lower case letter as well."
 msgstr ""
 
-#: ../virtaal/support/tutorial.py:88
+#: ../virtaal/support/tutorial.py
 msgid ""
 "This message is a question. Make sure that you use the correct question mark "
 "in your translation as well."
 msgstr ""
 
-#: ../virtaal/support/tutorial.py:93
+#: ../virtaal/support/tutorial.py
 msgid ""
 "This message is a label as part of a form. Note how it ends with a colon (:)."
 msgstr ""
 
-#: ../virtaal/support/tutorial.py:98
+#: ../virtaal/support/tutorial.py
 msgid ""
 "If the source will remain mostly or completely unchanged it is convenient to "
 "copy the entire source string with Alt+Down. Here is almost nothing to "
 "translate, so just press Alt+Down and make corrections if necessary."
 msgstr ""
 
-#: ../virtaal/support/tutorial.py:105
+#: ../virtaal/support/tutorial.py
 msgid ""
 "Placeables are special parts of the text, like the © symbol, that can be "
 "automatically highlighted and easily inserted into the translation. Select "
 "the © with Alt+Right and transfer it to the target with Alt+Down."
 msgstr ""
 
-#: ../virtaal/support/tutorial.py:112
+#: ../virtaal/support/tutorial.py
 msgid ""
 "Recognised placeables include special symbols, numbers, variable "
 "placeholders, acronyms and many more. Move to each one with Alt+Right and "
 "transfer it down with Alt+Down."
 msgstr ""
 
-#: ../virtaal/support/tutorial.py:118
+#: ../virtaal/support/tutorial.py
 msgid ""
 "This message ends with ... to indicate that clicking on this text will cause "
 "a dialogue to appear instead of just performing an action. Be sure to end "
 "your message with ... as well."
 msgstr ""
 
-#: ../virtaal/support/tutorial.py:124
+#: ../virtaal/support/tutorial.py
 msgid ""
 "This message ends with a special character that looks like three dots. "
 "Select the special character with Alt+Right and copy it to your translation "
 "with Alt+Down. Don't just type three dot characters."
 msgstr ""
 
-#: ../virtaal/support/tutorial.py:131
+#: ../virtaal/support/tutorial.py
 msgid ""
 "This message has two sentences. Translate them and make sure you start each "
 "with a capital letter if your language uses them, and end each sentence "
 "properly."
 msgstr ""
 
-#: ../virtaal/support/tutorial.py:137
+#: ../virtaal/support/tutorial.py
 msgid ""
 "This message marks the word \"now\" as important with bold tags. These tags "
 "can be transferred from the source with Alt+Right and Alt+Down. Leave the "
@@ -1542,14 +1528,14 @@ msgid ""
 "Read more about XML markup here: http://en.wikipedia.org/wiki/XML"
 msgstr ""
 
-#: ../virtaal/support/tutorial.py:145
+#: ../virtaal/support/tutorial.py
 msgid ""
 "This message is very similar to the previous message. Use the suggestion of "
 "the previous translation with Ctrl+1. Note how the only difference is that "
 "this one ends with a full stop after the last tag."
 msgstr ""
 
-#: ../virtaal/support/tutorial.py:152
+#: ../virtaal/support/tutorial.py
 #, python-format
 msgid ""
 "In this message \"%d\" is a placeholder (variable) that represents a number. "
@@ -1559,7 +1545,7 @@ msgid ""
 "refer to a percentage."
 msgstr ""
 
-#: ../virtaal/support/tutorial.py:160
+#: ../virtaal/support/tutorial.py
 #, python-format
 msgid ""
 "In this message, \"%d\" refers again to the number of files, but note how "
@@ -1571,7 +1557,7 @@ msgid ""
 "translation/plurals.html"
 msgstr ""
 
-#: ../virtaal/support/tutorial.py:171
+#: ../virtaal/support/tutorial.py
 msgid ""
 "In this message the proper way of translating plurals are seen. You need to "
 "enter between 1 and 6 different versions of the translation to ensure the "
@@ -1580,7 +1566,7 @@ msgid ""
 "translation/plurals.html"
 msgstr ""
 
-#: ../virtaal/support/tutorial.py:182
+#: ../virtaal/support/tutorial.py
 #, python-format
 msgid ""
 "In this message, \"%s\" is a placeholder (variable) that represents a file "
@@ -1589,7 +1575,7 @@ msgid ""
 "as example.odt'.  Note that \"%s\" does not refer to a percentage."
 msgstr ""
 
-#: ../virtaal/support/tutorial.py:190
+#: ../virtaal/support/tutorial.py
 #, python-format
 msgid ""
 "In this message the variable is surrounded by double quotes. Make sure your "
@@ -1599,7 +1585,7 @@ msgid ""
 "different quoting characters you can just type them around the variable."
 msgstr ""
 
-#: ../virtaal/support/tutorial.py:199
+#: ../virtaal/support/tutorial.py
 msgid ""
 "In this message, \"%(name)s\" is a placeholder (variable). Note that the 's' "
 "is part of the variable, and the whole variable from '%' to the 's' should "
@@ -1607,27 +1593,27 @@ msgid ""
 "you an idea of what they will contain. In this case, it will contain a name."
 msgstr ""
 
-#: ../virtaal/support/tutorial.py:207
+#: ../virtaal/support/tutorial.py
 msgid ""
 "In this message the user of the software is asked to do something. Make sure "
 "you translate it by being as polite or respectful as is necessary for your "
 "culture."
 msgstr ""
 
-#: ../virtaal/support/tutorial.py:213
+#: ../virtaal/support/tutorial.py
 msgid ""
 "In this message there is reference to \"Linux\" (a product name). Many "
 "languages will not translate it, but your language might use a "
 "transliteration if you don't use the Latin script for your language."
 msgstr ""
 
-#: ../virtaal/support/tutorial.py:220
+#: ../virtaal/support/tutorial.py
 msgid ""
 "This message contains the URL (web address) of the project website. It must "
 "be transferred as a placeable or typed over exactly."
 msgstr ""
 
-#: ../virtaal/support/tutorial.py:225
+#: ../virtaal/support/tutorial.py
 msgid ""
 "This message refers to a website with more information. Sometimes you might "
 "be allowed or encouraged to change the URL (web address) to a website in "
@@ -1636,14 +1622,14 @@ msgid ""
 "article in your language about XML."
 msgstr ""
 
-#: ../virtaal/support/tutorial.py:234
+#: ../virtaal/support/tutorial.py
 msgid ""
 "This translation contains an ambiguous word - it has two possible meanings. "
 "Make sure you can see the context information showing that this is a verb "
 "(an action as in \"click here to view it\")."
 msgstr ""
 
-#: ../virtaal/support/tutorial.py:241
+#: ../virtaal/support/tutorial.py
 msgid ""
 "This translation contains an ambiguous word - it has two possible meanings. "
 "Make sure you can see the context information showing that this is a noun (a "
@@ -1652,7 +1638,7 @@ msgid ""
 "definitely appropriate in this case as well."
 msgstr ""
 
-#: ../virtaal/support/tutorial.py:250
+#: ../virtaal/support/tutorial.py
 msgid ""
 "An accelerator key is a key on your keyboard that you can press to quickly "
 "access a menu or function. It is also called a hot key, access key or "
@@ -1664,28 +1650,28 @@ msgid ""
 "pressing Alt+F."
 msgstr ""
 
-#: ../virtaal/support/tutorial.py:262
+#: ../virtaal/support/tutorial.py
 msgid "In this entry you can see other kind of accelerator."
 msgstr ""
 
-#: ../virtaal/support/tutorial.py:266
+#: ../virtaal/support/tutorial.py
 msgid "And another kind of accelerator."
 msgstr ""
 
-#: ../virtaal/support/tutorial.py:271
+#: ../virtaal/support/tutorial.py
 msgid ""
 "You can maintain a local terminology file to help you translate "
 "consistently. To add a term, select a word (or words), press Ctrl+T and fill "
 "in the details for the new term. Select the text below and add a term for it."
 msgstr ""
 
-#: ../virtaal/support/tutorial.py:279
+#: ../virtaal/support/tutorial.py
 msgid ""
 "In the previous entry you have created one terminology entry for the "
 "\"filter\" verb. Now do the same for \"filter\" noun."
 msgstr ""
 
-#: ../virtaal/support/tutorial.py:284
+#: ../virtaal/support/tutorial.py
 msgid ""
 "If you have created any terminology in the previous entries you may now see "
 "some of the words with a green background (or other color depending on your "
@@ -1698,20 +1684,20 @@ msgid ""
 "translation field."
 msgstr ""
 
-#: ../virtaal/support/tutorial.py:297
+#: ../virtaal/support/tutorial.py
 msgid ""
 "This message has two lines. Make sure that your translation also contains "
 "two lines. You can separate lines with Shift+Enter or copy newline "
 "placeables (displayed as ¶)."
 msgstr ""
 
-#: ../virtaal/support/tutorial.py:304
+#: ../virtaal/support/tutorial.py
 msgid ""
 "This message contains tab characters to separate some headings. Make sure "
 "you separate your translations in the same way."
 msgstr ""
 
-#: ../virtaal/support/tutorial.py:309
+#: ../virtaal/support/tutorial.py
 msgid ""
 "This message contains a large number that is formatted according to the "
 "American convention. Translate this but make sure to format the number "
@@ -1721,7 +1707,7 @@ msgid ""
 "formatting: this number is bigger than one thousand."
 msgstr ""
 
-#: ../virtaal/support/tutorial.py:319
+#: ../virtaal/support/tutorial.py
 msgid ""
 "This message refers to miles. If the programmers encourage it, you might "
 "want to change this to kilometres in your translation, if kilometers are "
@@ -1730,7 +1716,7 @@ msgid ""
 "number is changed, but in this case it is safe to do so."
 msgstr ""
 
-#: ../virtaal/support/tutorial.py:328
+#: ../virtaal/support/tutorial.py
 msgid ""
 "This message contains a link that the user will be able to click on to visit "
 "the help page. Make sure you correctly keep the information between the "
@@ -1738,7 +1724,7 @@ msgid ""
 "tags, even if your language uses a different type of quotation marks."
 msgstr ""
 
-#: ../virtaal/support/tutorial.py:338
+#: ../virtaal/support/tutorial.py
 #, python-format
 msgid ""
 "This message contains a similar link, but the programmers decided to rather "
@@ -1747,14 +1733,14 @@ msgid ""
 "opening and closing tags of the previous translation."
 msgstr ""
 
-#: ../virtaal/support/tutorial.py:346
+#: ../virtaal/support/tutorial.py
 msgid ""
 "This message contains the <b> and </b> tags to emphasize a word, while "
 "everything is within the <p> and </p> tags. Make sure your whole translation "
 "is within the <p> and </p> tags."
 msgstr ""
 
-#: ../virtaal/support/tutorial.py:352
+#: ../virtaal/support/tutorial.py
 msgid ""
 "This message contains a similar link that is contained within <span> and </"
 "span>. Make sure you correctly keep all the tags (<...>), and that the link "
@@ -1765,51 +1751,51 @@ msgid ""
 "</span> tag."
 msgstr ""
 
-#: ../virtaal/views/checksunitview.py:59
+#: ../virtaal/views/checksunitview.py
 msgid "No issues"
 msgstr ""
 
-#: ../virtaal/views/checksunitview.py:66
+#: ../virtaal/views/checksunitview.py
 msgid "Quality Check"
 msgstr ""
 
-#: ../virtaal/views/checksunitview.py:72
+#: ../virtaal/views/checksunitview.py
 msgid "Description"
 msgstr ""
 
-#: ../virtaal/views/checksprojview.py:27
+#: ../virtaal/views/checksprojview.py
 msgid "Project Type"
 msgstr ""
 
 #. l10n: The label indicating the checker style (GNOME/KDE/whatever)
-#: ../virtaal/views/checksprojview.py:53
+#: ../virtaal/views/checksprojview.py
 #, python-format
 msgid "Checks: %(checker_name)s"
 msgstr ""
 
-#: ../virtaal/views/langview.py:59
+#: ../virtaal/views/langview.py
 msgid "_New Language Pair..."
 msgstr ""
 
-#: ../virtaal/views/mainview.py:251
+#: ../virtaal/views/mainview.py
 msgid "Error"
 msgstr ""
 
-#: ../virtaal/views/mainview.py:283
+#: ../virtaal/views/mainview.py
 msgid "Choose a Translation File"
 msgstr ""
 
-#: ../virtaal/views/mainview.py:360
+#: ../virtaal/views/mainview.py
 msgid ""
 "The current file has been modified.\n"
 "Do you want to save your changes?"
 msgstr ""
 
-#: ../virtaal/views/mainview.py:363
+#: ../virtaal/views/mainview.py
 msgid "_Discard"
 msgstr ""
 
-#: ../virtaal/views/mainview.py:462
+#: ../virtaal/views/mainview.py
 msgid "Could not open the dropped file - its file name could not be decoded."
 msgstr ""
 
@@ -1817,29 +1803,29 @@ msgstr ""
 #. %(modified_marker)s is a star that is displayed if the file is modified, and should be at the start of the window title
 #. %(current_file)s is the file name of the current file
 #. most languages will not need to change this
-#: ../virtaal/views/mainview.py:547
+#: ../virtaal/views/mainview.py
 #, python-format
 msgid "%(modified_marker)s%(current_file)s - Virtaal"
 msgstr ""
 
-#: ../virtaal/views/mainview.py:572
+#: ../virtaal/views/mainview.py
 msgid "Please enter the number of noun forms (plurals) to use"
 msgstr ""
 
-#: ../virtaal/views/mainview.py:578
+#: ../virtaal/views/mainview.py
 msgid "Please enter the plural equation to use"
 msgstr ""
 
-#: ../virtaal/views/mainview.py:872
+#: ../virtaal/views/mainview.py
 #, python-format
 msgid "Virtaal %s is available (you have %s)"
 msgstr ""
 
-#: ../virtaal/views/mainview.py:874
+#: ../virtaal/views/mainview.py
 msgid "Download"
 msgstr ""
 
-#: ../virtaal/views/mainview.py:895
+#: ../virtaal/views/mainview.py
 #, python-format
 msgid ""
 "Your settings file could not be read, so Virtaal started with default "
@@ -1848,523 +1834,520 @@ msgstr ""
 
 #. l10n: This refers to the 'mode' that determines how Virtaal moves
 #. between units.
-#: ../virtaal/views/modeview.py:48
+#: ../virtaal/views/modeview.py
 msgid "N_avigation:"
 msgstr ""
 
-#: ../virtaal/views/propertiesview.py:21
+#: ../virtaal/views/propertiesview.py
 msgid "Untranslated:"
 msgstr ""
 
-#: ../virtaal/views/propertiesview.py:22
+#: ../virtaal/views/propertiesview.py
 msgid "Needs work:"
 msgstr ""
 
-#: ../virtaal/views/propertiesview.py:23
+#: ../virtaal/views/propertiesview.py
 msgid "Rejected:"
 msgstr ""
 
-#: ../virtaal/views/propertiesview.py:24
+#: ../virtaal/views/propertiesview.py
 msgid "Needs review:"
 msgstr ""
 
-#: ../virtaal/views/propertiesview.py:25
+#: ../virtaal/views/propertiesview.py
 msgid "Translated:"
 msgstr ""
 
-#: ../virtaal/views/propertiesview.py:26
+#: ../virtaal/views/propertiesview.py
 msgid "Reviewed:"
 msgstr ""
 
-#: ../virtaal/views/propertiesview.py:48
+#: ../virtaal/views/propertiesview.py
 msgid "(0%)"
 msgstr ""
 
-#: ../virtaal/views/propertiesview.py:50
+#: ../virtaal/views/propertiesview.py
 msgid "(100%)"
 msgstr ""
 
 #. l10n: This is the formatting for percentages in the file properties. If unsure, just copy the original.
-#: ../virtaal/views/propertiesview.py:53
+#: ../virtaal/views/propertiesview.py
 #, python-format
 msgid "(%04.1f%%)"
 msgstr ""
 
-#: ../virtaal/views/propertiesview.py:123
+#: ../virtaal/views/propertiesview.py
 msgid "Save the file for up-to-date information"
 msgstr ""
 
 #. l10n: The total number of words. You can not use %Id at this stage. If unsure, just copy the original.
-#: ../virtaal/views/propertiesview.py:180
-#: ../virtaal/views/propertiesview.py:181
+#: ../virtaal/views/propertiesview.py
 #, python-format
 msgid "<b>%d</b>"
 msgstr ""
 
-#: ../virtaal/views/propertiesview.py:192
+#: ../virtaal/views/propertiesview.py
 #, python-format
 msgid "%.1f KB"
 msgstr ""
 
-#: ../virtaal/views/storeview.py:137 ../virtaal/views/storeview.py:146
+#: ../virtaal/views/storeview.py
 msgid "Export failed"
 msgstr ""
 
-#: ../virtaal/views/storeview.py:155
+#: ../virtaal/views/storeview.py
 msgid "Preview failed"
 msgstr ""
 
-#: ../virtaal/views/unitview.py:638
+#: ../virtaal/views/unitview.py
 msgid "Move one step back in the workflow (Ctrl+Shift+Enter)"
 msgstr ""
 
-#: ../virtaal/views/unitview.py:639
+#: ../virtaal/views/unitview.py
 msgid "Click to move to a specific state in the workflow"
 msgstr ""
 
-#: ../virtaal/views/unitview.py:640
+#: ../virtaal/views/unitview.py
 msgid "Move one step forward in the workflow (Ctrl+Enter)"
 msgstr ""
 
-#: ../virtaal/views/widgets/aboutdialog.py:22
+#: ../virtaal/views/widgets/aboutdialog.py
 msgid "Copyright © 2007-2026 Zuza Software Foundation"
 msgstr ""
 
 #. l10n: Please retain the literal name "Virtaal", but feel free to
 #. additionally transliterate the name and to add a translation of "For Language", which is what the name means.
-#: ../virtaal/views/widgets/aboutdialog.py:25
+#: ../virtaal/views/widgets/aboutdialog.py
 msgid "Virtaal is a program for doing translation."
 msgstr ""
 
-#: ../virtaal/views/widgets/aboutdialog.py:26
+#: ../virtaal/views/widgets/aboutdialog.py
 msgid ""
 "The initial focus is on software translation (localization or l10n), but we "
 "definitely intend it to be useful as a general purpose tool for Computer "
 "Aided Translation (CAT)."
 msgstr ""
 
-#: ../virtaal/views/widgets/aboutdialog.py:40
+#: ../virtaal/views/widgets/aboutdialog.py
 msgid "Virtaal website"
 msgstr ""
 
-#: ../virtaal/views/widgets/aboutdialog.py:66
+#: ../virtaal/views/widgets/aboutdialog.py
 msgid "We thank our donors:"
 msgstr ""
 
-#: ../virtaal/views/widgets/aboutdialog.py:67
+#: ../virtaal/views/widgets/aboutdialog.py
 msgid "The International Development Research Centre"
 msgstr ""
 
-#: ../virtaal/views/widgets/aboutdialog.py:69
+#: ../virtaal/views/widgets/aboutdialog.py
 msgid "Mozilla Corporation"
 msgstr ""
 
 #. l10n: Rather than translating, fill in the names of the translators
-#: ../virtaal/views/widgets/aboutdialog.py:74
+#: ../virtaal/views/widgets/aboutdialog.py
 msgid "translator-credits"
 msgstr ""
 
-#: ../virtaal/views/widgets/langadddialog.py:89
+#: ../virtaal/views/widgets/langadddialog.py
 msgid "Language code must be an ASCII string."
 msgstr ""
 
-#: ../virtaal/views/widgets/langadddialog.py:92
+#: ../virtaal/views/widgets/langadddialog.py
 msgid "Language code must be at least 2 characters long."
 msgstr ""
 
-#: ../virtaal/views/widgets/langselectdialog.py:65
-#: ../virtaal/views/widgets/langselectdialog.py:72
+#: ../virtaal/views/widgets/langselectdialog.py
 msgid "Language"
 msgstr ""
 
 #. l10n: This is the column heading for the language code
-#: ../virtaal/views/widgets/langselectdialog.py:80
-#: ../virtaal/views/widgets/langselectdialog.py:87
+#: ../virtaal/views/widgets/langselectdialog.py
 msgid "Code"
 msgstr ""
 
-#: ../virtaal/views/widgets/selectview.py:59
+#: ../virtaal/views/widgets/selectview.py
 msgid "Enabled"
 msgstr ""
 
-#: ../virtaal/views/widgets/selectview.py:120
+#: ../virtaal/views/widgets/selectview.py
 msgid "Configure..."
 msgstr ""
 
-#: ../virtaal/views/widgets/shortcutswindow.py:15
+#: ../virtaal/views/widgets/shortcutswindow.py
 msgid "Global"
 msgstr ""
 
-#: ../virtaal/views/widgets/shortcutswindow.py:16
+#: ../virtaal/views/widgets/shortcutswindow.py
 msgid "Open a file"
 msgstr ""
 
-#: ../virtaal/views/widgets/shortcutswindow.py:17
+#: ../virtaal/views/widgets/shortcutswindow.py
 msgid "Save the current file"
 msgstr ""
 
-#: ../virtaal/views/widgets/shortcutswindow.py:18
+#: ../virtaal/views/widgets/shortcutswindow.py
 msgid "Close the current file"
 msgstr ""
 
-#: ../virtaal/views/widgets/shortcutswindow.py:19
+#: ../virtaal/views/widgets/shortcutswindow.py
 msgid "Quit Virtaal"
 msgstr ""
 
-#: ../virtaal/views/widgets/shortcutswindow.py:20
+#: ../virtaal/views/widgets/shortcutswindow.py
 msgid "Show preferences dialog"
 msgstr ""
 
-#: ../virtaal/views/widgets/shortcutswindow.py:21
+#: ../virtaal/views/widgets/shortcutswindow.py
 msgid "Show file properties and statistics"
 msgstr ""
 
-#: ../virtaal/views/widgets/shortcutswindow.py:22
+#: ../virtaal/views/widgets/shortcutswindow.py
 msgid "Toggle fullscreen mode"
 msgstr ""
 
-#: ../virtaal/views/widgets/shortcutswindow.py:23
+#: ../virtaal/views/widgets/shortcutswindow.py
 msgid "Show this Keyboard Shortcuts window"
 msgstr ""
 
-#: ../virtaal/views/widgets/shortcutswindow.py:25
+#: ../virtaal/views/widgets/shortcutswindow.py
 msgid "Navigation"
 msgstr ""
 
-#: ../virtaal/views/widgets/shortcutswindow.py:26
+#: ../virtaal/views/widgets/shortcutswindow.py
 msgid "Move to next translation"
 msgstr ""
 
-#: ../virtaal/views/widgets/shortcutswindow.py:27
+#: ../virtaal/views/widgets/shortcutswindow.py
 msgid "Move to previous unit"
 msgstr ""
 
-#: ../virtaal/views/widgets/shortcutswindow.py:28
+#: ../virtaal/views/widgets/shortcutswindow.py
 msgid "Move to next unit"
 msgstr ""
 
-#: ../virtaal/views/widgets/shortcutswindow.py:29
+#: ../virtaal/views/widgets/shortcutswindow.py
 msgid "Move 10 units up"
 msgstr ""
 
-#: ../virtaal/views/widgets/shortcutswindow.py:30
+#: ../virtaal/views/widgets/shortcutswindow.py
 msgid "Move 10 units down"
 msgstr ""
 
-#: ../virtaal/views/widgets/shortcutswindow.py:32
+#: ../virtaal/views/widgets/shortcutswindow.py
 msgid "Move to next search match"
 msgstr ""
 
-#: ../virtaal/views/widgets/shortcutswindow.py:33
+#: ../virtaal/views/widgets/shortcutswindow.py
 msgid "Move to previous search match"
 msgstr ""
 
-#: ../virtaal/views/widgets/shortcutswindow.py:35
+#: ../virtaal/views/widgets/shortcutswindow.py
 msgid "Units"
 msgstr ""
 
-#: ../virtaal/views/widgets/shortcutswindow.py:36
+#: ../virtaal/views/widgets/shortcutswindow.py
 msgid "Select previous placeable"
 msgstr ""
 
-#: ../virtaal/views/widgets/shortcutswindow.py:37
+#: ../virtaal/views/widgets/shortcutswindow.py
 msgid "Select next placeable"
 msgstr ""
 
-#: ../virtaal/views/widgets/shortcutswindow.py:38
+#: ../virtaal/views/widgets/shortcutswindow.py
 msgid "Copy the source or selected placeable to the target"
 msgstr ""
 
-#: ../virtaal/views/widgets/shortcutswindow.py:39
+#: ../virtaal/views/widgets/shortcutswindow.py
 msgid "Enter a new line"
 msgstr ""
 
-#: ../virtaal/views/widgets/shortcutswindow.py:40
+#: ../virtaal/views/widgets/shortcutswindow.py
 msgid "Mark unit \"Needs work\" as \"Translated\" and go to the next unit"
 msgstr ""
 
-#: ../virtaal/views/widgets/shortcutswindow.py:41
+#: ../virtaal/views/widgets/shortcutswindow.py
 msgid "Mark unit as \"Needs work\" and go to the next unit"
 msgstr ""
 
-#: ../virtaal/views/widgets/shortcutswindow.py:42
+#: ../virtaal/views/widgets/shortcutswindow.py
 msgid "Undo the last change"
 msgstr ""
 
-#: ../virtaal/views/widgets/shortcutswindow.py:45
+#: ../virtaal/views/widgets/shortcutswindow.py
 msgid "Use the first translation suggestion"
 msgstr ""
 
-#: ../virtaal/views/widgets/shortcutswindow.py:46
+#: ../virtaal/views/widgets/shortcutswindow.py
 msgid "Show/Hide checks"
 msgstr ""
 
-#: ../virtaal/views/widgets/shortcutswindow.py:47
+#: ../virtaal/views/widgets/shortcutswindow.py
 msgid "Show/Hide translation suggestions"
 msgstr ""
 
-#: ../virtaal/views/widgets/shortcutswindow.py:48
+#: ../virtaal/views/widgets/shortcutswindow.py
 msgid "Hide translation suggestions, if shown"
 msgstr ""
 
-#: ../virtaal/views/widgets/shortcutswindow.py:49
+#: ../virtaal/views/widgets/shortcutswindow.py
 msgid "Add a term to the local terminology file"
 msgstr ""
 
-#: ../virtaal/views/widgets/shortcutswindow.py:51
+#: ../virtaal/views/widgets/shortcutswindow.py
 msgid "Moving focus"
 msgstr ""
 
-#: ../virtaal/views/widgets/shortcutswindow.py:52
+#: ../virtaal/views/widgets/shortcutswindow.py
 msgid "Move to the next target field"
 msgstr ""
 
-#: ../virtaal/views/widgets/shortcutswindow.py:53
+#: ../virtaal/views/widgets/shortcutswindow.py
 msgid "Move to the previous target field"
 msgstr ""
 
-#: ../virtaal/views/widgets/shortcutswindow.py:54
+#: ../virtaal/views/widgets/shortcutswindow.py
 msgid "Jump to the language-pair selector"
 msgstr ""
 
-#: ../virtaal/views/widgets/shortcutswindow.py:55
+#: ../virtaal/views/widgets/shortcutswindow.py
 msgid "Jump to the \"Navigation:\" mode selector"
 msgstr ""
 
-#: ../virtaal/views/widgets/shortcutswindow.py:56
+#: ../virtaal/views/widgets/shortcutswindow.py
 msgid "Close the search bar and return to normal editing"
 msgstr ""
 
-#: ../virtaal/views/widgets/welcomescreen.py:83
+#: ../virtaal/views/widgets/welcomescreen.py
 msgid "Translation memory"
 msgstr ""
 
-#: ../virtaal/views/widgets/welcomescreen.py:85
+#: ../virtaal/views/widgets/welcomescreen.py
 msgid "Quality checks"
 msgstr ""
 
-#: ../virtaal/views/widgets/welcomescreen.py:86
+#: ../virtaal/views/widgets/welcomescreen.py
 msgid "Machine translation"
 msgstr ""
 
-#: ../virtaal/views/widgets/welcomescreen.py:87
+#: ../virtaal/views/widgets/welcomescreen.py
 msgid "Highlighting and insertion of placeables"
 msgstr ""
 
-#: ../virtaal/views/widgets/welcomescreen.py:88
+#: ../virtaal/views/widgets/welcomescreen.py
 msgid "Many plugins and options for customization"
 msgstr ""
 
-#: ../virtaal/models/storemodel.py:126
+#: ../virtaal/models/storemodel.py
 msgid "The file does not exist."
 msgstr ""
 
-#: ../virtaal/models/storemodel.py:128
+#: ../virtaal/models/storemodel.py
 msgid "Not a valid file."
 msgstr ""
 
-#: ../share/mime/packages/virtaal-mimetype.xml.in.h:1
+#: ../share/mime/packages/virtaal-mimetype.xml.in.h
 msgid "TMX Translation Memory"
 msgstr ""
 
-#: ../share/mime/packages/virtaal-mimetype.xml.in.h:2
+#: ../share/mime/packages/virtaal-mimetype.xml.in.h
 msgid "TMX"
 msgstr ""
 
-#: ../share/mime/packages/virtaal-mimetype.xml.in.h:3
+#: ../share/mime/packages/virtaal-mimetype.xml.in.h
 msgid "Translation Memory eXchange"
 msgstr ""
 
-#: ../share/mime/packages/virtaal-mimetype.xml.in.h:4
+#: ../share/mime/packages/virtaal-mimetype.xml.in.h
 msgid "TBX Glossary"
 msgstr ""
 
-#: ../share/mime/packages/virtaal-mimetype.xml.in.h:5
+#: ../share/mime/packages/virtaal-mimetype.xml.in.h
 msgid "TBX"
 msgstr ""
 
-#: ../share/mime/packages/virtaal-mimetype.xml.in.h:6
+#: ../share/mime/packages/virtaal-mimetype.xml.in.h
 msgid "TermBase eXchange"
 msgstr ""
 
-#: ../share/mime/packages/virtaal-mimetype.xml.in.h:7
+#: ../share/mime/packages/virtaal-mimetype.xml.in.h
 msgid "Wordfast Translation Memory"
 msgstr ""
 
-#: ../share/mime/packages/virtaal-mimetype.xml.in.h:8
+#: ../share/mime/packages/virtaal-mimetype.xml.in.h
 msgid "Qt Linguist Translation File"
 msgstr ""
 
-#: ../share/mime/packages/virtaal-mimetype.xml.in.h:9
+#: ../share/mime/packages/virtaal-mimetype.xml.in.h
 msgid "Qt Message File"
 msgstr ""
 
-#: ../share/mime/packages/virtaal-mimetype.xml.in.h:10
+#: ../share/mime/packages/virtaal-mimetype.xml.in.h
 msgid "Qt Phrase Book"
 msgstr ""
 
-#: ../share/mime/packages/virtaal-mimetype.xml.in.h:11
+#: ../share/mime/packages/virtaal-mimetype.xml.in.h
 msgid "INI File"
 msgstr ""
 
-#: ../share/mime/packages/virtaal-mimetype.xml.in.h:12
+#: ../share/mime/packages/virtaal-mimetype.xml.in.h
 msgid "INI"
 msgstr ""
 
-#: ../share/mime/packages/virtaal-mimetype.xml.in.h:13
+#: ../share/mime/packages/virtaal-mimetype.xml.in.h
 msgid "Initialization"
 msgstr ""
 
-#: ../share/mime/packages/virtaal-mimetype.xml.in.h:14
+#: ../share/mime/packages/virtaal-mimetype.xml.in.h
 msgid "Java Properties File"
 msgstr ""
 
-#: ../share/mime/packages/virtaal-mimetype.xml.in.h:15
+#: ../share/mime/packages/virtaal-mimetype.xml.in.h
 msgid "OpenOffice.org Translation File"
 msgstr ""
 
-#: ../share/mime/packages/virtaal-mimetype.xml.in.h:16
+#: ../share/mime/packages/virtaal-mimetype.xml.in.h
 msgid "XLIFF Translation File"
 msgstr ""
 
-#: ../share/mime/packages/virtaal-mimetype.xml.in.h:17
+#: ../share/mime/packages/virtaal-mimetype.xml.in.h
 msgid "XLIFF"
 msgstr ""
 
-#: ../share/mime/packages/virtaal-mimetype.xml.in.h:18
+#: ../share/mime/packages/virtaal-mimetype.xml.in.h
 msgid "XML Localization Interchange File Format"
 msgstr ""
 
-#: ../share/mime/packages/virtaal-mimetype.xml.in.h:19
+#: ../share/mime/packages/virtaal-mimetype.xml.in.h
 msgid "C++ RC File"
 msgstr ""
 
-#: ../share/mime/packages/virtaal-mimetype.xml.in.h:20
+#: ../share/mime/packages/virtaal-mimetype.xml.in.h
 msgid "RC"
 msgstr ""
 
-#: ../share/mime/packages/virtaal-mimetype.xml.in.h:21
+#: ../share/mime/packages/virtaal-mimetype.xml.in.h
 msgid "Resource Compiler"
 msgstr ""
 
-#: ../share/mime/packages/virtaal-mimetype.xml.in.h:22
+#: ../share/mime/packages/virtaal-mimetype.xml.in.h
 msgid "Tcl Translation File"
 msgstr ""
 
-#: ../share/mime/packages/virtaal-mimetype.xml.in.h:23
+#: ../share/mime/packages/virtaal-mimetype.xml.in.h
 msgid "JavaScript error message file"
 msgstr ""
 
-#: ../share/mime/packages/virtaal-mimetype.xml.in.h:24
+#: ../share/mime/packages/virtaal-mimetype.xml.in.h
 msgid "Gettext Translation Template"
 msgstr ""
 
-#: ../share/mime/packages/virtaal-mimetype.xml.in.h:25
+#: ../share/mime/packages/virtaal-mimetype.xml.in.h
 msgid "Trados Tag Editor"
 msgstr ""
 
-#: ../share/mime/packages/virtaal-mimetype.xml.in.h:26
+#: ../share/mime/packages/virtaal-mimetype.xml.in.h
 msgid "OS X Strings File"
 msgstr ""
 
-#: ../share/mime/packages/virtaal-mimetype.xml.in.h:27
+#: ../share/mime/packages/virtaal-mimetype.xml.in.h
 msgid "UTX Dictionary"
 msgstr ""
 
-#: ../share/mime/packages/virtaal-mimetype.xml.in.h:28
+#: ../share/mime/packages/virtaal-mimetype.xml.in.h
 msgid "UTX"
 msgstr ""
 
-#: ../share/mime/packages/virtaal-mimetype.xml.in.h:29
+#: ../share/mime/packages/virtaal-mimetype.xml.in.h
 msgid "Universal Terminology eXchange"
 msgstr ""
 
-#: ../devsupport/tmp_strings.py:10
+#: ../devsupport/tmp_strings.py
 msgid "Gettext PO file"
 msgstr ""
 
-#: ../devsupport/tmp_strings.py:11
+#: ../devsupport/tmp_strings.py
 msgid "Gettext MO file"
 msgstr ""
 
-#: ../devsupport/tmp_strings.py:12
+#: ../devsupport/tmp_strings.py
 msgid "Qt .qm file"
 msgstr ""
 
-#: ../devsupport/tmp_strings.py:13
+#: ../devsupport/tmp_strings.py
 msgid "OmegaT Glossary"
 msgstr ""
 
-#: ../devsupport/tmp_strings.py:16
+#: ../devsupport/tmp_strings.py
 msgid "usage: "
 msgstr ""
 
-#: ../devsupport/tmp_strings.py:17
+#: ../devsupport/tmp_strings.py
 msgid "positional arguments"
 msgstr ""
 
-#: ../devsupport/tmp_strings.py:18
+#: ../devsupport/tmp_strings.py
 msgid "options"
 msgstr ""
 
-#: ../devsupport/tmp_strings.py:19
+#: ../devsupport/tmp_strings.py
 msgid "show this help message and exit"
 msgstr ""
 
-#: ../devsupport/tmp_strings.py:20
+#: ../devsupport/tmp_strings.py
 msgid "show program's version number and exit"
 msgstr ""
 
-#: ../bin/virtaal:102
+#: ../bin/virtaal
 msgid "LOG"
 msgstr ""
 
-#: ../bin/virtaal:103
+#: ../bin/virtaal
 msgid "turn on logging, storing the result to the supplied filename."
 msgstr ""
 
-#: ../bin/virtaal:104
+#: ../bin/virtaal
 msgid "CONFIG"
 msgstr ""
 
-#: ../bin/virtaal:105
+#: ../bin/virtaal
 msgid "use the configuration file given by the supplied filename."
 msgstr ""
 
-#: ../bin/virtaal:107
+#: ../bin/virtaal
 msgid "enable debugging features"
 msgstr ""
 
-#: ../bin/virtaal:110
+#: ../bin/virtaal
 msgid ""
 "use a synthetic pseudo-translation for every UI string (see devsupport/"
 "pseudo-translation/generate_pseudo_translation.py)"
 msgstr ""
 
-#: ../bin/virtaal:113
+#: ../bin/virtaal
 msgid "like --pseudo-translation, but also simulates a right-to-left UI layout"
 msgstr ""
 
-#: ../bin/virtaal:116
+#: ../bin/virtaal
 msgid "PROFILE"
 msgstr ""
 
-#: ../bin/virtaal:118
+#: ../bin/virtaal
 msgid "perform profiling, storing the result to the supplied filename."
 msgstr ""
 
-#: ../bin/virtaal:144
+#: ../bin/virtaal
 msgid "Could not open log file '%(filename)s'"
 msgstr ""
 
-#: ../bin/virtaal:154
+#: ../bin/virtaal
 msgid "Could not read configuration file '%(filename)s'"
 msgstr ""
 
-#: ../bin/virtaal:192
+#: ../bin/virtaal
 msgid "Profiling support is not available"
 msgstr ""
 
-#: ../bin/virtaal:204
+#: ../bin/virtaal
 msgid "Could not open profile file '%(filename)s'"
 msgstr ""


### PR DESCRIPTION
`po/intltool-update` now passes `xgettext --add-location=file` - `#:` comments keep the filename (still traceable to source) but drop the line number, which was the part that shifted on every unrelated edit and forced a full-file diff/merge-conflict risk on every regeneration (hit this directly on #3488).

One-time large diff in this PR from every existing location comment losing its line number; verified empirically that a line-shifting edit elsewhere in a file no longer touches the pot at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017KayAA91cuhe4xCpDYBg9K