### PR TITLE
Remove sections absent from a full-file save_config() call

### DIFF
--- a/virtaal/common/pan_app.py
+++ b/virtaal/common/pan_app.py
@@ -454,9 +454,15 @@ def save_config(filename, config, section=None):
 
     if section:
         config = {section: config}
-
-    for sect in config.keys():
-        parser.remove_section(sect)
+        for sect in config.keys():
+            parser.remove_section(sect)
+    else:
+        # config is the entire file's content per this function's own
+        # contract above - a section missing from it (e.g. an item the
+        # caller deleted since the last save) must not survive from
+        # what's already on disk.
+        for sect in parser.sections():
+            parser.remove_section(sect)
 
     for section, section_conf in config.items():
         if section not in parser.sections():

--- a/virtaal/common/test_pan_app.py
+++ b/virtaal/common/test_pan_app.py
@@ -165,6 +165,32 @@ def test_settings_recovers_from_a_corrupt_virtaal_ini(tmp_path):
     assert settings.config.sections() == settings.sections  # all empty, none lost
 
 
+def test_save_config_without_a_section_removes_entries_absent_from_the_new_data(tmp_path):
+    # #1906: deleting a web look-up entry showed as removed in the UI
+    # but stayed in weblookup.ini - each entry is its own section, and
+    # a deleted one is simply absent from the dict handed to the next
+    # save, not explicitly removed by the caller.
+    path = str(tmp_path / 'test.ini')
+    pan_app.save_config(path, {'Google': {'url': 'http://google.com'},
+                                'Wikipedia': {'url': 'http://wikipedia.org'}})
+
+    pan_app.save_config(path, {'Google': {'url': 'http://google.com'}})
+
+    assert pan_app.load_config(path) == {'Google': {'url': 'http://google.com'}}
+
+
+def test_save_config_with_a_section_leaves_other_sections_alone(tmp_path):
+    path = str(tmp_path / 'test.ini')
+    pan_app.save_config(path, {'name': 'af_ZA'}, section='plugin_a')
+    pan_app.save_config(path, {'name': 'de_DE'}, section='plugin_b')
+
+    pan_app.save_config(path, {'name': 'af_ZA_updated'}, section='plugin_a')
+
+    conf = pan_app.load_config(path)
+    assert conf['plugin_a'] == {'name': 'af_ZA_updated'}
+    assert conf['plugin_b'] == {'name': 'de_DE'}
+
+
 def test_open_frozen_log_trims_before_appending(tmp_path):
     path = str(tmp_path / "test.log")
     with open(path, 'w', encoding='utf-8') as f:


### PR DESCRIPTION
Fixes #1906.

`save_config()` only cleared sections present as keys in the new data, so a section simply missing from it (e.g. a deleted weblookup entry) silently survived from the previous save - the config UI showed it removed, but `weblookup.ini` still had it.

Only affects the two callers that pass a complete, section-less config dict (`weblookup.py`, `langcontroller.py`) - callers that pass `section=` still only touch that one section, unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017KayAA91cuhe4xCpDYBg9K