### PR TITLE
Only enable Cut/Copy when there's an actual selection

### DIFF
--- a/virtaal/test/test_unitcontroller.py
+++ b/virtaal/test/test_unitcontroller.py
@@ -35,6 +35,59 @@ class TestUnitController(TestScaffolding):
         self.unit_controller.set_unit_target(0, ['Test',])
         assert str(self.unit_controller.view.targets[0].elem) == 'Test'
 
+    def test_cut_copy_disabled_without_a_selection(self, monkeypatch):
+        # #1021: Cut/Copy used to stay enabled the whole time a textbox
+        # had focus, regardless of whether anything was selected.
+        test_unit = self.trans_store.getunits()[1]
+        view = self.unit_controller.load_unit(test_unit)
+        monkeypatch.setattr(view.targets[0], 'is_focus', lambda: True)
+
+        view._update_edit_menu_sensitivity()
+
+        assert not view.mnu_cut.get_sensitive()
+        assert not view.mnu_copy.get_sensitive()
+        assert view.mnu_paste.get_sensitive()  # no selection needed to paste
+
+    def test_cut_copy_enabled_with_a_selection_in_the_target(self, monkeypatch):
+        if not getattr(self.main_controller, 'placeables_controller', None):
+            PlaceablesController(self.main_controller)
+
+        test_unit = self.trans_store.getunits()[1]
+        view = self.unit_controller.load_unit(test_unit)
+        target = view.targets[0]
+        target.set_text('some text')
+        buf = target.get_buffer()
+        buf.select_range(buf.get_start_iter(), buf.get_end_iter())
+        monkeypatch.setattr(target, 'is_focus', lambda: True)
+
+        view._update_edit_menu_sensitivity()
+
+        assert view.mnu_cut.get_sensitive()
+        assert view.mnu_copy.get_sensitive()
+
+    def test_copy_but_not_cut_enabled_for_a_selection_in_a_source(self, monkeypatch):
+        # Sources aren't editable - Cut never applies to them, even
+        # with text selected.
+        if not getattr(self.main_controller, 'placeables_controller', None):
+            PlaceablesController(self.main_controller)
+
+        # A different unit than the other tests here use - load_unit()
+        # no-ops if asked to reload whatever's already showing, which
+        # would leave a stale/empty source buffer since these tests
+        # share one UnitController across the whole class.
+        test_unit = self.trans_store.getunits()[2]
+        view = self.unit_controller.load_unit(test_unit)
+        source = view.sources[0]
+        buf = source.get_buffer()
+        buf.select_range(buf.get_start_iter(), buf.get_end_iter())
+        monkeypatch.setattr(source, 'is_focus', lambda: True)
+
+        view._update_edit_menu_sensitivity()
+
+        assert not view.mnu_cut.get_sensitive()
+        assert view.mnu_copy.get_sensitive()
+        assert not view.mnu_paste.get_sensitive()  # can't paste into a source
+
     def test_stale_alt_down_does_not_corrupt_a_later_unit(self):
         """Alt+Down ('transfer from source') defers its copy via
         GLib.idle_add(). If the loaded unit changes before that runs,

--- a/virtaal/views/unitview.py
+++ b/virtaal/views/unitview.py
@@ -180,9 +180,7 @@ class UnitView(Gtk.EventBox, GObjectWrapper, Gtk.CellEditable, BaseView):
             mnu_next.set_sensitive(True)
             mnu_prev.set_sensitive(True)
             mnu_transfer.set_sensitive(True)
-            self.mnu_cut.set_sensitive(True)
-            self.mnu_copy.set_sensitive(True)
-            self.mnu_paste.set_sensitive(True)
+            self._update_edit_menu_sensitivity()
         self.controller.main_controller.store_controller.connect('store-closed', on_store_closed)
         self.controller.main_controller.store_controller.connect('store-loaded', on_store_loaded)
 
@@ -469,6 +467,8 @@ class UnitView(Gtk.EventBox, GObjectWrapper, Gtk.CellEditable, BaseView):
         textbox.set_text(text or '')
         textbox.connect('focus-in-event', self._on_textbox_focused)
         textbox.connect('focus-out-event', self._on_textbox_unfocused)
+        textbox.get_buffer().connect(
+            'notify::has-selection', lambda *args: self._update_edit_menu_sensitivity())
 
         scrollwnd = Gtk.ScrolledWindow()
         scrollwnd.set_policy(Gtk.PolicyType.NEVER, scroll_policy)
@@ -735,9 +735,28 @@ class UnitView(Gtk.EventBox, GObjectWrapper, Gtk.CellEditable, BaseView):
         self.emit('paste-start', old_text, offsets, target_num)
 
     def _on_textbox_focused(self, textbox, event):
-        for mnu in (self.mnu_cut, self.mnu_copy, self.mnu_paste):
-            mnu.set_sensitive(True)
+        self._update_edit_menu_sensitivity()
 
     def _on_textbox_unfocused(self, textbox, event):
-        for mnu in (self.mnu_cut, self.mnu_copy, self.mnu_paste):
-            mnu.set_sensitive(False)
+        self._update_edit_menu_sensitivity()
+
+    def _update_edit_menu_sensitivity(self):
+        """Recompute Cut/Copy/Paste sensitivity for whichever textbox
+            is currently focused, if any."""
+        focused = None
+        for textbox in self.targets + self.sources:
+            if textbox.is_focus():
+                focused = textbox
+                break
+
+        if focused is None:
+            self.mnu_cut.set_sensitive(False)
+            self.mnu_copy.set_sensitive(False)
+            self.mnu_paste.set_sensitive(False)
+            return
+
+        has_selection = focused.get_buffer().get_has_selection()
+        is_target = focused in self.targets
+        self.mnu_cut.set_sensitive(is_target and has_selection)
+        self.mnu_copy.set_sensitive(has_selection)
+        self.mnu_paste.set_sensitive(is_target)


### PR DESCRIPTION
Fixes #1021.

Cut/Copy sensitivity was tied purely to whether a textbox had focus, never to whether anything was actually selected in it - confirmed still true against current code, and confirmed against Collabora Office that real editors disable Cut/Copy without a selection while leaving Paste alone (Paste needs no precondition to attempt).

Hooks `GtkTextBuffer`'s `notify::has-selection` (fires on every selection/deselection) alongside the existing focus tracking, recomputing all three menu items' sensitivity from scratch each time:
- Cut: focused textbox is a target, and has a selection.
- Copy: focused textbox (target or source) has a selection.
- Paste: focused textbox is a target (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017KayAA91cuhe4xCpDYBg9K