### PR TITLE
Fix TM matching corrupting non-ASCII source text

### DIFF
--- a/virtaal/support/selector.py
+++ b/virtaal/support/selector.py
@@ -169,6 +169,13 @@ class Selector:
 
     def __call__(self, environ, start_response):
         """Delegate request to the appropriate WSGI app."""
+        # Diverges from the vendored original: PEP 3333 requires
+        # PATH_INFO to be UTF-8 bytes decoded as latin-1 ("native
+        # string" convention) - matching unquoted/decoded against it
+        # directly mangles any non-ASCII path segment (e.g. a Cyrillic
+        # TM source string), corrupting the very text this routes on
+        # (translate/virtaal#1405).
+        environ["PATH_INFO"] = environ["PATH_INFO"].encode("latin-1").decode("utf-8")
         app, svars, methods, matched = self.select(
             environ["PATH_INFO"], environ["REQUEST_METHOD"]
         )

--- a/virtaal/support/test_tmserver.py
+++ b/virtaal/support/test_tmserver.py
@@ -1,0 +1,60 @@
+#
+# Copyright (C) Virtaal contributors.
+#
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
+
+import json
+import threading
+import time
+import urllib.request
+from urllib.parse import quote
+
+from virtaal.support import tmserver, wsgi
+
+
+def _start_server(db_path, port):
+    app = tmserver.TMServer(str(db_path), None)
+    thread = threading.Thread(target=wsgi.launch_server, args=('localhost', port, app.rest), daemon=True)
+    thread.start()
+    time.sleep(0.5)  # give cheroot a moment to actually bind before the first request
+    return app
+
+
+def _translate(port, source, slang, tlang):
+    url = 'http://localhost:%d/%s/%s/unit/%s' % (port, slang, tlang, quote(source, safe=''))
+    with urllib.request.urlopen(url, timeout=5) as resp:
+        return json.loads(resp.read().decode('utf-8'))
+
+
+def test_translate_unit_matches_a_non_ascii_source_exactly(tmp_path):
+    # Real bug (#1405): PATH_INFO is PEP 3333 "native string" - UTF-8
+    # bytes decoded as latin-1 - and selector.py used to match/route on
+    # it directly without the required re-encode/re-decode round trip,
+    # mangling any non-ASCII source string before it ever reached the
+    # TM lookup. A Russian source used to score well under 100% against
+    # its own exact match; confirmed 83% in the original report.
+    port = 18765
+    app = _start_server(tmp_path / 'tm.db', port)
+    source = 'Здравствуйте'
+    app.tmdb.add_dict({'source': source, 'target': 'Hello', 'context': ''}, 'ru', 'en')
+
+    matches = _translate(port, source, 'ru', 'en')
+
+    assert matches, 'expected at least one match for an exact source string'
+    assert matches[0]['source'] == source
+    assert matches[0]['quality'] == 100.0
+
+
+def test_translate_unit_still_matches_an_ascii_source(tmp_path):
+    port = 18766
+    app = _start_server(tmp_path / 'tm.db', port)
+    source = 'Hello world'
+    app.tmdb.add_dict({'source': source, 'target': 'Bonjour le monde', 'context': ''}, 'en', 'fr')
+
+    matches = _translate(port, source, 'en', 'fr')
+
+    assert matches
+    assert matches[0]['source'] == source
+    assert matches[0]['quality'] == 100.0


### PR DESCRIPTION
Fixes #1405.

`selector.py` (vendored from translate-toolkit, which dropped it entirely with no replacement) matched routes directly against `environ["PATH_INFO"]`. PEP 3333 requires that to be UTF-8 bytes decoded as latin-1 ("native string" convention) - the app is responsible for re-encoding to latin-1 bytes and re-decoding as UTF-8 to recover the real text. Skipping that silently mangled any non-ASCII TM source string (e.g. Cyrillic) before it ever reached the database lookup.

Verified end-to-end through the real production path (`TMServer` + `wsgi.launch_server`, a real HTTP request): a Cyrillic source that should score 100% against its own exact match returned **zero matches at all** before this fix, not just a degraded score. Confirmed the fix doesn't regress plain ASCII.

Also confirmed this is still relevant today, not just historically: `wsgi.py` uses `cheroot.wsgi.Server` - cheroot is CherryPy's own HTTP server component, so the original report's "this bug is specific to Cherrypy" is still an accurate description of the current stack, not something the Python 3 port already fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017KayAA91cuhe4xCpDYBg9K