### PR TITLE
fuzz.yml: fix duration_seconds input being passed as a float

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -17,8 +17,8 @@ on:
     inputs:
       duration_seconds:
         description: "How long to fuzz for, per platform (seconds)"
-        type: number
-        default: 600
+        type: string
+        default: "600"
 
 jobs:
   fuzz-linux:


### PR DESCRIPTION
The manual UI-fuzzing workflow run linked from #(n/a) failed immediately:

```
--duration-seconds "600.0"
fuzz_ui.py: error: argument --duration-seconds: invalid int value: '600.0'
```

GitHub Actions serializes `workflow_dispatch` `type: number` inputs as floats internally, so `600` comes back as `"600.0"` even when using the untouched default - a well-documented GitHub Actions quirk, not specific to this workflow. `fuzz_ui.py`'s argparse (`type=int`) rejects that.

Switched `duration_seconds` to `type: string`, which passes through the value literally. Couldn't live-dispatch-test this from a fork branch (`workflow_dispatch` needs the ref being tested to exist in the repo being dispatched against) - the fix is mechanical and the root cause is confirmed directly from the failed run's own error message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017KayAA91cuhe4xCpDYBg9K