### PR TITLE
Keep the fuzzy row colour visible when the row is selected

### DIFF
--- a/virtaal/test/test_unitcontroller.py
+++ b/virtaal/test/test_unitcontroller.py
@@ -160,6 +160,44 @@ class TestUnitController(TestScaffolding):
         assert test_unit.get_state_id() == before, \
             "advance_workflow_state() alone shouldn't persist to the real unit yet"
 
+    def test_loading_a_fuzzy_unit_colours_the_editor_background(self, monkeypatch):
+        # The row being actively edited is drawn by UnitView itself, not
+        # StoreCellRenderer.do_render() - #3321's fix doesn't reach it.
+        # Uses a fresh, isolated unit rather than this fixture's shared
+        # ones - pypo.pounit.set_state_n() force-clears fuzzy on a unit
+        # with an empty target, and this class's other tests leave the
+        # shared units' target content in whatever state they last set
+        # it to, which markfuzzy() alone can't reliably override here.
+        from translate.storage import pypo
+        fuzzy_unit = pypo.pofile().addsourceunit("Fuzzy test string")
+        fuzzy_unit.target = "Fuzzy test string, translated"
+        fuzzy_unit.markfuzzy(True)
+        fuzzy_unit._modified = False  # normally set by UnitController.load_unit(), bypassed here
+        assert fuzzy_unit.isfuzzy()
+
+        other_unit = self.trans_store.getunits()[2]
+        self.unit_controller.load_unit(other_unit)  # a real reload below, not a same-unit no-op
+        view = self.unit_controller.view
+        calls = []
+        monkeypatch.setattr(view, 'override_background_color', lambda state, color: calls.append(color))
+
+        view.load_unit(fuzzy_unit)
+
+        assert calls and calls[-1] is not None
+
+    def test_loading_a_non_fuzzy_unit_clears_the_editor_background(self, monkeypatch):
+        units = self.trans_store.getunits()
+        plain_unit, other_unit = units[1], units[2]
+        assert not plain_unit.isfuzzy()
+        self.unit_controller.load_unit(other_unit)
+        view = self.unit_controller.view
+        calls = []
+        monkeypatch.setattr(view, 'override_background_color', lambda state, color: calls.append(color))
+
+        self.unit_controller.load_unit(plain_unit)
+
+        assert calls and calls[-1] is None
+
     def test_stale_alt_down_does_not_corrupt_a_later_unit(self):
         """Alt+Down ('transfer from source') defers its copy via
         GLib.idle_add(). If the loaded unit changes before that runs,

--- a/virtaal/views/unitview.py
+++ b/virtaal/views/unitview.py
@@ -17,6 +17,7 @@ from virtaal.common import GObjectWrapper
 
 from . import rendering
 from .baseview import BaseView
+from .theme import current_theme, str_to_rgba
 from .widgets.listnav import ListNavigator
 from .widgets.textbox import TextBox
 
@@ -282,6 +283,10 @@ class UnitView(Gtk.EventBox, GObjectWrapper, Gtk.CellEditable, BaseView):
             src.select_elem(elem=None)
 
         self.unit = unit
+        if unit.isfuzzy():
+            self.override_background_color(Gtk.StateFlags.NORMAL, str_to_rgba(current_theme['fuzzy_row_bg']))
+        else:
+            self.override_background_color(Gtk.StateFlags.NORMAL, None)
         self.disable_signals(['modified', 'insert-text', 'delete-text'])
         self._update_editor_gui()
         self.enable_signals(['modified', 'insert-text', 'delete-text'])

--- a/virtaal/views/widgets/storecellrenderer.py
+++ b/virtaal/views/widgets/storecellrenderer.py
@@ -12,7 +12,7 @@ from translate.lang import factory
 
 from virtaal.common import pan_app
 from virtaal.views import markup, rendering
-from virtaal.views.theme import current_theme
+from virtaal.views.theme import current_theme, str_to_rgba
 
 
 @functools.singledispatch
@@ -223,9 +223,29 @@ class StoreCellRenderer(Gtk.CellRenderer):
             self._editor_modified_id = editor.connect("modified", self._on_modified)
         return editor
 
-    def do_render(self, window, widget, _background_area, cell_area, _flags):
+    def _paint_fuzzy_background_if_selected(self, cr, background_area, flags):
+        """GTK only honours cell_background while a row isn't selected -
+            the theme's own selection highlight otherwise unconditionally
+            replaces it, hiding the fuzzy indicator on exactly the rows a
+            translator is most likely to have selected."""
+        if self.unit is None or not self.unit.isfuzzy():
+            return
+        if not flags & Gtk.CellRendererState.SELECTED:
+            return
+
+        rgba = str_to_rgba(current_theme['fuzzy_row_bg'])
+        cr.save()
+        cr.set_source_rgba(rgba.red, rgba.green, rgba.blue, rgba.alpha)
+        cr.rectangle(background_area.x, background_area.y, background_area.width, background_area.height)
+        cr.fill()
+        cr.restore()
+
+    def do_render(self, window, widget, background_area, cell_area, flags):
         if self.editable:
             return True
+
+        self._paint_fuzzy_background_if_selected(window, background_area, flags)
+
         x_offset, y_offset, width, _height = self.do_get_size(widget, cell_area)
         x = cell_area.x + x_offset
         y = cell_area.y + y_offset

--- a/virtaal/views/widgets/test_storecellrenderer.py
+++ b/virtaal/views/widgets/test_storecellrenderer.py
@@ -5,10 +5,16 @@
 # later license. See the LICENSE file for a copy of the license and
 # the AUTHORS.md file for copyright and authorship information.
 
+from types import SimpleNamespace
+
+import cairo
 import pytest
 from gi.repository import Gtk
 
-from virtaal.views.widgets.storecellrenderer import compute_optimal_height
+from virtaal.views.widgets.storecellrenderer import (
+    StoreCellRenderer,
+    compute_optimal_height,
+)
 
 
 def test_compute_optimal_height_unregistered_type_raises():
@@ -46,3 +52,38 @@ def test_compute_optimal_height_container_skips_invisible_children():
 
     assert visible_label.get_size_request()[0] == 200
     assert hidden_label.get_size_request() == (-1, -1)
+
+
+def _rectangle(width=10, height=10):
+    return SimpleNamespace(x=0, y=0, width=width, height=height)
+
+
+def _blank_pixel(fuzzy, flags):
+    """Paint into a fresh transparent surface and return its first
+    pixel - non-zero means something was actually painted there."""
+    renderer = StoreCellRenderer(None)
+    renderer.unit = SimpleNamespace(isfuzzy=lambda: fuzzy)
+    surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, 10, 10)
+    cr = cairo.Context(surface)
+
+    renderer._paint_fuzzy_background_if_selected(cr, _rectangle(), flags)
+
+    surface.flush()
+    return bytes(surface.get_data()[:4])
+
+
+def test_paints_fuzzy_background_when_selected():
+    # GTK only honours cell_background while a row isn't selected - the
+    # selection highlight otherwise unconditionally replaces it,
+    # hiding the fuzzy indicator on exactly the rows a translator is
+    # most likely to have selected (#3321).
+    assert _blank_pixel(fuzzy=True, flags=Gtk.CellRendererState.SELECTED) != b'\x00\x00\x00\x00'
+
+
+def test_does_not_paint_when_not_selected():
+    # GTK's own cell_background already handles this case correctly.
+    assert _blank_pixel(fuzzy=True, flags=Gtk.CellRendererState(0)) == b'\x00\x00\x00\x00'
+
+
+def test_does_not_paint_a_selected_non_fuzzy_row():
+    assert _blank_pixel(fuzzy=False, flags=Gtk.CellRendererState.SELECTED) == b'\x00\x00\x00\x00'


### PR DESCRIPTION
Fixes #3321. Flagged live in Mac dark mode (fuzzy rows invisible), but confirmed the same root cause applies regardless of theme.

GTK only honours `cell_background` while a row isn't selected - the theme's own selection highlight otherwise unconditionally replaces it. Since fuzzy rows are exactly the ones a translator navigates to and selects (Ctrl+Up/Down, Incomplete mode, or just the first unit in a freshly-opened file), this hits constantly - not a dark-mode-specific bug, just far more noticeable there since a plain selection highlight and a missing fuzzy indicator both look like "nothing special here."

Confirmed live that the underlying light/dark theme switch itself works correctly (`theme.update_style()` does switch `current_theme` to the dark palette when `gtk-application-prefer-dark-theme` is set, verified directly) - the bug is specifically the selection-overrides-cell_background behaviour, not theme detection.

Fix: `do_render()` now explicitly repaints the fuzzy background itself when the row is both fuzzy and selected, since GTK's own machinery won't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017KayAA91cuhe4xCpDYBg9K