### PR TITLE
Add whitespace-handling test fixtures (PO, XLIFF, TMX)

### DIFF
--- a/devsupport/testfiles/generate_whitespace_testfiles.py
+++ b/devsupport/testfiles/generate_whitespace_testfiles.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) Virtaal contributors.
+#
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
+
+"""Regenerates devsupport/testfiles/whitespace.{po,xlf,tmx} from the one
+case list below - run this after editing CASES, don't hand-edit the
+generated files (exotic Unicode space characters are error-prone to
+retype correctly by hand across three formats).
+
+Most cases wrap their probe text in guillemets («»), so a mid-string
+space shows as a visible gap next to the delimiter even though the
+space character itself may be invisible or unusually narrow/wide. The
+leading/trailing cases only get a guillemet on the far end - the
+whitespace under test must be the string's actual first/last
+character (what Virtaal's own leading/trailing-space handling actually
+anchors on), not sit behind a visible delimiter.
+
+Targets are deliberately left untranslated - Alt+Down ("copy source to
+target") is the intended way to populate them while testing, so the
+exact codepoint reaches the target without anyone having to retype an
+invisible or exotic Unicode character by hand.
+"""
+
+import io
+
+from translate.storage import pypo, tmx, xliff
+
+# Every non-ASCII/invisible character below is spelled as an explicit
+# \uXXXX escape, never embedded raw - an embedded NBSP/ZWSP/etc. looks
+# identical to its ASCII lookalike (or to nothing at all) in a plain
+# text view, making this list unreadable and unsafe to hand-edit.
+CASES = [
+    ("leading-space", "U+0020 SPACE, leading", " Leading\u00bb"),
+    ("trailing-space", "U+0020 SPACE, trailing", "\u00abTrailing "),
+    ("double-space", "two U+0020 SPACE in a row, mid-sentence", "\u00abDouble  space\u00bb"),
+    ("nbsp-leading", "U+00A0 NO-BREAK SPACE, leading", "\u00a0NBSP leading\u00bb"),
+    ("nbsp-trailing", "U+00A0 NO-BREAK SPACE, trailing", "\u00abNBSP trailing\u00a0"),
+    ("nbsp-inline", "U+00A0 NO-BREAK SPACE, mid-string (the classic number+unit case)", "\u00ab10\u00a0km\u00bb"),
+    ("en-space", "U+2002 EN SPACE", "\u00abEn\u2002space\u00bb"),
+    ("em-space", "U+2003 EM SPACE", "\u00abEm\u2003space\u00bb"),
+    ("thin-space", "U+2009 THIN SPACE", "\u00abThin\u2009space\u00bb"),
+    ("hair-space", "U+200A HAIR SPACE", "\u00abHair\u200aspace\u00bb"),
+    ("narrow-nbsp", "U+202F NARROW NO-BREAK SPACE", "\u00abNarrow\u202fNBSP\u00bb"),
+    ("figure-space", "U+2007 FIGURE SPACE", "\u00abFigure\u2007space\u00bb"),
+    ("punctuation-space", "U+2008 PUNCTUATION SPACE", "\u00abPunctuation\u2008space\u00bb"),
+    ("ideographic-space", "U+3000 IDEOGRAPHIC SPACE", "\u00abIdeographic\u3000space\u00bb"),
+    ("mathematical-space", "U+205F MEDIUM MATHEMATICAL SPACE", "\u00abMath\u205fspace\u00bb"),
+    ("ogham-space-mark", "U+1680 OGHAM SPACE MARK (has a visible glyph in some fonts, unlike the others here)", "\u00abOgham\u1680mark\u00bb"),
+    ("zwsp-inline", "U+200B ZERO WIDTH SPACE, mid-word - invisible by design. "
+                     "Can't be verified by eye; check with a hex dump/codepoint "
+                     "inspector after saving, not by looking at it.", "\u00abZero\u200bwidth\u00bb"),
+    ("tab-leading", "U+0009 TAB, leading (bonus - not one of the originally requested cases, but a common real one)", "\tTab leading\u00bb"),
+    ("tab-trailing", "U+0009 TAB, trailing (bonus, ditto)", "\u00abTab trailing\t"),
+]
+
+
+def build_po():
+    store = pypo.pofile()
+    for slug, description, text in CASES:
+        unit = store.addsourceunit(text)
+        unit.addlocation(slug)
+        unit.addnote(description, origin="developer")
+    return store
+
+
+def build_xliff():
+    store = xliff.xlifffile()
+    for slug, description, text in CASES:
+        unit = store.addsourceunit(text)
+        unit.addlocation(slug)
+        unit.addnote(description, origin="developer")
+    return store
+
+
+def build_tmx():
+    store = tmx.tmxfile()
+    store.settargetlanguage("en")
+    for slug, description, text in CASES:
+        # tmx units are always translation pairs (no separate
+        # untranslated state) - target mirrors source, since a TM
+        # source viewed in Virtaal is read-only anyway (there's no
+        # Alt+Down workflow to exercise here as there is for PO/XLIFF).
+        store.addsourceunit(text)
+        store.units[-1].target = text
+        store.units[-1].addnote(f"{slug}: {description}", origin="developer")
+    return store
+
+
+def main():
+    for filename, builder in [
+        ("whitespace.po", build_po),
+        ("whitespace.xlf", build_xliff),
+        ("whitespace.tmx", build_tmx),
+    ]:
+        store = builder()
+        buf = io.BytesIO()
+        store.serialize(buf)
+        with open(filename, "wb") as f:
+            f.write(buf.getvalue())
+        print(f"Wrote {filename} ({len(CASES)} cases)")
+
+
+if __name__ == "__main__":
+    main()

--- a/devsupport/testfiles/whitespace.po
+++ b/devsupport/testfiles/whitespace.po
@@ -1,0 +1,108 @@
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-09-12 18:11+0100\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Translate Toolkit 3.19.18\n"
+
+#. U+0020 SPACE, leading
+#: leading-space
+msgid " Leading»"
+msgstr ""
+
+#. U+0020 SPACE, trailing
+#: trailing-space
+msgid "«Trailing "
+msgstr ""
+
+#. two U+0020 SPACE in a row, mid-sentence
+#: double-space
+msgid "«Double  space»"
+msgstr ""
+
+#. U+00A0 NO-BREAK SPACE, leading
+#: nbsp-leading
+msgid " NBSP leading»"
+msgstr ""
+
+#. U+00A0 NO-BREAK SPACE, trailing
+#: nbsp-trailing
+msgid "«NBSP trailing "
+msgstr ""
+
+#. U+00A0 NO-BREAK SPACE, mid-string (the classic number+unit case)
+#: nbsp-inline
+msgid "«10 km»"
+msgstr ""
+
+#. U+2002 EN SPACE
+#: en-space
+msgid "«En space»"
+msgstr ""
+
+#. U+2003 EM SPACE
+#: em-space
+msgid "«Em space»"
+msgstr ""
+
+#. U+2009 THIN SPACE
+#: thin-space
+msgid "«Thin space»"
+msgstr ""
+
+#. U+200A HAIR SPACE
+#: hair-space
+msgid "«Hair space»"
+msgstr ""
+
+#. U+202F NARROW NO-BREAK SPACE
+#: narrow-nbsp
+msgid "«Narrow NBSP»"
+msgstr ""
+
+#. U+2007 FIGURE SPACE
+#: figure-space
+msgid "«Figure space»"
+msgstr ""
+
+#. U+2008 PUNCTUATION SPACE
+#: punctuation-space
+msgid "«Punctuation space»"
+msgstr ""
+
+#. U+3000 IDEOGRAPHIC SPACE
+#: ideographic-space
+msgid "«Ideographic　space»"
+msgstr ""
+
+#. U+205F MEDIUM MATHEMATICAL SPACE
+#: mathematical-space
+msgid "«Math space»"
+msgstr ""
+
+#. U+1680 OGHAM SPACE MARK (has a visible glyph in some fonts, unlike the others here)
+#: ogham-space-mark
+msgid "«Ogham mark»"
+msgstr ""
+
+#. U+200B ZERO WIDTH SPACE, mid-word - invisible by design. Can't be verified by eye; check with a hex dump/codepoint inspector after saving, not by looking at it.
+#: zwsp-inline
+msgid "«Zero​width»"
+msgstr ""
+
+#. U+0009 TAB, leading (bonus - not one of the originally requested cases, but a common real one)
+#: tab-leading
+msgid "\tTab leading»"
+msgstr ""
+
+#. U+0009 TAB, trailing (bonus, ditto)
+#: tab-trailing
+msgid "«Tab trailing\t"
+msgstr ""

--- a/devsupport/testfiles/whitespace.tmx
+++ b/devsupport/testfiles/whitespace.tmx
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE tmx SYSTEM "tmx14.dtd">
+<tmx version="1.4">
+  <header creationtool="Translate Toolkit" creationtoolversion="3.19.18" segtype="sentence" o-tmf="UTF-8" adminlang="en" srclang="en" datatype="PlainText"/>
+  <body>
+    <tu>
+      <note>leading-space: U+0020 SPACE, leading</note>
+      <tuv xml:lang="en">
+        <seg> Leading»</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <note>trailing-space: U+0020 SPACE, trailing</note>
+      <tuv xml:lang="en">
+        <seg>«Trailing </seg>
+      </tuv>
+    </tu>
+    <tu>
+      <note>double-space: two U+0020 SPACE in a row, mid-sentence</note>
+      <tuv xml:lang="en">
+        <seg>«Double  space»</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <note>nbsp-leading: U+00A0 NO-BREAK SPACE, leading</note>
+      <tuv xml:lang="en">
+        <seg> NBSP leading»</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <note>nbsp-trailing: U+00A0 NO-BREAK SPACE, trailing</note>
+      <tuv xml:lang="en">
+        <seg>«NBSP trailing </seg>
+      </tuv>
+    </tu>
+    <tu>
+      <note>nbsp-inline: U+00A0 NO-BREAK SPACE, mid-string (the classic number+unit case)</note>
+      <tuv xml:lang="en">
+        <seg>«10 km»</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <note>en-space: U+2002 EN SPACE</note>
+      <tuv xml:lang="en">
+        <seg>«En space»</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <note>em-space: U+2003 EM SPACE</note>
+      <tuv xml:lang="en">
+        <seg>«Em space»</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <note>thin-space: U+2009 THIN SPACE</note>
+      <tuv xml:lang="en">
+        <seg>«Thin space»</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <note>hair-space: U+200A HAIR SPACE</note>
+      <tuv xml:lang="en">
+        <seg>«Hair space»</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <note>narrow-nbsp: U+202F NARROW NO-BREAK SPACE</note>
+      <tuv xml:lang="en">
+        <seg>«Narrow NBSP»</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <note>figure-space: U+2007 FIGURE SPACE</note>
+      <tuv xml:lang="en">
+        <seg>«Figure space»</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <note>punctuation-space: U+2008 PUNCTUATION SPACE</note>
+      <tuv xml:lang="en">
+        <seg>«Punctuation space»</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <note>ideographic-space: U+3000 IDEOGRAPHIC SPACE</note>
+      <tuv xml:lang="en">
+        <seg>«Ideographic　space»</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <note>mathematical-space: U+205F MEDIUM MATHEMATICAL SPACE</note>
+      <tuv xml:lang="en">
+        <seg>«Math space»</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <note>ogham-space-mark: U+1680 OGHAM SPACE MARK (has a visible glyph in some fonts, unlike the others here)</note>
+      <tuv xml:lang="en">
+        <seg>«Ogham mark»</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <note>zwsp-inline: U+200B ZERO WIDTH SPACE, mid-word - invisible by design. Can't be verified by eye; check with a hex dump/codepoint inspector after saving, not by looking at it.</note>
+      <tuv xml:lang="en">
+        <seg>«Zero​width»</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <note>tab-leading: U+0009 TAB, leading (bonus - not one of the originally requested cases, but a common real one)</note>
+      <tuv xml:lang="en">
+        <seg>	Tab leading»</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <note>tab-trailing: U+0009 TAB, trailing (bonus, ditto)</note>
+      <tuv xml:lang="en">
+        <seg>«Tab trailing	</seg>
+      </tuv>
+    </tu>
+  </body>
+</tmx>

--- a/devsupport/testfiles/whitespace.xlf
+++ b/devsupport/testfiles/whitespace.xlf
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.1" version="1.1">
+  <file original="NoName" source-language="en" datatype="plaintext">
+    <body>
+      <trans-unit xml:space="preserve" id="2">
+        <source> Leading»</source>
+        <context-group name="" purpose="location">
+          <context context-type="sourcefile">leading-space</context>
+        </context-group>
+        <note from="developer">U+0020 SPACE, leading</note>
+      </trans-unit>
+      <trans-unit xml:space="preserve" id="3">
+        <source>«Trailing </source>
+        <context-group name="" purpose="location">
+          <context context-type="sourcefile">trailing-space</context>
+        </context-group>
+        <note from="developer">U+0020 SPACE, trailing</note>
+      </trans-unit>
+      <trans-unit xml:space="preserve" id="4">
+        <source>«Double  space»</source>
+        <context-group name="" purpose="location">
+          <context context-type="sourcefile">double-space</context>
+        </context-group>
+        <note from="developer">two U+0020 SPACE in a row, mid-sentence</note>
+      </trans-unit>
+      <trans-unit xml:space="preserve" id="5">
+        <source> NBSP leading»</source>
+        <context-group name="" purpose="location">
+          <context context-type="sourcefile">nbsp-leading</context>
+        </context-group>
+        <note from="developer">U+00A0 NO-BREAK SPACE, leading</note>
+      </trans-unit>
+      <trans-unit xml:space="preserve" id="6">
+        <source>«NBSP trailing </source>
+        <context-group name="" purpose="location">
+          <context context-type="sourcefile">nbsp-trailing</context>
+        </context-group>
+        <note from="developer">U+00A0 NO-BREAK SPACE, trailing</note>
+      </trans-unit>
+      <trans-unit xml:space="preserve" id="7">
+        <source>«10 km»</source>
+        <context-group name="" purpose="location">
+          <context context-type="sourcefile">nbsp-inline</context>
+        </context-group>
+        <note from="developer">U+00A0 NO-BREAK SPACE, mid-string (the classic number+unit case)</note>
+      </trans-unit>
+      <trans-unit xml:space="preserve" id="8">
+        <source>«En space»</source>
+        <context-group name="" purpose="location">
+          <context context-type="sourcefile">en-space</context>
+        </context-group>
+        <note from="developer">U+2002 EN SPACE</note>
+      </trans-unit>
+      <trans-unit xml:space="preserve" id="9">
+        <source>«Em space»</source>
+        <context-group name="" purpose="location">
+          <context context-type="sourcefile">em-space</context>
+        </context-group>
+        <note from="developer">U+2003 EM SPACE</note>
+      </trans-unit>
+      <trans-unit xml:space="preserve" id="10">
+        <source>«Thin space»</source>
+        <context-group name="" purpose="location">
+          <context context-type="sourcefile">thin-space</context>
+        </context-group>
+        <note from="developer">U+2009 THIN SPACE</note>
+      </trans-unit>
+      <trans-unit xml:space="preserve" id="11">
+        <source>«Hair space»</source>
+        <context-group name="" purpose="location">
+          <context context-type="sourcefile">hair-space</context>
+        </context-group>
+        <note from="developer">U+200A HAIR SPACE</note>
+      </trans-unit>
+      <trans-unit xml:space="preserve" id="12">
+        <source>«Narrow NBSP»</source>
+        <context-group name="" purpose="location">
+          <context context-type="sourcefile">narrow-nbsp</context>
+        </context-group>
+        <note from="developer">U+202F NARROW NO-BREAK SPACE</note>
+      </trans-unit>
+      <trans-unit xml:space="preserve" id="13">
+        <source>«Figure space»</source>
+        <context-group name="" purpose="location">
+          <context context-type="sourcefile">figure-space</context>
+        </context-group>
+        <note from="developer">U+2007 FIGURE SPACE</note>
+      </trans-unit>
+      <trans-unit xml:space="preserve" id="14">
+        <source>«Punctuation space»</source>
+        <context-group name="" purpose="location">
+          <context context-type="sourcefile">punctuation-space</context>
+        </context-group>
+        <note from="developer">U+2008 PUNCTUATION SPACE</note>
+      </trans-unit>
+      <trans-unit xml:space="preserve" id="15">
+        <source>«Ideographic　space»</source>
+        <context-group name="" purpose="location">
+          <context context-type="sourcefile">ideographic-space</context>
+        </context-group>
+        <note from="developer">U+3000 IDEOGRAPHIC SPACE</note>
+      </trans-unit>
+      <trans-unit xml:space="preserve" id="16">
+        <source>«Math space»</source>
+        <context-group name="" purpose="location">
+          <context context-type="sourcefile">mathematical-space</context>
+        </context-group>
+        <note from="developer">U+205F MEDIUM MATHEMATICAL SPACE</note>
+      </trans-unit>
+      <trans-unit xml:space="preserve" id="17">
+        <source>«Ogham mark»</source>
+        <context-group name="" purpose="location">
+          <context context-type="sourcefile">ogham-space-mark</context>
+        </context-group>
+        <note from="developer">U+1680 OGHAM SPACE MARK (has a visible glyph in some fonts, unlike the others here)</note>
+      </trans-unit>
+      <trans-unit xml:space="preserve" id="18">
+        <source>«Zero​width»</source>
+        <context-group name="" purpose="location">
+          <context context-type="sourcefile">zwsp-inline</context>
+        </context-group>
+        <note from="developer">U+200B ZERO WIDTH SPACE, mid-word - invisible by design. Can't be verified by eye; check with a hex dump/codepoint inspector after saving, not by looking at it.</note>
+      </trans-unit>
+      <trans-unit xml:space="preserve" id="19">
+        <source>	Tab leading»</source>
+        <context-group name="" purpose="location">
+          <context context-type="sourcefile">tab-leading</context>
+        </context-group>
+        <note from="developer">U+0009 TAB, leading (bonus - not one of the originally requested cases, but a common real one)</note>
+      </trans-unit>
+      <trans-unit xml:space="preserve" id="20">
+        <source>«Tab trailing	</source>
+        <context-group name="" purpose="location">
+          <context context-type="sourcefile">tab-trailing</context>
+        </context-group>
+        <note from="developer">U+0009 TAB, trailing (bonus, ditto)</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>


### PR DESCRIPTION
Manual test fixtures for whitespace handling - leading/trailing space, doubled internal space, NBSP, ten other Unicode space-separator characters, ZWSP, and (bonus) leading/trailing tabs.

Generated from one case list (`generate_whitespace_testfiles.py`) rather than hand-writing the same exotic Unicode three times across formats - verified each case round-trips correctly through all three formats' real serializers, and through `StoreModel` itself.

Note for whoever picks these up: Virtaal's own "flag double/leading/trailing spaces" placeable (`SpacesPlaceable` in translate-toolkit) is wired up but commented out in `placeablescontroller.py`, marked "not working well yet" - these fixtures don't currently trigger any visual highlighting in the app, they test storage/round-trip correctness. Worth a fresh look at re-enabling it now, separately from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017KayAA91cuhe4xCpDYBg9K