### PR TITLE
Log the real exception when a dependency check fails

### DIFF
--- a/.claude/skills/virtaal-issue-triage/SKILL.md
+++ b/.claude/skills/virtaal-issue-triage/SKILL.md
@@ -122,6 +122,41 @@ In every case, the close comment cites the concrete evidence (a commit,
 a grep result, an actual test run) - never a bare "fixed" or "no
 longer applicable" with nothing to check it against.
 
+## `gh issue list` silently caps at 30
+
+**Always pass `--limit` explicitly** (500 comfortably covers this
+repo's whole open backlog) - without it, `gh issue list` defaults to
+30 results, sorted by most-recently-updated, with no warning that
+anything was cut off. Confirmed the hard way (2026-09-12): a sweep
+believed to cover "all 30 open issues" was actually only the 30
+most-recently-touched ones (many touched by this session's own earlier
+comments) - the repo actually had 211 open, 89 of them real bug
+reports (non-enhancement/question) sitting untouched below that
+default page. Get the true count first (`gh issue list --repo
+translate/virtaal --state open --limit 500 --json number -q
+'length'`) before ever calling a review pass "done" or "the whole
+backlog."
+
+## Checking a report that links an external tracker bug
+
+If the report itself links a bug on another project's tracker (a GTK/
+GNOME bug for an input-method or rendering issue is common here),
+check *that* bug's actual resolution status directly rather than
+inferring from "we ported to a newer toolkit version" alone - it's
+concrete evidence, not a plausibility argument:
+
+```
+curl -sL -A "Mozilla/5.0" "https://bugzilla.gnome.org/show_bug.cgi?id=NNNNNN" \
+  | grep -iE "bz_status_|RESOLVED|duplicate"
+```
+
+Old GNOME Bugzilla redirects to a banner page for GitLab now, but the
+original bug's page still renders below it with real status - resolved
+directly, or marked a duplicate of another bug worth checking too (a
+confirmed 2026-09-12 case: two separate Virtaal issues, filed years
+apart, both root-caused to the same one upstream GTK bug, itself
+RESOLVED FIXED - closed both off that single piece of evidence).
+
 ## Batch mechanics
 
 Fetching many issue bodies at once (title + body, to actually read

--- a/virtaal/support/depcheck.py
+++ b/virtaal/support/depcheck.py
@@ -6,6 +6,7 @@
 # the AUTHORS.md file for copyright and authorship information.
 
 import importlib.util
+import logging
 
 __all__ = ['check_dependencies', 'extra_tests', 'import_checks']
 
@@ -30,7 +31,7 @@ def test_gtk_version():
         # That seems to be fixed in time for 2.18 which was released in
         # September 2009
     except Exception:
-        pass
+        logging.debug("gtk dependency check failed", exc_info=True)
     return False
 
 def test_sqlite3_version():
@@ -47,7 +48,7 @@ def test_translate_toolkit_version():
         from translate.__version__ import ver
         return ver >= MIN_TRANSLATE_VERSION
     except Exception:
-        pass
+        logging.debug("translate-toolkit dependency check failed", exc_info=True)
     return False
 
 


### PR DESCRIPTION
Fixes #1136.

`depcheck.py`'s GTK/translate-toolkit version checks silently swallowed the actual exception - a badly-compiled or broken library present but unusable was reported identically to it being absent entirely, with no way to see why. Now logs the real exception at debug level.

Also folds two lessons from this session's issue-backlog sweep into the `virtaal-issue-triage` skill (unrelated to the code fix, bundled since both are small).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017KayAA91cuhe4xCpDYBg9K