### PR TITLE
Add regression tests for three closed-as-fixed issues

### DIFF
--- a/virtaal/support/test_toolkit_regressions.py
+++ b/virtaal/support/test_toolkit_regressions.py
@@ -1,0 +1,41 @@
+#
+# Copyright (C) Virtaal contributors.
+#
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
+
+"""Pins translate-toolkit storage-format behaviour that real Virtaal
+bug reports hit in the past - not code Virtaal itself wraps, so
+nothing else in this test suite would catch a future toolkit upgrade
+regressing any of these. See each test's own comment for which issue
+it guards."""
+
+import io
+
+from translate.storage import xliff
+
+
+def test_xliff_preserves_a_trailing_non_breaking_space():
+    # #2088: a trailing U+00A0 in the target used to get silently
+    # dropped on save.
+    content = b'''<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<file source-language="en" target-language="fr" datatype="plaintext" original="test">
+<body>
+<trans-unit id="1">
+<source xml:space="preserve">Hello\xc2\xa0</source>
+<target></target>
+</trans-unit>
+</body>
+</file>
+</xliff>
+'''
+    store = xliff.xlifffile(content)
+    store.units[0].target = "Bonjour\xa0"
+
+    buf = io.BytesIO()
+    store.serialize(buf)
+    reparsed = xliff.xlifffile(buf.getvalue())
+
+    assert reparsed.units[0].target == "Bonjour\xa0"

--- a/virtaal/support/test_toolkit_regressions.py
+++ b/virtaal/support/test_toolkit_regressions.py
@@ -13,7 +13,7 @@ it guards."""
 
 import io
 
-from translate.storage import xliff
+from translate.storage import pypo, xliff
 
 
 def test_xliff_preserves_a_trailing_non_breaking_space():
@@ -39,3 +39,31 @@ def test_xliff_preserves_a_trailing_non_breaking_space():
     reparsed = xliff.xlifffile(buf.getvalue())
 
     assert reparsed.units[0].target == "Bonjour\xa0"
+
+
+def test_po_header_comments_round_trip_unchanged():
+    # #3231: blank "#" lines and leading-space indentation in the
+    # header comments used to be stripped/reformatted on save.
+    content = b'''# Danish translation for X
+# Copyright (C) 2016 X
+#
+# scootergrisen, 2016.
+#
+#
+#
+# test1
+#  test2
+#
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\\n"
+
+msgid "Hello"
+msgstr "Bonjour"
+'''
+    store = pypo.pofile(content)
+
+    buf = io.BytesIO()
+    store.serialize(buf)
+
+    assert buf.getvalue() == content

--- a/virtaal/test/test_storemodel.py
+++ b/virtaal/test/test_storemodel.py
@@ -92,3 +92,30 @@ def test_last_translator_is_name_and_email_when_both_are_given(tmp_path):
     model, path = _model_with_translator_info(tmp_path, name="Jan Alleman", email="me@example.com")
     model.save_file()
     assert 'Last-Translator: Jan Alleman <me@example.com>\\n' in path.read_text()
+
+
+def test_vanished_ts_translation_is_excluded_but_does_not_crash(tmp_path):
+    # #3263: a Qt .ts <translation type="vanished"> unit used to crash
+    # StoreModel.load_file() outright - it should load cleanly and be
+    # hidden from the UI (obsolete), not shown alongside real units.
+    path = tmp_path / "test.ts"
+    path.write_text('''<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="gd">
+<context>
+    <name>Test</name>
+    <message>
+        <source>OK</source>
+        <translation type="vanished">Ceart ma-thà</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Sguir dheth</translation>
+    </message>
+</context>
+</TS>
+''', encoding='utf-8')
+
+    model = StoreModel(str(path), controller=None)
+
+    assert [str(u.source) for u in model.get_units()] == ['Cancel']


### PR DESCRIPTION
#2088, #3231, and #3263 were all confirmed fixed against current translate-toolkit (one-off verification scripts, closing comments cite the evidence) but none had a permanent test - a future toolkit upgrade regressing any of them would go unnoticed. Adds one test per issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017KayAA91cuhe4xCpDYBg9K