### PR TITLE
Fix Replace All crashing on XLIFF/TMX/TS files

### DIFF
--- a/devsupport/testfiles/æ/checks æ.po
+++ b/devsupport/testfiles/æ/checks æ.po
@@ -1,0 +1,205 @@
+# A PO file to make it easier to review checks in Virtaal.
+# This is not meant as an exhaustive test of the checks - the unit tests are
+# far more complete. This will mostly be useful to check UI strings. It has
+# a bias towards the GNOME configuration for maximal coverage of tests.
+# Copyright 2016 F Wolff
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: translate-devel@lists.sourceforge.net\n"
+"POT-Creation-Date: 2016-01-01 00:00+0000\n"
+"PO-Revision-Date: 2016-03-12 19:00+0200\n"
+"Last-Translator: F Wolff <friedel@translate.org.za>\n"
+"Language-Team: translate-dev@lists.sourceforge.net\n"
+"Language: en_GB\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Virtaal-0.7.1\n"
+"X-Project-Style: gnome\n"
+
+#. Should trigger 'untranslated', but Virtaal will not show it, since it is handled through workflow features
+msgid "word"
+msgstr ""
+
+#. Should trigger 'unchanged'
+msgid "word1 word2"
+msgstr "word1 word2"
+
+#. Should trigger 'blank'
+msgid "a word or two"
+msgstr " "
+
+#. Should trigger 'short'
+msgid "A non-trivial source sentence"
+msgstr "X"
+
+#. Should trigger 'long'
+msgid "Short"
+msgstr "A very long translation that has way too much text in it"
+
+#. Should trigger 'escapes'
+msgid ""
+"The backslash is fun on Windows\\filenames or in regular expressions for "
+"handling Windows\\\\filenames"
+msgstr "A translation without the necessary backslashes"
+
+#. Should trigger 'newlines'
+msgid ""
+"This has a newline\n"
+"in the middle"
+msgstr "This doesn't have a newline"
+
+#. Should trigger 'tabs' (Virtaal shows tabs simply as 8 spaces)
+msgid "This has a tab just before\tthis"
+msgstr "This doesn't have a tab"
+
+#. Should trigger 'singlequoting'
+msgid "Some words in 'single quotes'"
+msgstr "No words quoted"
+
+#. Should trigger 'doublequoting'
+msgid "Some words in \"double qoutes\""
+msgstr "No words quoted"
+
+#. Should trigger 'doublespacing'
+msgid "A string with single spaces only"
+msgstr "Double spaces used before the last  word"
+
+#. Should trigger 'puncspacing'
+msgid "Correct punctuation spacing (or we think so)"
+msgstr "Incorrect punctuation spacing ( hopefully)"
+
+#. Should trigger 'printf'
+msgid "A variable can be printed with printf: %s"
+msgstr "Without a printf variable, a variable won't be printed"
+
+#. Should trigger 'pythonbraceformat'
+msgid "Python variable number {}"
+msgstr "Python variable number {3}"
+
+#. Should trigger 'accelerators'
+msgid "Another string in this _file"
+msgstr "Another wrong translation"
+
+#. Should trigger 'variables'
+msgid "Some kind of $(variable)"
+msgstr "I also want a $(varyable)"
+
+#. Should trigger 'functions'
+msgid "Let's call check()"
+msgstr "I prefer control()"
+
+#. Should trigger 'emails'
+msgid "Send to test@example.com"
+msgstr "Send to tart@example.com"
+
+#. Should trigger 'urls'
+msgid "Go to https://example.com"
+msgstr "Go to http://example.com"
+
+#. Should trigger 'numbers'
+msgid "There are 300 ways to do this"
+msgstr "There are multiple ways to do this"
+
+#. Should trigger 'starwhitespace'
+msgid "No starting whitespace"
+msgstr " Some whitespace at the start"
+
+#. Should trigger 'endwhitespace'
+msgid "No ending whitespace"
+msgstr "Some whitespace at the end "
+
+#. Should trigger 'startpunc'
+msgid "(Some test for starting punctuation)"
+msgstr "Hopefully you see the error (here)"
+
+#. Should trigger 'endpunc'
+msgid "There are ways of doing this:"
+msgstr "There is no way to do this!"
+
+#. Should trigger 'purepunc'
+msgid "+++"
+msgstr "PLUS"
+
+#. Should trigger 'brackets'
+msgid "Some use of (brackets)"
+msgstr "Brackets totally forgotten"
+
+#. Should trigger 'sentencecount'
+msgid "Translate this. And this?"
+msgstr "Did I translate it all?"
+
+#. Should trigger 'options'
+msgid "Use the --qa option"
+msgstr "Review the text"
+
+#. Should trigger 'startcaps'
+msgid "Starting with capital"
+msgstr "no Starting capital"
+
+#. Should trigger 'simplecaps'
+msgid "Just normal sentence case"
+msgstr "A Title Case Happy Translator Was Here"
+
+#. Should trigger 'acronyms'
+msgid "The English writer likes to use a TLA"
+msgstr "I don't want to use three letter acronyms"
+
+#. Should trigger 'doublewords'
+msgid "Fluent sentence"
+msgstr "Unnecessary repetition of of a word"
+
+#. Should trigger 'notranslatewords', but there is no configuration for this in Virtaal yet
+msgid "Maybe something like Ethernet should not be translated"
+msgstr "Maybe I just like saying the Netether"
+
+#. Should trigger 'musttranslatewords', but there is no configuration for this in Virtaal yet
+msgid "Certain words like 'translate' simply must be translated"
+msgstr "I refuse to translate the word 'translate'"
+
+#. Should trigger 'validchars', but there is no configuration for this in Virtaal yet
+msgid "Only ASCII characters"
+msgstr "I dón't want tó bé restricted to ASCII"
+
+#. Should trigger 'filepaths'
+msgid "This contains a /path/to/a/file"
+msgstr "This contains a /path/tp/a/file"
+
+#. Should trigger 'xmtags'
+msgid "XML tags are <b>fun</b>"
+msgstr "XML tags can be <b>fun<b>"
+
+#. Should trigger 'kdecomments'
+msgid ""
+"_: An archaic KDE context comment\n"
+"The actual source text"
+msgstr ""
+"_: I'll be clever and translate in a text editor and duplicate the KDE comment"
+
+#. Should trigger 'compendiumconflicts'
+msgid "translation memories are a good idea"
+msgstr ""
+"#-#-#-#-#  file1.po  #-#-#-#-#\n"
+"but msgcat must be used carefully\n"
+"#-#-#-#-#  file2.po  #-#-#-#-#\n"
+"look mamma, no hands"
+
+
+#. Should trigger 'simpleplurals'
+msgid "Maybe I should use gettext plural(s)"
+msgstr "Yes, you should use those (proper) plurals"
+
+#. Should trigger 'spellcheck', but depends on libraries and some configuration
+msgid "I'll write carefully with regards to spelling"
+msgstr "I'm just going to pound my fist on the keyboard: hyjnn"
+
+#. Should trigger 'credits' if the project style is correct
+msgid "translator-credits"
+msgstr "Me, myself and I"
+
+#. Should trigger 'gconf'
+#: somewhere.gschema.xml.in
+msgid "The test's name is \"gconf\""
+msgstr "The test's name is \"goonf\""

--- a/devsupport/testfiles/𝐮𝐧𝐢𝐜𝐨𝐝𝐞/checks 𝐮𝐧𝐢𝐜𝐨𝐝𝐞.po
+++ b/devsupport/testfiles/𝐮𝐧𝐢𝐜𝐨𝐝𝐞/checks 𝐮𝐧𝐢𝐜𝐨𝐝𝐞.po
@@ -1,0 +1,205 @@
+# A PO file to make it easier to review checks in Virtaal.
+# This is not meant as an exhaustive test of the checks - the unit tests are
+# far more complete. This will mostly be useful to check UI strings. It has
+# a bias towards the GNOME configuration for maximal coverage of tests.
+# Copyright 2016 F Wolff
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: translate-devel@lists.sourceforge.net\n"
+"POT-Creation-Date: 2016-01-01 00:00+0000\n"
+"PO-Revision-Date: 2016-03-12 19:00+0200\n"
+"Last-Translator: F Wolff <friedel@translate.org.za>\n"
+"Language-Team: translate-dev@lists.sourceforge.net\n"
+"Language: en_GB\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Virtaal-0.7.1\n"
+"X-Project-Style: gnome\n"
+
+#. Should trigger 'untranslated', but Virtaal will not show it, since it is handled through workflow features
+msgid "word"
+msgstr ""
+
+#. Should trigger 'unchanged'
+msgid "word1 word2"
+msgstr "word1 word2"
+
+#. Should trigger 'blank'
+msgid "a word or two"
+msgstr " "
+
+#. Should trigger 'short'
+msgid "A non-trivial source sentence"
+msgstr "X"
+
+#. Should trigger 'long'
+msgid "Short"
+msgstr "A very long translation that has way too much text in it"
+
+#. Should trigger 'escapes'
+msgid ""
+"The backslash is fun on Windows\\filenames or in regular expressions for "
+"handling Windows\\\\filenames"
+msgstr "A translation without the necessary backslashes"
+
+#. Should trigger 'newlines'
+msgid ""
+"This has a newline\n"
+"in the middle"
+msgstr "This doesn't have a newline"
+
+#. Should trigger 'tabs' (Virtaal shows tabs simply as 8 spaces)
+msgid "This has a tab just before\tthis"
+msgstr "This doesn't have a tab"
+
+#. Should trigger 'singlequoting'
+msgid "Some words in 'single quotes'"
+msgstr "No words quoted"
+
+#. Should trigger 'doublequoting'
+msgid "Some words in \"double qoutes\""
+msgstr "No words quoted"
+
+#. Should trigger 'doublespacing'
+msgid "A string with single spaces only"
+msgstr "Double spaces used before the last  word"
+
+#. Should trigger 'puncspacing'
+msgid "Correct punctuation spacing (or we think so)"
+msgstr "Incorrect punctuation spacing ( hopefully)"
+
+#. Should trigger 'printf'
+msgid "A variable can be printed with printf: %s"
+msgstr "Without a printf variable, a variable won't be printed"
+
+#. Should trigger 'pythonbraceformat'
+msgid "Python variable number {}"
+msgstr "Python variable number {3}"
+
+#. Should trigger 'accelerators'
+msgid "Another string in this _file"
+msgstr "Another wrong translation"
+
+#. Should trigger 'variables'
+msgid "Some kind of $(variable)"
+msgstr "I also want a $(varyable)"
+
+#. Should trigger 'functions'
+msgid "Let's call check()"
+msgstr "I prefer control()"
+
+#. Should trigger 'emails'
+msgid "Send to test@example.com"
+msgstr "Send to tart@example.com"
+
+#. Should trigger 'urls'
+msgid "Go to https://example.com"
+msgstr "Go to http://example.com"
+
+#. Should trigger 'numbers'
+msgid "There are 300 ways to do this"
+msgstr "There are multiple ways to do this"
+
+#. Should trigger 'starwhitespace'
+msgid "No starting whitespace"
+msgstr " Some whitespace at the start"
+
+#. Should trigger 'endwhitespace'
+msgid "No ending whitespace"
+msgstr "Some whitespace at the end "
+
+#. Should trigger 'startpunc'
+msgid "(Some test for starting punctuation)"
+msgstr "Hopefully you see the error (here)"
+
+#. Should trigger 'endpunc'
+msgid "There are ways of doing this:"
+msgstr "There is no way to do this!"
+
+#. Should trigger 'purepunc'
+msgid "+++"
+msgstr "PLUS"
+
+#. Should trigger 'brackets'
+msgid "Some use of (brackets)"
+msgstr "Brackets totally forgotten"
+
+#. Should trigger 'sentencecount'
+msgid "Translate this. And this?"
+msgstr "Did I translate it all?"
+
+#. Should trigger 'options'
+msgid "Use the --qa option"
+msgstr "Review the text"
+
+#. Should trigger 'startcaps'
+msgid "Starting with capital"
+msgstr "no Starting capital"
+
+#. Should trigger 'simplecaps'
+msgid "Just normal sentence case"
+msgstr "A Title Case Happy Translator Was Here"
+
+#. Should trigger 'acronyms'
+msgid "The English writer likes to use a TLA"
+msgstr "I don't want to use three letter acronyms"
+
+#. Should trigger 'doublewords'
+msgid "Fluent sentence"
+msgstr "Unnecessary repetition of of a word"
+
+#. Should trigger 'notranslatewords', but there is no configuration for this in Virtaal yet
+msgid "Maybe something like Ethernet should not be translated"
+msgstr "Maybe I just like saying the Netether"
+
+#. Should trigger 'musttranslatewords', but there is no configuration for this in Virtaal yet
+msgid "Certain words like 'translate' simply must be translated"
+msgstr "I refuse to translate the word 'translate'"
+
+#. Should trigger 'validchars', but there is no configuration for this in Virtaal yet
+msgid "Only ASCII characters"
+msgstr "I dón't want tó bé restricted to ASCII"
+
+#. Should trigger 'filepaths'
+msgid "This contains a /path/to/a/file"
+msgstr "This contains a /path/tp/a/file"
+
+#. Should trigger 'xmtags'
+msgid "XML tags are <b>fun</b>"
+msgstr "XML tags can be <b>fun<b>"
+
+#. Should trigger 'kdecomments'
+msgid ""
+"_: An archaic KDE context comment\n"
+"The actual source text"
+msgstr ""
+"_: I'll be clever and translate in a text editor and duplicate the KDE comment"
+
+#. Should trigger 'compendiumconflicts'
+msgid "translation memories are a good idea"
+msgstr ""
+"#-#-#-#-#  file1.po  #-#-#-#-#\n"
+"but msgcat must be used carefully\n"
+"#-#-#-#-#  file2.po  #-#-#-#-#\n"
+"look mamma, no hands"
+
+
+#. Should trigger 'simpleplurals'
+msgid "Maybe I should use gettext plural(s)"
+msgstr "Yes, you should use those (proper) plurals"
+
+#. Should trigger 'spellcheck', but depends on libraries and some configuration
+msgid "I'll write carefully with regards to spelling"
+msgstr "I'm just going to pound my fist on the keyboard: hyjnn"
+
+#. Should trigger 'credits' if the project style is correct
+msgid "translator-credits"
+msgstr "Me, myself and I"
+
+#. Should trigger 'gconf'
+#: somewhere.gschema.xml.in
+msgid "The test's name is \"gconf\""
+msgstr "The test's name is \"goonf\""

--- a/virtaal/modes/searchmode.py
+++ b/virtaal/modes/searchmode.py
@@ -285,11 +285,12 @@ class SearchMode(BaseMode):
         return [match for match in self.matches if match.unit is unit]
 
     def _get_unit_matches_dict(self):
+        # Keyed by id(), not the unit itself - translate-toolkit's
+        # lxml-based units (XLIFF, TMX, TS) define __eq__ without
+        # __hash__, making them unhashable.
         d = {}
         for match in self.matches:
-            if match.unit not in d:
-                d[match.unit] = []
-            d[match.unit].append(match)
+            d.setdefault(id(match.unit), []).append(match)
         return d
 
     def _highlight_matches(self):
@@ -392,7 +393,7 @@ class SearchMode(BaseMode):
         repl_str = self.ent_replace.get_text()
         unit_matches = self._get_unit_matches_dict()
 
-        for unit, matches in unit_matches.items():
+        for matches in unit_matches.values():
             for match in reversed(matches):
                 self.replace_match(match, repl_str)
 

--- a/virtaal/modes/test_searchmode.py
+++ b/virtaal/modes/test_searchmode.py
@@ -7,7 +7,10 @@
 
 from types import SimpleNamespace
 
+from translate.storage import xliff
+
 from virtaal.modes.searchmode import SearchMode
+from virtaal.support.pogrep_compat import GrepFilter
 
 
 class _FakeUnit:
@@ -42,3 +45,40 @@ def test_replace_match_updates_plural_target_string():
     mode.replace_match(match, 'dogs')
 
     assert unit.target == ['cat', 'dogs']
+
+
+def _xliff_unit(source, target):
+    u = xliff.xlifffile().addsourceunit(source)
+    u.target = target
+    return u
+
+
+def test_replace_all_on_xliff_units():
+    """_get_unit_matches_dict() keyed matches by the unit object itself
+    - translate-toolkit's lxml-based units (XLIFF, TMX, TS) define
+    __eq__ without __hash__, making them unhashable, so clicking
+    "Replace All" on any such file crashed with TypeError before a
+    single replacement happened (#3258)."""
+    units = [
+        _xliff_unit("Don't know", "Don't know"),
+        _xliff_unit("x", "Don't know and also Don't know"),
+    ]
+    f = GrepFilter(searchstring="Don't know", searchparts=('target',),
+                    ignorecase=True, useregexp=False, max_matches=200000)
+    matches, _ = f.getmatches(units)
+
+    mode = SearchMode.__new__(SearchMode)
+    mode.controller = SimpleNamespace(
+        main_controller=SimpleNamespace(
+            unit_controller=None,
+            undo_controller=SimpleNamespace(record_start=lambda: None, record_stop=lambda: None),
+        ))
+    mode.matches = matches
+    mode.ent_replace = SimpleNamespace(get_text=lambda: 'REPLACED')
+    mode._search_timeout = 0  # _cancel_search_timeout() then no-ops
+    mode.update_search = lambda: None  # not under test here
+
+    mode._replace_all()  # must not raise
+
+    assert units[0].target == 'REPLACED'
+    assert units[1].target == 'REPLACED and also REPLACED'

--- a/virtaal/support/test_pogrep_compat.py
+++ b/virtaal/support/test_pogrep_compat.py
@@ -1,0 +1,47 @@
+#
+# Copyright (C) Virtaal contributors.
+#
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
+
+import unicodedata
+
+from translate.storage import po
+
+from virtaal.support.pogrep_compat import GrepFilter
+
+
+def _unit(source, target):
+    u = po.pofile().addsourceunit(source)
+    u.target = target
+    return u
+
+
+def test_getmatches_does_not_raise():
+    # Real crash (Python 3.14+): upstream GrepFilter.getmatches() ORs
+    # in re.LOCALE, which is invalid with a str pattern.
+    units = [_unit("Don't know", "Don't know")]
+    f = GrepFilter(searchstring="Don't know", searchparts=('source', 'target'),
+                    ignorecase=True, useregexp=False, max_matches=200000)
+
+    matches, indexes = f.getmatches(units)
+
+    assert indexes == [0]
+    assert [m.start for m in matches] == [0, 0]  # matched in both source and target
+
+
+def test_getmatches_maps_offsets_through_nfd_decomposed_accents():
+    # A search term with no accents at all must still land on the right
+    # offsets when *other* text in the same string is NFD-decomposed
+    # (e.g. a Java/Oracle export), since the underlying normalize()/
+    # real_index() machinery matches against the NFC-composed form.
+    nfd_e_acute = unicodedata.normalize('NFD', "é")
+    units = [_unit("x", nfd_e_acute + " Don't know and also Don't know " + nfd_e_acute)]
+    f = GrepFilter(searchstring="Don't know", searchparts=('target',),
+                    ignorecase=True, useregexp=False, max_matches=200000)
+
+    matches, _ = f.getmatches(units)
+
+    raw = units[0].target
+    assert [raw[m.start:m.end] for m in matches] == ["Don't know", "Don't know"]


### PR DESCRIPTION
Clicking "Replace All" on an XLIFF (or TMX/TS) file crashed with `TypeError: unhashable type` before making a single replacement - `_get_unit_matches_dict()` used the unit object as a dict key, but translate-toolkit's lxml-based units define `__eq__` without `__hash__`.

- Key by `id(unit)` instead.
- Add regression tests for this, plus for pogrep_compat's Python 3.14 `re.LOCALE` fix and its NFC offset mapping (neither had any coverage).
- Add non-ASCII test fixtures (`æ`, and an astral-plane lookalike needing UTF-16 surrogate pairs on Windows) for manual drag-and-drop testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017KayAA91cuhe4xCpDYBg9K