### PR TITLE
Show a crash dialog with a bug-report button on uncaught exceptions

### DIFF
--- a/virtaal/main.py
+++ b/virtaal/main.py
@@ -45,6 +45,9 @@ class Virtaal:
     """The main Virtaal program entry point."""
 
     def __init__(self, startupfile):
+        from virtaal.support.crash_dialog import install as install_crash_dialog
+        install_crash_dialog()
+
         # PyGObject-wrapped GTK widgets routinely end up in Python
         # reference cycles (e.g. via bound-method signal connections),
         # and GTK's C-level widget dispose/unparent chain is not

--- a/virtaal/support/crash_dialog.py
+++ b/virtaal/support/crash_dialog.py
@@ -1,0 +1,99 @@
+#
+# Copyright (C) Virtaal contributors.
+#
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
+
+"""Shows a dialog with the traceback on any uncaught exception, with a
+button to open a pre-filled bug report (see FEATURE-CRASH-REPORTING.md).
+Covers exceptions from GTK/GLib callbacks too - PyGObject already
+routes those through sys.excepthook rather than crashing outright."""
+
+import logging
+import sys
+import traceback
+
+# Comfortably under GitHub's URL length limit even after the other
+# prefilled fields and percent-encoding overhead; the full traceback is
+# always in the log file regardless.
+MAX_REPORTED_TRACEBACK_CHARS = 4000
+
+_showing_dialog = False
+
+
+def install():
+    sys.excepthook = _on_uncaught_exception
+
+
+def _on_uncaught_exception(exc_type, exc_value, tb):
+    global _showing_dialog
+
+    if issubclass(exc_type, (KeyboardInterrupt, SystemExit)):
+        sys.__excepthook__(exc_type, exc_value, tb)
+        return
+
+    full_text = "".join(traceback.format_exception(exc_type, exc_value, tb))
+    logging.error("Uncaught exception:\n%s", full_text)
+
+    if _showing_dialog:
+        # The dialog itself raised - don't recurse into it again.
+        return
+
+    try:
+        _showing_dialog = True
+        _show_dialog(full_text)
+    except Exception:
+        logging.exception("Failed to show the crash dialog")
+    finally:
+        _showing_dialog = False
+
+
+def truncate_for_report(text, limit=MAX_REPORTED_TRACEBACK_CHARS):
+    """Keep the tail of a traceback - that's where the actual exception
+        is - noting that it was cut if so."""
+    if len(text) <= limit:
+        return text
+    return "(truncated - see the full log)\n...\n" + text[-limit:]
+
+
+def build_report_url(full_text):
+    from virtaal.support.bug_report import build_bug_report_url
+    return build_bug_report_url(extra_fields={
+        'logs': truncate_for_report(full_text),
+        # Every report from here has a real traceback, unlike the
+        # generic Help > Report a Bug path - label it as such.
+        'labels': 'bug,traceback',
+    })
+
+
+def _show_dialog(full_text):
+    from gi.repository import Gtk
+
+    from virtaal.support import openmailto
+
+    dialog = Gtk.MessageDialog(
+        None, Gtk.DialogFlags.MODAL, Gtk.MessageType.ERROR, Gtk.ButtonsType.NONE,
+        _("Virtaal hit an unexpected error"))
+    dialog.format_secondary_text(
+        _("This might not affect your current work, but if it keeps happening, "
+          "reporting it helps get it fixed."))
+
+    expander = Gtk.Expander(label=_("Details"))
+    textview = Gtk.TextView(editable=False, monospace=True)
+    textview.get_buffer().set_text(full_text)
+    scrolled = Gtk.ScrolledWindow()
+    scrolled.set_size_request(480, 200)
+    scrolled.add(textview)
+    expander.add(scrolled)
+    dialog.get_content_area().pack_start(expander, True, True, 0)
+    expander.show_all()
+
+    dialog.add_button(_("Close"), Gtk.ResponseType.CLOSE)
+    dialog.add_button(_("Report This Bug…"), Gtk.ResponseType.ACCEPT)
+    dialog.set_default_response(Gtk.ResponseType.ACCEPT)
+
+    response = dialog.run()
+    dialog.destroy()
+    if response == Gtk.ResponseType.ACCEPT:
+        openmailto.open(build_report_url(full_text))

--- a/virtaal/support/test_crash_dialog.py
+++ b/virtaal/support/test_crash_dialog.py
@@ -1,0 +1,79 @@
+#
+# Copyright (C) Virtaal contributors.
+#
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
+
+import sys
+from urllib.parse import parse_qs, urlsplit
+
+from virtaal.support import crash_dialog
+
+
+def _exc_info(exc_type, message):
+    try:
+        raise exc_type(message)
+    except exc_type:
+        return sys.exc_info()
+
+
+def test_install_sets_excepthook(monkeypatch):
+    monkeypatch.setattr(sys, 'excepthook', sys.__excepthook__)
+    crash_dialog.install()
+    assert sys.excepthook is crash_dialog._on_uncaught_exception
+
+
+def test_truncate_for_report_leaves_short_text_alone():
+    text = "short traceback"
+    assert crash_dialog.truncate_for_report(text, limit=100) == text
+
+
+def test_truncate_for_report_keeps_the_tail_of_long_text():
+    text = "x" * 50 + "THE ACTUAL ERROR"
+    truncated = crash_dialog.truncate_for_report(text, limit=20)
+    assert truncated.endswith("THE ACTUAL ERROR")
+    assert len(truncated) < len(text)
+
+
+def test_keyboard_interrupt_bypasses_the_dialog(monkeypatch):
+    calls = []
+    monkeypatch.setattr(crash_dialog, '_show_dialog', lambda text: calls.append(text))
+    monkeypatch.setattr(sys, '__excepthook__', lambda *a: calls.append('default-hook'))
+
+    crash_dialog._on_uncaught_exception(*_exc_info(KeyboardInterrupt, ''))
+
+    assert calls == ['default-hook']
+
+
+def test_uncaught_exception_shows_dialog_and_logs(monkeypatch, caplog):
+    calls = []
+    monkeypatch.setattr(crash_dialog, '_show_dialog', lambda text: calls.append(text))
+
+    crash_dialog._on_uncaught_exception(*_exc_info(ValueError, 'boom'))
+
+    assert len(calls) == 1
+    assert 'ValueError: boom' in calls[0]
+    assert 'Uncaught exception' in caplog.text
+
+
+def test_build_report_url_labels_it_as_a_traceback():
+    url = crash_dialog.build_report_url("Traceback...\nValueError: boom")
+    fields = {k: v[0] for k, v in parse_qs(urlsplit(url).query).items()}
+
+    assert fields['labels'] == 'bug,traceback'
+    assert 'ValueError: boom' in fields['logs']
+
+
+def test_dialog_raising_does_not_recurse_or_propagate(monkeypatch):
+    calls = []
+
+    def boom(text):
+        calls.append(text)
+        raise RuntimeError('dialog construction failed')
+
+    monkeypatch.setattr(crash_dialog, '_show_dialog', boom)
+
+    crash_dialog._on_uncaught_exception(*_exc_info(ValueError, 'boom'))  # must not raise
+
+    assert len(calls) == 1


### PR DESCRIPTION
Beta builds are likely to hit tracebacks, and there was no way for a user to know or report one short of digging through log files.

Installs a `sys.excepthook` early in `Virtaal.__init__` that logs the full traceback (always in the log file too) and shows a dialog with the traceback and a "Report This Bug…" button, which opens a pre-filled GitHub issue via the existing `build_bug_report_url()` helper. Nothing is sent automatically - the user sees and approves what's reported.

Covers exceptions raised from GTK/GLib callbacks (signal handlers, `idle_add`, etc.) as well as ordinary code - verified live that PyGObject already routes both through `sys.excepthook` and keeps the main loop running afterward, so one hook handles both.

Does not catch native crashes (segfaults) - the process is gone before Python code can run; out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017KayAA91cuhe4xCpDYBg9K