### PR TITLE
Add Navigation menu entries for the workflow-state shortcuts

### DIFF
--- a/devsupport/testing/fuzz/fuzz_ui.py
+++ b/devsupport/testing/fuzz/fuzz_ui.py
@@ -104,6 +104,7 @@ class Fuzzer:
             (10, 'save_temp', self._act_save_temp),
             (10, 'close_reopen', self._act_close_reopen),
             (10, 'resize_window', self._act_resize_window),
+            (10, 'advance_state', self._act_advance_state),
         ]
 
     def _build_controllers(self):
@@ -178,6 +179,15 @@ class Fuzzer:
     def _act_resize_window(self):
         window = self.main_controller.view.main_window
         window.resize(self.rng.randint(300, 1200), self.rng.randint(200, 900))
+
+    def _act_advance_state(self):
+        # Ctrl+Enter/Ctrl+Shift+Enter, and the Navigation menu's
+        # equivalent items - all three call this same method.
+        unit = self.store_controller.cursor and self.store_controller.cursor.deref()
+        if unit is None:
+            return
+        self._load_current_unit()
+        self.unit_controller.view.advance_workflow_state(self.rng.choice([1, -1]))
 
     # RUN LOOP #
 

--- a/po/virtaal.pot
+++ b/po/virtaal.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Virtaal 1.0.0-beta1\n"
 "Report-Msgid-Bugs-To: translate-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2026-09-12 09:23+0100\n"
+"POT-Creation-Date: 2026-09-12 09:45+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -209,6 +209,14 @@ msgstr ""
 
 #: ../share/virtaal/virtaal.ui.h
 msgid "_Page Down"
+msgstr ""
+
+#: ../share/virtaal/virtaal.ui.h ../virtaal/views/unitview.py
+msgid "Move one step forward in the workflow (Ctrl+Enter)"
+msgstr ""
+
+#: ../share/virtaal/virtaal.ui.h ../virtaal/views/unitview.py
+msgid "Move one step back in the workflow (Ctrl+Shift+Enter)"
 msgstr ""
 
 #: ../share/virtaal/virtaal.ui.h
@@ -1900,15 +1908,7 @@ msgid "Preview failed"
 msgstr ""
 
 #: ../virtaal/views/unitview.py
-msgid "Move one step back in the workflow (Ctrl+Shift+Enter)"
-msgstr ""
-
-#: ../virtaal/views/unitview.py
 msgid "Click to move to a specific state in the workflow"
-msgstr ""
-
-#: ../virtaal/views/unitview.py
-msgid "Move one step forward in the workflow (Ctrl+Enter)"
 msgstr ""
 
 #: ../virtaal/views/widgets/aboutdialog.py

--- a/po/virtaal.pot
+++ b/po/virtaal.pot
@@ -211,12 +211,16 @@ msgstr ""
 msgid "_Page Down"
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h ../virtaal/views/unitview.py
-msgid "Move one step forward in the workflow (Ctrl+Enter)"
+#: ../share/virtaal/virtaal.ui.h
+msgid "Next Unit"
 msgstr ""
 
-#: ../share/virtaal/virtaal.ui.h ../virtaal/views/unitview.py
-msgid "Move one step back in the workflow (Ctrl+Shift+Enter)"
+#: ../share/virtaal/virtaal.ui.h ../virtaal/views/widgets/shortcutswindow.py
+msgid "Next Unit and Advance State"
+msgstr ""
+
+#: ../share/virtaal/virtaal.ui.h ../virtaal/views/widgets/shortcutswindow.py
+msgid "Next Unit and Reverse State"
 msgstr ""
 
 #: ../share/virtaal/virtaal.ui.h
@@ -1908,7 +1912,15 @@ msgid "Preview failed"
 msgstr ""
 
 #: ../virtaal/views/unitview.py
+msgid "Move one step back in the workflow (Ctrl+Shift+Enter)"
+msgstr ""
+
+#: ../virtaal/views/unitview.py
 msgid "Click to move to a specific state in the workflow"
+msgstr ""
+
+#: ../virtaal/views/unitview.py
+msgid "Move one step forward in the workflow (Ctrl+Enter)"
 msgstr ""
 
 #: ../virtaal/views/widgets/aboutdialog.py
@@ -2060,14 +2072,6 @@ msgstr ""
 
 #: ../virtaal/views/widgets/shortcutswindow.py
 msgid "Enter a new line"
-msgstr ""
-
-#: ../virtaal/views/widgets/shortcutswindow.py
-msgid "Mark unit \"Needs work\" as \"Translated\" and go to the next unit"
-msgstr ""
-
-#: ../virtaal/views/widgets/shortcutswindow.py
-msgid "Mark unit as \"Needs work\" and go to the next unit"
 msgstr ""
 
 #: ../virtaal/views/widgets/shortcutswindow.py

--- a/share/virtaal/virtaal.ui
+++ b/share/virtaal/virtaal.ui
@@ -894,12 +894,22 @@ If you are translating from English to French then French would be your translat
                       </object>
                     </child>
                     <child>
+                      <object class="GtkMenuItem" id="mnu_next_unit">
+                        <property name="visible">True</property>
+                        <property name="sensitive">False</property>
+                        <property name="can_focus">False</property>
+                        <property name="use_action_appearance">False</property>
+                        <property name="label" translatable="yes">Next Unit</property>
+                      </object>
+                    </child>
+                    <child>
                       <object class="GtkMenuItem" id="mnu_state_advance">
                         <property name="visible">True</property>
                         <property name="sensitive">False</property>
                         <property name="can_focus">False</property>
                         <property name="use_action_appearance">False</property>
-                        <property name="label" translatable="yes">Move one step forward in the workflow (Ctrl+Enter)</property>
+                        <property name="accel_path">&lt;Virtaal&gt;/Navigation/StateAdvance</property>
+                        <property name="label" translatable="yes">Next Unit and Advance State</property>
                       </object>
                     </child>
                     <child>
@@ -908,7 +918,8 @@ If you are translating from English to French then French would be your translat
                         <property name="sensitive">False</property>
                         <property name="can_focus">False</property>
                         <property name="use_action_appearance">False</property>
-                        <property name="label" translatable="yes">Move one step back in the workflow (Ctrl+Shift+Enter)</property>
+                        <property name="accel_path">&lt;Virtaal&gt;/Navigation/StateReverse</property>
+                        <property name="label" translatable="yes">Next Unit and Reverse State</property>
                       </object>
                     </child>
                   </object>

--- a/share/virtaal/virtaal.ui
+++ b/share/virtaal/virtaal.ui
@@ -887,6 +887,30 @@ If you are translating from English to French then French would be your translat
                         <property name="use_underline">True</property>
                       </object>
                     </child>
+                    <child>
+                      <object class="GtkSeparatorMenuItem" id="separator_mnu_nav_state">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkMenuItem" id="mnu_state_advance">
+                        <property name="visible">True</property>
+                        <property name="sensitive">False</property>
+                        <property name="can_focus">False</property>
+                        <property name="use_action_appearance">False</property>
+                        <property name="label" translatable="yes">Move one step forward in the workflow (Ctrl+Enter)</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkMenuItem" id="mnu_state_reverse">
+                        <property name="visible">True</property>
+                        <property name="sensitive">False</property>
+                        <property name="can_focus">False</property>
+                        <property name="use_action_appearance">False</property>
+                        <property name="label" translatable="yes">Move one step back in the workflow (Ctrl+Shift+Enter)</property>
+                      </object>
+                    </child>
                   </object>
                 </child>
               </object>

--- a/virtaal/test/test_unitcontroller.py
+++ b/virtaal/test/test_unitcontroller.py
@@ -133,6 +133,15 @@ class TestUnitController(TestScaffolding):
         fixed - it isn't, and it isn't a bug in this function either."""
         self._assert_initial_cursor_position("%B", "%|B")
 
+    def test_advance_workflow_state_on_a_freshly_loaded_unit(self):
+        """load_unit() left the state-nav widget's own selection
+        unset - move_state() (Ctrl+Enter, Ctrl+Shift+Enter, and the
+        Navigation menu's equivalent items) crashed with TypeError on
+        the very first attempt on any freshly loaded unit."""
+        test_unit = self.trans_store.getunits()[1]
+        view = self.unit_controller.load_unit(test_unit)
+        view.advance_workflow_state(1)  # must not raise
+
     def test_stale_alt_down_does_not_corrupt_a_later_unit(self):
         """Alt+Down ('transfer from source') defers its copy via
         GLib.idle_add(). If the loaded unit changes before that runs,

--- a/virtaal/test/test_unitcontroller.py
+++ b/virtaal/test/test_unitcontroller.py
@@ -142,6 +142,24 @@ class TestUnitController(TestScaffolding):
         view = self.unit_controller.load_unit(test_unit)
         view.advance_workflow_state(1)  # must not raise
 
+    def test_advance_workflow_state_alone_does_not_persist(self):
+        """advance_workflow_state() only moves the state-nav widget's
+        own selection - the real underlying unit state is only written
+        once editing finishes (UnitController._unit_done(), fired when
+        loading the next unit after finish_editing_and_advance()/
+        editing_done() - not exercised by this lightweight harness, but
+        verified live end to end). The Navigation menu's combined
+        actions must call both, not just the state change."""
+        test_unit = self.trans_store.getunits()[1]
+        test_unit.target = 'A translation'
+        view = self.unit_controller.load_unit(test_unit)
+        view.modified()  # marks the unit modified, as a real edit would
+
+        before = test_unit.get_state_id()
+        view.advance_workflow_state(1)
+        assert test_unit.get_state_id() == before, \
+            "advance_workflow_state() alone shouldn't persist to the real unit yet"
+
     def test_stale_alt_down_does_not_corrupt_a_later_unit(self):
         """Alt+Down ('transfer from source') defers its copy via
         GLib.idle_add(). If the loaded unit changes before that runs,

--- a/virtaal/views/mainview.py
+++ b/virtaal/views/mainview.py
@@ -186,6 +186,7 @@ class MainView(BaseView):
         self.gui.get_object('mnu_revert').connect('activate', self._on_file_revert)
         self.gui.get_object('mnu_quit').connect('activate', self._on_quit)
         # Navigation menu signals
+        self.gui.get_object('mnu_next_unit').connect('activate', self._on_next_unit)
         self.gui.get_object('mnu_state_advance').connect('activate', self._on_state_advance)
         self.gui.get_object('mnu_state_reverse').connect('activate', self._on_state_reverse)
         # View menu signals
@@ -968,11 +969,18 @@ class MainView(BaseView):
         self.controller.quit()
         return True
 
+    def _on_next_unit(self, _widget=None):
+        self.controller.unit_controller.view.finish_editing_and_advance()
+
     def _on_state_advance(self, _widget=None):
-        self.controller.unit_controller.view.advance_workflow_state(1)
+        view = self.controller.unit_controller.view
+        view.advance_workflow_state(1)
+        view.finish_editing_and_advance()
 
     def _on_state_reverse(self, _widget=None):
-        self.controller.unit_controller.view.advance_workflow_state(-1)
+        view = self.controller.unit_controller.view
+        view.advance_workflow_state(-1)
+        view.finish_editing_and_advance()
 
     def _on_recent_file_activated(self, chooser):
         item = chooser.get_current_item()
@@ -989,7 +997,7 @@ class MainView(BaseView):
 
     def _on_store_closed(self, store_controller):
         for widget_name in ('mnu_saveas', 'mnu_close', 'mnu_update', 'mnu_properties', 'mnu_binary_export',
-                             'mnu_state_advance', 'mnu_state_reverse'):
+                             'mnu_next_unit', 'mnu_state_advance', 'mnu_state_reverse'):
             self.gui.get_object(widget_name).set_sensitive(False)
         self.status_bar.set_sensitive(False)
         self.main_window.set_title(_('Virtaal'))
@@ -999,6 +1007,7 @@ class MainView(BaseView):
         self.gui.get_object('mnu_close').set_sensitive(True)
         self.gui.get_object('mnu_update').set_sensitive(True)
         self.gui.get_object('mnu_properties').set_sensitive(True)
+        self.gui.get_object('mnu_next_unit').set_sensitive(True)
         self.gui.get_object('mnu_state_advance').set_sensitive(True)
         self.gui.get_object('mnu_state_reverse').set_sensitive(True)
         filename = store_controller.get_store_filename()

--- a/virtaal/views/mainview.py
+++ b/virtaal/views/mainview.py
@@ -185,6 +185,9 @@ class MainView(BaseView):
         self.gui.get_object('mnu_binary_export').connect('activate', self._on_file_binary_export)
         self.gui.get_object('mnu_revert').connect('activate', self._on_file_revert)
         self.gui.get_object('mnu_quit').connect('activate', self._on_quit)
+        # Navigation menu signals
+        self.gui.get_object('mnu_state_advance').connect('activate', self._on_state_advance)
+        self.gui.get_object('mnu_state_reverse').connect('activate', self._on_state_reverse)
         # View menu signals
         self.gui.get_object('mnu_fullscreen').connect('activate', self._on_fullscreen)
         # Help menu signals
@@ -965,6 +968,12 @@ class MainView(BaseView):
         self.controller.quit()
         return True
 
+    def _on_state_advance(self, _widget=None):
+        self.controller.unit_controller.view.advance_workflow_state(1)
+
+    def _on_state_reverse(self, _widget=None):
+        self.controller.unit_controller.view.advance_workflow_state(-1)
+
     def _on_recent_file_activated(self, chooser):
         item = chooser.get_current_item()
         if item.exists():
@@ -979,7 +988,8 @@ class MainView(BaseView):
         openmailto.open(build_bug_report_url())
 
     def _on_store_closed(self, store_controller):
-        for widget_name in ('mnu_saveas', 'mnu_close', 'mnu_update', 'mnu_properties', 'mnu_binary_export'):
+        for widget_name in ('mnu_saveas', 'mnu_close', 'mnu_update', 'mnu_properties', 'mnu_binary_export',
+                             'mnu_state_advance', 'mnu_state_reverse'):
             self.gui.get_object(widget_name).set_sensitive(False)
         self.status_bar.set_sensitive(False)
         self.main_window.set_title(_('Virtaal'))
@@ -989,6 +999,8 @@ class MainView(BaseView):
         self.gui.get_object('mnu_close').set_sensitive(True)
         self.gui.get_object('mnu_update').set_sensitive(True)
         self.gui.get_object('mnu_properties').set_sensitive(True)
+        self.gui.get_object('mnu_state_advance').set_sensitive(True)
+        self.gui.get_object('mnu_state_reverse').set_sensitive(True)
         filename = store_controller.get_store_filename()
         #TODO: move logic to storecontroller
         if filename.endswith('.po') or filename.endswith('.po.bz2') or filename.endswith('.po.gz'):

--- a/virtaal/views/storeview.py
+++ b/virtaal/views/storeview.py
@@ -50,6 +50,16 @@ class StoreView(BaseView):
                                Gdk.ModifierType.CONTROL_MASK)
         Gtk.AccelMap.add_entry("<Virtaal>/Navigation/PgDown", Gtk.accelerator_parse("Page_Down")[0],
                                Gdk.ModifierType.CONTROL_MASK)
+        # Same physical key as the target textbox's own Ctrl+Enter/
+        # Ctrl+Shift+Enter handling (unitview.py) - harmless overlap,
+        # since a focused textbox's own key handler consumes the event
+        # before it ever reaches this window-level accelerator. This is
+        # what makes the shortcut reachable when the textbox *doesn't*
+        # have focus, and what shows it as a real accelerator in the
+        # menu instead of baked into the label text.
+        Gtk.AccelMap.add_entry("<Virtaal>/Navigation/StateAdvance", Gdk.KEY_Return, Gdk.ModifierType.CONTROL_MASK)
+        Gtk.AccelMap.add_entry("<Virtaal>/Navigation/StateReverse", Gdk.KEY_Return,
+                               Gdk.ModifierType.CONTROL_MASK | Gdk.ModifierType.SHIFT_MASK)
 
         self.accel_group = Gtk.AccelGroup()
         self.accel_group.connect_by_path("<Virtaal>/Navigation/Up", self._treeview._move_up)
@@ -58,6 +68,12 @@ class StoreView(BaseView):
         self.accel_group.connect_by_path("<Virtaal>/Navigation/PgDown", self._treeview._move_pgdown)
 
         mainview = self.controller.main_controller.view
+        # Reuses MainView's own handlers (state change + advance to the
+        # next unit, same combination the textbox's own Ctrl+Enter/
+        # Ctrl+Shift+Enter handling performs) rather than duplicating
+        # that logic here.
+        self.accel_group.connect_by_path("<Virtaal>/Navigation/StateAdvance", lambda *a: mainview._on_state_advance())
+        self.accel_group.connect_by_path("<Virtaal>/Navigation/StateReverse", lambda *a: mainview._on_state_reverse())
         mainview.add_accel_group(self.accel_group)
         mainview.gui.get_object('menu_navigation').set_accel_group(self.accel_group)
         self.mnu_up = mainview.gui.get_object('mnu_up')
@@ -68,6 +84,20 @@ class StoreView(BaseView):
         self.mnu_down.set_accel_path('<Virtaal>/Navigation/Down')
         self.mnu_pageup.set_accel_path('<Virtaal>/Navigation/PgUp')
         self.mnu_pagedown.set_accel_path('<Virtaal>/Navigation/PgDown')
+        mainview.gui.get_object('mnu_state_advance').set_accel_path('<Virtaal>/Navigation/StateAdvance')
+        mainview.gui.get_object('mnu_state_reverse').set_accel_path('<Virtaal>/Navigation/StateReverse')
+
+        # GtkosxApplication only picks up a menu item's accelerator for
+        # the native menu bar when the item is (re)parented, not just
+        # because its accel_path/accel_group changed - same fix as
+        # mainview.py's own File/Help items (mnu_open et al.).
+        menu_navigation = mainview.gui.get_object('menu_navigation')
+        for item_id in ('mnu_state_advance', 'mnu_state_reverse'):
+            item = mainview.gui.get_object(item_id)
+            pos = menu_navigation.get_children().index(item)
+            menu_navigation.remove(item)
+            menu_navigation.insert(item, pos)
+        mainview.sync_menubar()
 
         self._set_menu_items_sensitive(False)
 

--- a/virtaal/views/unitview.py
+++ b/virtaal/views/unitview.py
@@ -680,12 +680,19 @@ class UnitView(Gtk.EventBox, GObjectWrapper, Gtk.CellEditable, BaseView):
 
     def _on_key_press_event(self, _widget, event, *_args):
         if event.keyval == Gdk.KEY_Return or event.keyval == Gdk.KEY_KP_Enter:
-            self.must_advance = True
-            # Clear selected elements
-            self.editing_done()
+            self.finish_editing_and_advance()
             return True
         self.must_advance = False
         return False
+
+    def finish_editing_and_advance(self):
+        """Finish editing the current unit and move to the next one -
+        what Enter does once there's no further target textbox to move
+        to within this unit (also used by Ctrl+Enter/Ctrl+Shift+Enter,
+        after they've changed the workflow state)."""
+        self.must_advance = True
+        # Clear selected elements
+        self.editing_done()
 
     def _on_query_tooltip(self, widget, x, y, keyboard_mode, tooltip):
         return True

--- a/virtaal/views/unitview.py
+++ b/virtaal/views/unitview.py
@@ -395,13 +395,11 @@ class UnitView(Gtk.EventBox, GObjectWrapper, Gtk.CellEditable, BaseView):
                 if next_textbox is not None and next_textbox.get_parent().props.visible:
                     self.focus_text_view(next_textbox)
                 else:
-                    if eventname == 'ctrl-enter' and self.unit.STATE:
+                    if eventname == 'ctrl-enter':
                         #Ctrl+Enter means additionally advance the unit in the workflow
-                        listnav = self._widgets['state']
-                        listnav.move_state(1)
-                    elif eventname == 'ctrl-shift-enter' and self.unit.STATE:
-                        listnav = self._widgets['state']
-                        listnav.move_state(-1)
+                        self.advance_workflow_state(1)
+                    elif eventname == 'ctrl-shift-enter':
+                        self.advance_workflow_state(-1)
                     # textbox is the last text view in this unit, so we need to move on
                     # to the next one.
                     self._on_key_press_event(None, event)
@@ -661,6 +659,14 @@ class UnitView(Gtk.EventBox, GObjectWrapper, Gtk.CellEditable, BaseView):
             select_name=state_name,
         )
         self._widgets['state'].show_all()
+
+    def advance_workflow_state(self, offset):
+        """Move the current unit's workflow state one step forward
+        (offset=1) or back (offset=-1) - shared by Ctrl+Enter/
+        Ctrl+Shift+Enter and the Navigation menu's equivalent items."""
+        if not self.unit.STATE:
+            return
+        self._widgets['state'].move_state(offset)
 
     def update_state(self, newstate):
         """Update it without emitting any signals or recreating anything."""

--- a/virtaal/views/widgets/shortcutswindow.py
+++ b/virtaal/views/widgets/shortcutswindow.py
@@ -37,8 +37,8 @@ SHORTCUT_GROUPS = [
         ("<Alt>Right", _("Select next placeable")),
         ("<Alt>Down", _("Copy the source or selected placeable to the target")),
         ("<Shift>Return", _("Enter a new line")),
-        ("<Primary>Return", _('Mark unit "Needs work" as "Translated" and go to the next unit')),
-        ("<Primary><Shift>Return", _('Mark unit as "Needs work" and go to the next unit')),
+        ("<Primary>Return", _("Next Unit and Advance State")),
+        ("<Primary><Shift>Return", _("Next Unit and Reverse State")),
         ("<Primary>z", _("Undo the last change")),
     ]),
     (_("Plug-ins"), [


### PR DESCRIPTION
Fixes #1499.

Ctrl+Enter/Ctrl+Shift+Enter (advance/reverse the current unit's workflow state) have existed since ~2010, but a menu entry was proposed and deferred back then ("messes with string freeze") and never added.

- Added a "Next Unit" entry alongside the two state ones (Enter itself has no menu-native accelerator - a global binding on bare Return risks colliding with other widgets' own Enter handling, e.g. the Add Term dialog's default action).
- Gave the two state entries real Gtk accelerators, matching Up/Down/PgUp/PgDown, instead of "(Ctrl+Enter)" text baked into the label.
- Extracted `UnitView.finish_editing_and_advance()` - the "move to next unit" action Enter already performs - so all three menu items and the textbox's own key handling share it.
- Fixed `shortcutswindow.py`'s description of the two shortcuts - it named a specific PO state transition ("Needs work" -> "Translated") that's wrong for XLIFF, which has five workflow states, not two.
- Added a regression test and a fuzzer action (`advance_state`) exercising this path.

**Known gap, not blocking**: the two state entries' accelerator doesn't render as a native hint in the macOS menu bar, despite being registered correctly (confirmed via `Gtk.AccelMap.lookup_entry()`) - both the keyboard shortcut and the menu click work regardless. The `remove`/`reinsert` + `sync_menubar()` fix that resolved an analogous native-menu issue elsewhere in this codebase (#3452, Ctrl+T) didn't resolve it here; root cause not yet found.

Verified live: menu entries appear correctly under Navigation with a separator grouping the three unit/state actions, are disabled until a file is open, and each performs the same action as its keyboard equivalent (confirmed the combined state-change-then-advance persists to the real unit, not just the state-nav widget's own selection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017KayAA91cuhe4xCpDYBg9K