### PR TITLE
Fix two gaps in automatic spell-check dictionary downloads

### DIFF
--- a/virtaal/support/dictionary_download_watcher.py
+++ b/virtaal/support/dictionary_download_watcher.py
@@ -36,8 +36,10 @@ class DictionaryDownloadWatcher:
         self._downloader_factory = downloader_factory or DictionaryDownloader
         self._tried = set()
         if self._enchant is not None:
-            main_controller.lang_controller.connect(
-                'target-lang-changed', self._on_target_lang_changed)
+            lang_controller = main_controller.lang_controller
+            lang_controller.connect('target-lang-changed', self._on_target_lang_changed)
+            if lang_controller.target_lang:
+                self._on_target_lang_changed(lang_controller, lang_controller.target_lang.code)
 
     def _has_dictionary(self, language):
         if self._enchant.dict_exists(language):

--- a/virtaal/support/dictionary_downloader.py
+++ b/virtaal/support/dictionary_downloader.py
@@ -94,12 +94,16 @@ class DictionaryDownloader:
         )
 
     def _on_file(self, filename, result):
-        target_dir = self.target_dir or dictionary_write_dir()
-        os.makedirs(target_dir, exist_ok=True)
-        dest = os.path.join(target_dir, filename)
-        with open(dest, 'wb') as f:
-            f.write(result)
-        self._written.append(dest)
+        try:
+            target_dir = self.target_dir or dictionary_write_dir()
+            os.makedirs(target_dir, exist_ok=True)
+            dest = os.path.join(target_dir, filename)
+            with open(dest, 'wb') as f:
+                f.write(result)
+            self._written.append(dest)
+        except Exception as e:
+            logging.debug('dictionary download: could not write %s: %s', filename, e)
+            return self._on_file_error(filename, None)
         self._fetch_next_file()
 
     def _on_file_error(self, filename, status):

--- a/virtaal/support/dictionary_downloader.py
+++ b/virtaal/support/dictionary_downloader.py
@@ -28,6 +28,7 @@ from virtaal.support.dictionary_source import (
     candidate_folders,
     dictionary_write_dir,
     list_dictionary_folders,
+    locale_covers,
     parse_dictionaries_xcu,
 )
 
@@ -75,7 +76,7 @@ class DictionaryDownloader:
 
     def _on_xcu(self, _request, result):
         for entry in parse_dictionaries_xcu(result):
-            if self.locale_code in entry['locales']:
+            if locale_covers(self.locale_code, entry['locales']):
                 self._files = list(entry['files'])
                 return self._fetch_next_file()
         self._try_next_folder()

--- a/virtaal/support/dictionary_source.py
+++ b/virtaal/support/dictionary_source.py
@@ -126,6 +126,21 @@ def candidate_folders(locale_code, known_folders):
     return seen
 
 
+def _locale_covers(locale_code, entry_locales):
+    """True if locale_code is covered by entry_locales (a dictionary's
+    own advertised locale list, already underscore-normalised).
+
+    Checks for an exact match first. If locale_code has no region of
+    its own ("ca", not "ca_ES"), also matches any of that language's
+    regional variants - some real dictionaries (e.g. "ca"'s) only ever
+    list regional variants, never the bare language."""
+    if locale_code in entry_locales:
+        return True
+    if '_' not in locale_code:
+        return any(loc.startswith(locale_code + '_') for loc in entry_locales)
+    return False
+
+
 def find_dictionary(locale_code, folders, fetch_xcu):
     """Find the HunSpellDic_* entry covering locale_code.
 
@@ -143,7 +158,7 @@ def find_dictionary(locale_code, folders, fetch_xcu):
     ordered += [f for f in folders if f not in ordered]
     for folder in ordered:
         for entry in parse_dictionaries_xcu(fetch_xcu(folder)):
-            if locale_code in entry['locales']:
+            if _locale_covers(locale_code, entry['locales']):
                 return folder, entry['files']
     return None
 

--- a/virtaal/support/dictionary_source.py
+++ b/virtaal/support/dictionary_source.py
@@ -126,7 +126,7 @@ def candidate_folders(locale_code, known_folders):
     return seen
 
 
-def _locale_covers(locale_code, entry_locales):
+def locale_covers(locale_code, entry_locales):
     """True if locale_code is covered by entry_locales (a dictionary's
     own advertised locale list, already underscore-normalised).
 
@@ -158,7 +158,7 @@ def find_dictionary(locale_code, folders, fetch_xcu):
     ordered += [f for f in folders if f not in ordered]
     for folder in ordered:
         for entry in parse_dictionaries_xcu(fetch_xcu(folder)):
-            if _locale_covers(locale_code, entry['locales']):
+            if locale_covers(locale_code, entry['locales']):
                 return folder, entry['files']
     return None
 

--- a/virtaal/support/test_dictionary_download_watcher.py
+++ b/virtaal/support/test_dictionary_download_watcher.py
@@ -8,9 +8,15 @@
 from virtaal.support.dictionary_download_watcher import DictionaryDownloadWatcher
 
 
+class _FakeLanguageModel:
+    def __init__(self, code):
+        self.code = code
+
+
 class _FakeLangController:
-    def __init__(self):
+    def __init__(self, target_lang=None):
         self.handlers = {}
+        self.target_lang = _FakeLanguageModel(target_lang) if target_lang else None
 
     def connect(self, signal, handler):
         self.handlers[signal] = handler
@@ -20,8 +26,8 @@ class _FakeLangController:
 
 
 class _FakeMainController:
-    def __init__(self):
-        self.lang_controller = _FakeLangController()
+    def __init__(self, target_lang=None):
+        self.lang_controller = _FakeLangController(target_lang)
 
 
 class _FakeEnchant:
@@ -50,9 +56,9 @@ class _FakeDownloader:
         self.started = True
 
 
-def _make_watcher(known_dicts=()):
+def _make_watcher(known_dicts=(), target_lang=None):
     _FakeDownloader.instances = []
-    main_controller = _FakeMainController()
+    main_controller = _FakeMainController(target_lang)
     watcher = DictionaryDownloadWatcher(
         main_controller,
         enchant_module=_FakeEnchant(known_dicts),
@@ -98,3 +104,22 @@ def test_on_done_callback_does_not_raise():
     main_controller, _watcher = _make_watcher(known_dicts=set())
     main_controller.lang_controller.emit_target_lang_changed('af_ZA')
     _FakeDownloader.instances[0].on_done()  # must not raise
+
+
+def test_checks_the_already_current_language_at_construction():
+    # target-lang-changed never fires for a language that's already
+    # the saved default when LanguageController starts up - the
+    # already-current value needs checking directly too.
+    _watcher = _make_watcher(known_dicts=set(), target_lang='ca')[1]
+    assert len(_FakeDownloader.instances) == 1
+    assert _FakeDownloader.instances[0].language == 'ca'
+
+
+def test_does_not_check_a_current_language_that_already_has_a_dictionary():
+    _make_watcher(known_dicts={'ca'}, target_lang='ca')
+    assert _FakeDownloader.instances == []
+
+
+def test_no_current_language_is_not_an_error():
+    _make_watcher(known_dicts=set(), target_lang=None)  # must not raise
+    assert _FakeDownloader.instances == []

--- a/virtaal/support/test_dictionary_downloader.py
+++ b/virtaal/support/test_dictionary_downloader.py
@@ -179,6 +179,31 @@ def test_bare_language_matches_a_regional_only_dictionary(tmp_path):
     assert client.last_url().endswith('ca.aff')
 
 
+def test_write_failure_cleans_up_and_gives_up_instead_of_crashing(tmp_path, monkeypatch):
+    # dictionary_write_dir() calls into libenchant via ctypes - its
+    # exact behaviour depends on whichever build got bundled (a
+    # missing symbol was observed live on one packaged build).
+    import virtaal.support.dictionary_downloader as dictionary_downloader
+    def raises():
+        raise AttributeError('symbol not found')
+    monkeypatch.setattr(dictionary_downloader, 'dictionary_write_dir', raises)
+
+    client = _FakeClient()
+    done = []
+    downloader = DictionaryDownloader('de_DE', on_done=lambda: done.append(True), client=client)
+
+    downloader.start()
+    _, tree_cb, _ = client.calls[-1]
+    tree_cb(None, TREE_RESULT)
+    _, xcu_cb, _ = client.calls[-1]
+    xcu_cb(None, DE_XCU)
+    _, aff_cb, _ = client.calls[-1]
+
+    aff_cb(None, b'aff content')  # must not raise
+
+    assert done == [True]
+
+
 def test_default_target_dir_is_dictionary_write_dir(monkeypatch):
     import virtaal.support.dictionary_downloader as dictionary_downloader
     monkeypatch.setattr(dictionary_downloader, 'dictionary_write_dir', lambda: '/fake/dir')

--- a/virtaal/support/test_dictionary_downloader.py
+++ b/virtaal/support/test_dictionary_downloader.py
@@ -13,7 +13,7 @@ import json
 import os
 
 from virtaal.support.dictionary_downloader import DictionaryDownloader
-from virtaal.support.test_dictionary_source import AR_XCU, DE_XCU
+from virtaal.support.test_dictionary_source import AR_XCU, CA_XCU, DE_XCU
 
 TREE_RESULT = json.dumps({
     'tree': [
@@ -161,6 +161,22 @@ def test_default_on_done_is_a_noop(tmp_path):
     xcu_cb(None, DE_XCU)
     _, xcu_cb2, _ = client.calls[-1]
     xcu_cb2(None, AR_XCU)  # no exception
+
+
+def test_bare_language_matches_a_regional_only_dictionary(tmp_path):
+    # "ca"'s own dictionary never lists bare "ca", only ca_ES/ca_AD/...
+    client = _FakeClient()
+    done = []
+    downloader = DictionaryDownloader('ca', on_done=lambda: done.append(True),
+                                       client=client, target_dir=str(tmp_path))
+
+    downloader.start()
+    _, tree_cb, _ = client.calls[-1]
+    tree_cb(None, json.dumps({'tree': [{'path': 'ca/dictionaries.xcu'}]}).encode('utf-8'))
+    _, xcu_cb, _ = client.calls[-1]
+    xcu_cb(None, CA_XCU)
+
+    assert client.last_url().endswith('ca.aff')
 
 
 def test_default_target_dir_is_dictionary_write_dir(monkeypatch):

--- a/virtaal/support/test_dictionary_source.py
+++ b/virtaal/support/test_dictionary_source.py
@@ -189,6 +189,46 @@ def test_find_dictionary_returns_none_when_nothing_matches():
     assert result is None
 
 
+# Actual copy of ca/dictionaries.xcu (blob
+# 2939195f27f7f005cd7082b355276938a9d00d0d) - the general dictionary's
+# own Locales never lists bare "ca", only its regional variants.
+CA_XCU = b"""<?xml version="1.0" encoding="UTF-8"?>
+<oor:component-data xmlns:oor="http://openoffice.org/2001/registry" xmlns:xs="http://www.w3.org/2001/XMLSchema" oor:name="Linguistic" oor:package="org.openoffice.Office">
+ <node oor:name="ServiceManager">
+    <node oor:name="Dictionaries">
+        <node oor:name="HunSpellDic_catalan_general" oor:op="fuse">
+            <prop oor:name="Locations" oor:type="oor:string-list">
+                <value>%origin%/ca.aff %origin%/ca.dic</value>
+            </prop>
+            <prop oor:name="Format" oor:type="xs:string">
+                <value>DICT_SPELL</value>
+            </prop>
+            <prop oor:name="Locales" oor:type="oor:string-list">
+                <value>ca-ES ca-AD ca-FR ca-IT</value>
+            </prop>
+        </node>
+        <node oor:name="HunSpellDic_catalan_valencia" oor:op="fuse">
+            <prop oor:name="Locations" oor:type="oor:string-list">
+                <value>%origin%/ca-valencia.aff %origin%/ca-valencia.dic</value>
+            </prop>
+            <prop oor:name="Format" oor:type="xs:string">
+                <value>DICT_SPELL</value>
+            </prop>
+            <prop oor:name="Locales" oor:type="oor:string-list">
+                <value>ca-ES-valencia</value>
+            </prop>
+        </node>
+    </node>
+ </node>
+</oor:component-data>
+"""
+
+
+def test_find_dictionary_matches_a_bare_language_against_regional_variants():
+    result = find_dictionary('ca', {'ca': 's1'}, lambda folder: CA_XCU)
+    assert result == ('ca', ['ca.aff', 'ca.dic'])
+
+
 def test_download_dictionary_cleans_up_partial_write_on_failure(monkeypatch, tmp_path):
     """de_DE_frami has two files - if the second one fails, the first
     must not be left behind for a later run to mistake as a complete,


### PR DESCRIPTION
Investigated after a live `enchant.errors.DefaultLanguageNotFoundError: ca` report on a packaged Windows build - traced why `DictionaryDownloadWatcher` never downloaded it, and why the real download path still wouldn't have worked even if it had fired. Four separate gaps, each with its own commit and regression test:

1. `target-lang-changed` never fires for a language that's already the saved default at startup, so the watcher never even saw it.
2. `find_dictionary()`'s bare-language matching ("ca" only has regional-variant locales, never bare `ca`) only reached the synchronous helper, not the real async path `DictionaryDownloadWatcher` actually uses.
3. That async path's own duplicate exact-match check gets the same bare-language fix.
4. A packaged-build CI run surfaced a real crash this PR's own fix exposed: `dictionary_write_dir()` calls into libenchant via ctypes, which can fail unpredictably depending on the bundled build (`AttributeError: dlsym(...): symbol not found`, observed live). Caught, matching this class's own documented "never surface as an application error" promise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017KayAA91cuhe4xCpDYBg9K