### PR TITLE
Add tests + a manual test file for initial cursor placement (#1841)

### DIFF
--- a/devsupport/testfiles/cursor-placement.po
+++ b/devsupport/testfiles/cursor-placement.po
@@ -1,0 +1,49 @@
+# Manual test file for initial cursor placement (translate/virtaal#1841).
+#
+# Each unit below is pre-filled and marked fuzzy, mirroring the real
+# scenario this matters for (a fuzzy match or an existing translation
+# a translator is revising) - an empty/untranslated unit always starts
+# the cursor at position 0, nothing interesting to check there.
+#
+# Open each unit in Virtaal and check where the cursor lands
+# automatically, without clicking anywhere - it should skip past
+# leading non-editable content (a newline, an XML tag, a recognised
+# %-style placeholder) onto the first real translatable text, not land
+# inside the non-editable part.
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+
+#. Expect: cursor after the newline, at the start of "A new paragraph".
+#, fuzzy
+msgid "\nA new paragraph"
+msgstr "\nA new paragraph"
+
+#. Expect: cursor after <b>, at the start of "bold text".
+#, fuzzy
+msgid "<b>bold text</b>"
+msgstr "<b>bold text</b>"
+
+#. Expect: cursor at the very end - the whole string is the tag, nothing to edit before it.
+#, fuzzy
+msgid "<b>"
+msgstr "<b>"
+
+#. Expect: cursor after %s, at the start of " files copied".
+#, fuzzy
+msgid "%s files copied"
+msgstr "%s files copied"
+
+#. Expect: cursor after %1, at the start of " of ".
+#, fuzzy
+msgid "%1 of %2 files copied"
+msgstr "%1 of %2 files copied"
+
+#. Known gap, not fixed here: %B isn't a real Python or Qt format
+#. specifier, so it isn't recognised as a placeable at all - expect
+#. the cursor to land between % and B (mid-token), not after the
+#. whole "%B". This is %B not being a valid placeholder, not a bug in
+#. the cursor-placement logic itself.
+#, fuzzy
+msgid "%B is not a real format specifier"
+msgstr "%B is not a real format specifier"

--- a/virtaal/test/test_unitcontroller.py
+++ b/virtaal/test/test_unitcontroller.py
@@ -88,6 +88,51 @@ class TestUnitController(TestScaffolding):
         assert view.mnu_copy.get_sensitive()
         assert not view.mnu_paste.get_sensitive()  # can't paste into a source
 
+    def _assert_initial_cursor_position(self, text, expected_marked):
+        """expected_marked is text with a '|' inserted at the offset
+        _get_editing_start_pos() is expected to place the cursor at."""
+        if not getattr(self.main_controller, 'placeables_controller', None):
+            PlaceablesController(self.main_controller)
+
+        test_unit = self.trans_store.getunits()[1]
+        view = self.unit_controller.load_unit(test_unit)
+        target = view.targets[0]
+        target.set_text(text)
+
+        pos = view._get_editing_start_pos(target.elem)
+
+        assert text[:pos] + '|' + text[pos:] == expected_marked
+
+    def test_initial_cursor_skips_a_leading_newline(self):
+        # translate/virtaal#1841
+        self._assert_initial_cursor_position("\nSome text", "\n|Some text")
+
+    def test_initial_cursor_skips_a_leading_xml_tag(self):
+        # translate/virtaal#1841
+        self._assert_initial_cursor_position("<b>bold</b>", "<b>|bold</b>")
+
+    def test_initial_cursor_goes_to_the_end_after_a_lone_xml_tag(self):
+        self._assert_initial_cursor_position("<b>", "<b>|")
+
+    def test_initial_cursor_skips_a_recognised_python_format_specifier(self):
+        # translate/virtaal#1841
+        self._assert_initial_cursor_position("%s files copied", "%s| files copied")
+
+    def test_initial_cursor_skips_a_recognised_qt_format_specifier(self):
+        self._assert_initial_cursor_position("%1 files copied", "%1| files copied")
+
+    def test_initial_cursor_goes_to_the_end_when_the_whole_string_is_a_placeable(self):
+        self._assert_initial_cursor_position("%s", "%s|")
+
+    def test_initial_cursor_lands_mid_token_for_an_unrecognised_percent_sequence(self):
+        """#1841's reported "%B" case: %B isn't a valid Python or Qt
+        format specifier, so translate-toolkit doesn't recognise it as
+        a placeable at all - it's just punctuation followed by a word
+        character, and the cursor lands between them. Documenting the
+        actual (still slightly awkward) behaviour, not asserting it's
+        fixed - it isn't, and it isn't a bug in this function either."""
+        self._assert_initial_cursor_position("%B", "%|B")
+
     def test_stale_alt_down_does_not_corrupt_a_later_unit(self):
         """Alt+Down ('transfer from source') defers its copy via
         GLib.idle_add(). If the loaded unit changes before that runs,


### PR DESCRIPTION
Reviewed #1841 - all 4 reported cases traced through the real `StoreModel` -> `UnitView` pipeline, not just reasoned about.

Result: 3 of the 4 already work correctly today -
- A leading newline: cursor lands right after it, at the start of the real text.
- A leading XML tag (`<b>`): cursor lands right after the tag.
- A recognised `%`-style placeholder (Python's `%s`/`%d`/`%(name)s`, Qt's `%1`/`%2`): cursor lands right after it.

The 4th (`%B`) still lands the cursor mid-token (between `%` and `B`) - but `%B` isn't a valid Python or Qt format specifier, so translate-toolkit never recognises it as a placeable at all. Not a bug in `_get_editing_start_pos()`; `%B` just isn't a real placeholder to skip over.

Adds regression tests locking in the working cases and documenting the `%B` behaviour, plus `devsupport/testfiles/cursor-placement.po` - fuzzy units covering each case, for anyone who wants to eyeball it directly in the running app rather than take the tests' word for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017KayAA91cuhe4xCpDYBg9K