### PR TITLE
Skip XML comment nodes when loading autocorrect data

### DIFF
--- a/virtaal/plugins/autocorrector.py
+++ b/virtaal/plugins/autocorrector.py
@@ -130,13 +130,14 @@ class AutoCorrector:
 
         from lxml import etree
         xml = etree.fromstring(xml_bytes)
-        # Sample element from DocumentList.xml (it has no root element!):
+        # Sample element from DocumentList.xml:
         #   <block-list:block block-list:abbreviated-name="teh" block-list:name="the"/>  # codespell:ignore teh
-        # This means that xml.iterchildren() will return an iterator over all
-        # of <block-list> elements and entry.values() will return a 2-tuple
-        # with the values of the "abbreviated-name" and "name" attributes.
-        # That is how I got to the simple line below.
-        self.correctiondict = dict([entry.values() for entry in xml.iterchildren()])
+        # entry.values() returns a 2-tuple of the "abbreviated-name" and
+        # "name" attributes. Several real DocumentList.xml files (e.g.
+        # "ca"'s) also have license-header XML comments as top-level
+        # children - iterchildren(etree.Element) excludes those, since
+        # a comment's own .values() is always empty.
+        self.correctiondict = dict([entry.values() for entry in xml.iterchildren(etree.Element)])
 
         # Add auto-correction regex for each loaded word.
         for key, value in self.correctiondict.items():

--- a/virtaal/plugins/test_autocorrector.py
+++ b/virtaal/plugins/test_autocorrector.py
@@ -37,6 +37,23 @@ def test_load_dictionary_reads_the_exact_locale_directory(tmp_path):
     assert corrector.correctiondict['adt'][0] == 'dat'
 
 
+def test_load_dictionary_skips_leading_comments(tmp_path):
+    # "ca"'s real DocumentList.xml (and others) have license-header XML
+    # comments as top-level children, alongside the real block entries.
+    content = b"""<?xml version="1.0" encoding="utf-8"?>
+<block-list:block-list xmlns:block-list="http://openoffice.org/2001/block-list">
+<!-- license header -->
+  <block-list:block block-list:abbreviated-name="adt" block-list:name="dat"/>
+</block-list:block-list>
+"""
+    _write_document_list(tmp_path, 'af_ZA', content=content)
+    corrector = AutoCorrector(main_controller=None, acorpath=str(tmp_path))
+
+    corrector.load_dictionary('af_ZA')  # must not raise
+
+    assert corrector.correctiondict['adt'][0] == 'dat'
+
+
 def test_load_dictionary_accepts_hyphenated_input(tmp_path):
     _write_document_list(tmp_path, 'af_ZA')
     corrector = AutoCorrector(main_controller=None, acorpath=str(tmp_path))


### PR DESCRIPTION
Several real LibreOffice `DocumentList.xml` files (e.g. "ca"'s) have license-header XML comments as top-level children alongside the real entries. Building the correction dict from every child, not just real elements, crashed:

```
ValueError: dictionary update sequence element #0 has length 0; 2 is required
```

Live traceback (Windows, Virtaal 1.0.0-beta1):
```
File "virtaal\support\autocorrect_downloader.py", line 70, in _on_document_list
File "virtaal\plugins\autocorrector.py", line 274, in on_done
File "virtaal\plugins\autocorrector.py", line 139, in load_dictionary
ValueError: dictionary update sequence element #0 has length 0; 2 is required
```

Filters `iterchildren()` to real elements only. Unrelated to autoterm's response-validation issue (#1503, PR #3508) - this crash happens on a correctly-downloaded, genuinely valid file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017KayAA91cuhe4xCpDYBg9K