### PR TITLE
Set the Windows uninstall list's icon to Virtaal's own

### DIFF
--- a/devsupport/packaging/windows/virtaal.iss
+++ b/devsupport/packaging/windows/virtaal.iss
@@ -42,6 +42,7 @@ PrivilegesRequiredOverridesAllowed=dialog
 OutputDir=..\..\..\dist\installer
 OutputBaseFilename=virtaal-{#MyAppVersion}-setup
 SetupIconFile={#IconsDir}\virtaal.ico
+UninstallDisplayIcon={app}\{#MyAppExeName}
 Compression=lzma2
 SolidCompression=yes
 WizardStyle=modern


### PR DESCRIPTION
Fixes #3286.

`UninstallDisplayIcon` was never set in `virtaal.iss`, so Windows' uninstall list (Control Panel/Settings > Apps) showed a generic icon instead of Virtaal's own. `virtaal.exe` already embeds the icon via PyInstaller's own `icon=` setting, so this just points `UninstallDisplayIcon` at the installed exe.

On the installed-size half of #3286: checked Inno Setup's own compiler source (`Setup.Install.pas`) - when `UninstallDisplaySize` isn't set, it computes one itself from installed file sizes and writes it to the same `EstimatedSize` registry value Windows' uninstall list reads for the size column, unconditionally. So that half was very likely already fixed by the switch to a modern Inno Setup, independent of this PR - not something this change needed to touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017KayAA91cuhe4xCpDYBg9K