### PR TITLE
Fix cursor jumping to the end of a word after Tab-autocompleting it

### DIFF
--- a/virtaal/test/test_textbox_cursor.py
+++ b/virtaal/test/test_textbox_cursor.py
@@ -1,0 +1,30 @@
+#
+# Copyright (C) Virtaal contributors.
+#
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
+
+from test_scaffolding import TestScaffolding
+
+
+class TestTextBoxCursor(TestScaffolding):
+
+    def test_cursor_move_clears_the_pending_refresh_position(self):
+        """Accepting an autocomplete suggestion (or any raw
+        buffer.insert()) leaves refresh_cursor_pos pointing at the end
+        of the inserted text, to be restored on the next refresh(). If
+        the user then moves the cursor with no text change (arrow
+        keys, Ctrl+Left/Right, a mouse click), that stale target must
+        not survive to snap the cursor back on the next refresh() -
+        exactly what made typing at the start of a Tab-completed word
+        jump the cursor to its end (#3229)."""
+        test_unit = self.trans_store.getunits()[1]
+        view = self.unit_controller.load_unit(test_unit)
+        textbox = view.targets[0]
+
+        textbox.refresh_cursor_pos = 999  # simulates the post-accept state
+
+        textbox._on_event_remove_suggestion()  # what a real cursor move fires
+
+        assert textbox.refresh_cursor_pos == -1

--- a/virtaal/views/widgets/textbox.py
+++ b/virtaal/views/widgets/textbox.py
@@ -785,6 +785,7 @@ class TextBox(Gtk.TextView):
 
     def _on_event_remove_suggestion(self, *args):
         self.suggestion = None
+        self.refresh_cursor_pos = -1
 
 
     # SPECIAL METHODS #


### PR DESCRIPTION
Fixes #3229.

Accepting an autocomplete suggestion inserts the word via a raw `buffer.insert()`, which sets `refresh_cursor_pos` so the cursor gets restored there on the next `refresh()`. Moving the cursor afterwards with no text change (arrow keys, Ctrl+Left/Right, a mouse click) never cleared that stale target - so typing again anywhere else in the word still snapped the cursor back to where the completion had ended, once the next refresh happened.

Fixed by clearing `refresh_cursor_pos` in the same handler that already runs on a cursor-only move (`_on_event_remove_suggestion`, wired to both `move-cursor` and `button-press-event`).

Verified with a regression test (fails on the old code, passes with the fix), the full suite, and live on macOS - typed a word into one unit, autocompleted a second unit from it, moved the cursor to the start of the completed word, typed a character, and confirmed the cursor no longer jumps to the end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017KayAA91cuhe4xCpDYBg9K