### PR TITLE
Fix File > Update crashing on every translate-toolkit version we support

### DIFF
--- a/virtaal/models/storemodel.py
+++ b/virtaal/models/storemodel.py
@@ -187,7 +187,9 @@ class StoreModel(BaseModel):
 
     def update_file(self, filename):
         # Adapted from Document.__init__()
-        from translate.storage import factory, statsdb
+        from translate.storage import factory
+
+        from virtaal.support import statsdb
         newstore = factory.getobject(filename)
         oldfilename = self._trans_store.filename
         oldfileobj = self._trans_store.fileobj
@@ -204,9 +206,9 @@ class StoreModel(BaseModel):
         import os
         import tempfile
         tempfd, tempfilename = tempfile.mkstemp()
-        os.write(tempfd, str(self._trans_store))
+        os.close(tempfd)  # savefile() reopens the path itself
+        self._trans_store.savefile(tempfilename)
         self.update_stats(filename=tempfilename)
-        os.close(tempfd)
         os.remove(tempfilename)
 
         self.controller.compare_stats(oldstats, self.stats)

--- a/virtaal/models/test_storemodel.py
+++ b/virtaal/models/test_storemodel.py
@@ -1,0 +1,51 @@
+#
+# Copyright (C) Virtaal contributors.
+#
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
+
+from virtaal.models.storemodel import StoreModel
+
+
+class _FakeController:
+    def compare_stats(self, old, new):
+        pass
+
+
+_OLD_PO = b'''msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\\n"
+
+msgid "Hello"
+msgstr "Hallo"
+'''
+
+_NEW_PO = b'''msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\\n"
+
+msgid "Hello"
+msgstr ""
+
+msgid "World"
+msgstr ""
+'''
+
+
+def test_update_file_merges_a_newer_template(tmp_path):
+    # Real crash (#3323): update_file() imported statsdb from
+    # translate.storage instead of virtaal.support, raising ImportError
+    # on any translate-toolkit version without that submodule - then,
+    # once that's fixed, os.write() with str(store) instead of a real
+    # serialize() raised TypeError, since str.write() needs bytes.
+    old_path = tmp_path / "old.po"
+    new_path = tmp_path / "new.po"
+    old_path.write_bytes(_OLD_PO)
+    new_path.write_bytes(_NEW_PO)
+
+    model = StoreModel(str(old_path), _FakeController())
+    model.update_file(str(new_path))
+
+    units = {u.source: u.target for u in model.get_units()}
+    assert units == {"Hello": "Hallo", "World": ""}


### PR DESCRIPTION
Found while scanning #3323's comments for real bugs.

`update_file()` (the "File > Update" from-template feature) imported `statsdb` from `translate.storage` instead of `virtaal.support` - `translate.storage.statsdb` doesn't exist in our current translate-toolkit either, so this crashed with `ImportError` on every call, not just the reporter's older version. Fixing that surfaced a second bug in the same method: `os.write(tempfd, str(self._trans_store))` - `os.write()` needs bytes, `str()` on the store doesn't produce them. Replaced the manual tempfile write with the store's own `savefile()`.

Verified end-to-end: merging an updated template into an existing translation now completes and produces correct before/after stats, instead of crashing immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017KayAA91cuhe4xCpDYBg9K