### PR TITLE
Point remaining dead sourceforge.net/virtaal.org links at docs.translatehouse.org

### DIFF
--- a/virtaal/plugins/tm/models/google_translate.py
+++ b/virtaal/plugins/tm/models/google_translate.py
@@ -23,7 +23,7 @@ code_translation = {
     'nb': 'no', # Google maps no (Norwegian) to its Norwegian (Bokmål) (nb) translator
 }
 
-virtaal_referrer = "http://virtaal.org/"
+virtaal_referrer = "https://virtaal.translatehouse.org/"
 
 class TMModel(BaseTMModel):
     """This is a Google Translate translation memory model.

--- a/virtaal/views/mainview.py
+++ b/virtaal/views/mainview.py
@@ -858,7 +858,7 @@ class MainView(BaseView):
 
     def _on_documentation(self, _widget=None):
         from virtaal.support import openmailto
-        openmailto.open("http://translate.sourceforge.net/wiki/virtaal/index")
+        openmailto.open("https://docs.translatehouse.org/projects/virtaal/en/latest/using_virtaal.html")
 
     def show_update_notice(self, tag_name, html_url):
         """Called at most once per session, from a frozen build only,
@@ -951,7 +951,7 @@ class MainView(BaseView):
         # If the guide is installed and no internet then open local
         # If Internet then go live, if no Internet or guide then disable
         from virtaal.support import openmailto
-        openmailto.open("http://translate.sourceforge.net/wiki/guide/start")
+        openmailto.open("https://docs.translatehouse.org/projects/localization-guide/en/")
 
     def _on_help_about(self, _widget=None):
         from .widgets.aboutdialog import AboutDialog


### PR DESCRIPTION
Fixes #3230 - the welcome screen's links were already updated, but Help > Documentation, Help > Localization Guide, and the Google Translate TM plugin's referrer header still pointed at the dead `translate.sourceforge.net` wiki / `virtaal.org`.

Not touched here, worth a follow-up: `docs/conf.py`'s `:wiki:` Sphinx role (used in 3 doc pages) still resolves to the same dead wiki, and `share/virtaal/virtaal.glade` (a leftover, unused-at-runtime file - confirmed nothing loads it) has the same dead links in translator-facing comments/tooltips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017KayAA91cuhe4xCpDYBg9K