### PR TITLE
Disable Codecov's PR comment

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,1 @@
+comment: false


### PR DESCRIPTION
Codecov's PR comment adds no useful information for reviewers here (see any recent PR) - the check status itself already reports pass/fail. Validated against Codecov's own /validate endpoint before committing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017KayAA91cuhe4xCpDYBg9K