### PR TITLE
Discard autoterm responses that don't parse as terminology

### DIFF
--- a/virtaal/plugins/terminology/models/autoterm.py
+++ b/virtaal/plugins/terminology/models/autoterm.py
@@ -178,6 +178,21 @@ class TerminologyModel(BaseTerminologyModel):
             pass
         return None
 
+    def _parses_as(self, content, ext):
+        """A captive-portal/signon network responds with its own login
+        page instead of the real file, but still with a normal 200
+        status - check the response actually parses as the format
+        we're about to save it as before trusting it."""
+        from io import BytesIO
+
+        buf = BytesIO(content)
+        buf.name = 'dummy.%s' % (ext)
+        try:
+            factory.getobject(buf)
+        except Exception:
+            return False
+        return True
+
     def _process_header(self, request, result, localfile=None):
         if request.status == 304:
             logging.debug('ETag matches for file %s :)' % (localfile))
@@ -191,6 +206,14 @@ class TerminologyModel(BaseTerminologyModel):
                     ext = 'po'
                 localfile = self._get_curr_term_filename(ext=ext)
                 localfile = os.path.join(self.TERMDIR, localfile)
+            else:
+                ext = os.path.splitext(localfile)[1].lstrip(os.extsep)
+
+            if not self._parses_as(result, ext):
+                logging.debug('Response for %s does not parse as %s - discarding' % (localfile, ext))
+                self.init_matcher(localfile if os.path.isfile(localfile) else '')
+                return
+
             logging.debug('Saving to %s' % (localfile))
             # result is real bytes - 'wb' preserves it exactly.
             open(localfile, 'wb').write(result)

--- a/virtaal/plugins/terminology/models/test_autoterm.py
+++ b/virtaal/plugins/terminology/models/test_autoterm.py
@@ -1,0 +1,69 @@
+#
+# Copyright (C) Virtaal contributors.
+#
+# This file is part of Virtaal. It is distributed under the GPL2 or
+# later license. See the LICENSE file for a copy of the license and
+# the AUTHORS.md file for copyright and authorship information.
+
+import io
+import os
+
+from virtaal.plugins.terminology.models.autoterm import TerminologyModel
+
+GOOD_PO = b'''msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\\n"
+
+msgid "Hello"
+msgstr "Bonjour"
+'''
+
+# A captive-portal/signon page: served with a normal 200 status, but
+# not the terminology file it claims to be.
+SIGNON_PAGE = b'<html><body>Please log in to continue</body></html>'
+
+
+class _FakeRequest:
+    status = 200
+
+    def __init__(self, headers=b'ETag: "abc123"\r\n'):
+        self.result_headers = io.BytesIO(headers)
+
+
+def _fake_self():
+    fake_self = TerminologyModel.__new__(TerminologyModel)
+    fake_self.config = {}
+    fake_self.matcher = None
+    return fake_self
+
+
+def test_process_header_saves_a_parseable_response(tmp_path):
+    fake_self = _fake_self()
+    localfile = os.path.join(str(tmp_path), 'en__fr.po')
+
+    TerminologyModel._process_header(fake_self, _FakeRequest(), GOOD_PO, localfile=localfile)
+
+    assert os.path.isfile(localfile)
+    assert open(localfile, 'rb').read() == GOOD_PO
+
+
+def test_process_header_discards_an_unparseable_response(tmp_path):
+    # #1503: a signon network's login page used to get saved and
+    # cached as if it were the real terminology file.
+    fake_self = _fake_self()
+    localfile = os.path.join(str(tmp_path), 'en__fr.po')
+
+    TerminologyModel._process_header(fake_self, _FakeRequest(), SIGNON_PAGE, localfile=localfile)
+
+    assert not os.path.isfile(localfile)
+    assert fake_self.config == {}
+
+
+def test_process_header_keeps_a_previously_cached_file_on_bad_response(tmp_path):
+    fake_self = _fake_self()
+    localfile = os.path.join(str(tmp_path), 'en__fr.po')
+    open(localfile, 'wb').write(GOOD_PO)
+
+    TerminologyModel._process_header(fake_self, _FakeRequest(), SIGNON_PAGE, localfile=localfile)
+
+    assert open(localfile, 'rb').read() == GOOD_PO


### PR DESCRIPTION
Fixes #1503.

A captive-portal/signon network responds with its own login page instead of the real file, but still with a normal 200 status. autoterm saved and cached that unconditionally, then failed to parse it on every subsequent launch until the 3-day cache expired.

Validate the response parses as the format it's about to be saved as before writing it to disk; on failure, keep whatever was previously cached instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017KayAA91cuhe4xCpDYBg9K